### PR TITLE
ci: standardised compliance toolchain (REUSE, Conventional Commits, Keep a Changelog, SemVer preflight)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deterministic PR validation workflow.
+#
+# This workflow is the source of truth for whether a pull request branch is a
+# valid candidate extension of the development branch. Per the project
+# compliance specification, it does NOT decide whether the branch is merged,
+# closed, released, or published — those remain human decisions outside the
+# deterministic core.
+#
+# Each job in this workflow is a pure, reproducible check. They share a fixed
+# tool pin set so that the same SHA always produces the same verdict.
+
+name: validate
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
+
+# Pinned tool versions. Bumping any of these is a deliberate change to the
+# deterministic core and should be done in a dedicated PR.
+env:
+  RUST_TOOLCHAIN: "1.84.0"
+  REUSE_TOOL_VERSION: "5.0.2"
+  COCOGITTO_VERSION: "6.2.0"
+  GIT_CLIFF_VERSION: "2.6.1"
+
+jobs:
+  # ---------------------------------------------------------------------
+  # A1: Explicit Provenance — every tracked file must be covered by either
+  # a SPDX header or an explicit annotation in REUSE.toml.
+  # ---------------------------------------------------------------------
+  provenance:
+    name: provenance (REUSE lint)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run reuse lint
+        uses: fsfe/reuse-action@v5
+        with:
+          args: --suppress-deprecation lint
+
+  # ---------------------------------------------------------------------
+  # A2: Structured History — every commit on the PR branch must satisfy
+  # Conventional Commits as parsed by cocogitto.
+  # ---------------------------------------------------------------------
+  commits:
+    name: commits (cocogitto check)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install cocogitto
+        run: |
+          curl -sSL "https://github.com/cocogitto/cocogitto/releases/download/${COCOGITTO_VERSION}/cocogitto-${COCOGITTO_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            | tar -xz -C /usr/local/bin cog
+          cog --version
+
+      - name: Determine commit range
+        id: range
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+            echo "from=${base}" >> "$GITHUB_OUTPUT"
+            echo "to=${head}"   >> "$GITHUB_OUTPUT"
+          else
+            echo "from=" >> "$GITHUB_OUTPUT"
+            echo "to="   >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: cog check (PR range)
+        if: steps.range.outputs.from != ''
+        run: cog check --from-latest-tag=false "${{ steps.range.outputs.from }}..${{ steps.range.outputs.to }}"
+
+      - name: cog check (push to main, newest commit only)
+        if: steps.range.outputs.from == ''
+        # Pre-existing history predates the policy and is grandfathered.
+        # On push, only the newly-landed commit must satisfy the grammar.
+        run: cog check HEAD~1..HEAD
+
+  # ---------------------------------------------------------------------
+  # A3: Derived Documentation — CHANGELOG.md `[Unreleased]` must equal the
+  # deterministic git-cliff projection of validated commits in range.
+  # ---------------------------------------------------------------------
+  changelog:
+    name: changelog (git-cliff consistency)
+    runs-on: ubuntu-24.04
+    needs: commits
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install git-cliff
+        run: |
+          curl -sSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            | tar -xz --strip-components=1 -C /usr/local/bin "git-cliff-${GIT_CLIFF_VERSION}/git-cliff"
+          git-cliff --version
+
+      - name: Verify CHANGELOG.md [Unreleased] matches projection
+        run: scripts/check_changelog.sh
+
+  # ---------------------------------------------------------------------
+  # A2 (cont.) / informational: deterministic SemVer preflight. Does not
+  # tag, push, publish, or otherwise affect external state.
+  # ---------------------------------------------------------------------
+  version-preflight:
+    name: version preflight (informational)
+    runs-on: ubuntu-24.04
+    needs: commits
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Compute next SemVer
+        id: semver
+        run: scripts/version_preflight.sh
+
+      - name: Surface result on PR
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "::notice title=Version preflight::base=${{ steps.semver.outputs.base_version }} bump=${{ steps.semver.outputs.bump_kind }} next=${{ steps.semver.outputs.next_version }}"
+
+  # ---------------------------------------------------------------------
+  # Aggregate gate. Required by branch protection so the deterministic
+  # verdict reduces to a single check.
+  # ---------------------------------------------------------------------
+  candidate-validity:
+    name: candidate validity (A5)
+    runs-on: ubuntu-24.04
+    needs: [provenance, commits, changelog, version-preflight]
+    steps:
+      - name: All deterministic checks passed
+        run: |
+          echo "Branch is a valid candidate extension of the development branch."
+          echo "Per Axiom A5 this does NOT decide merge, close, or release."

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,10 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  # Elevated to `write` only so the `report-failure` job can post a single
+  # PR comment summarising failed checks. No other job mutates PR state.
+  pull-requests: write
+  actions: read
 
 concurrency:
   group: validate-${{ github.ref }}
@@ -93,7 +96,7 @@ jobs:
 
       - name: cog check (PR range)
         if: steps.range.outputs.from != ''
-        run: cog check --from-latest-tag=false "${{ steps.range.outputs.from }}..${{ steps.range.outputs.to }}"
+        run: cog check "${{ steps.range.outputs.from }}..${{ steps.range.outputs.to }}"
 
       - name: cog check (push to main, newest commit only)
         if: steps.range.outputs.from == ''
@@ -141,9 +144,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Determine commit range
+        id: range
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "range=${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "range=HEAD~1..HEAD" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Compute next SemVer
         id: semver
-        run: scripts/version_preflight.sh
+        run: scripts/version_preflight.sh "${{ steps.range.outputs.range }}"
 
       - name: Surface result on PR
         if: github.event_name == 'pull_request'
@@ -163,3 +175,60 @@ jobs:
         run: |
           echo "Branch is a valid candidate extension of the development branch."
           echo "Per Axiom A5 this does NOT decide merge, close, or release."
+
+  # ---------------------------------------------------------------------
+  # On any failure within a PR, post a single comment on the PR that
+  # enumerates which deterministic check failed and links to the run.
+  # The intent is to put the failure context where downstream agents can
+  # see it via the GitHub API without scraping the Actions UI.
+  # ---------------------------------------------------------------------
+  report-failure:
+    name: report failure (PR comment)
+    runs-on: ubuntu-24.04
+    if: always() && github.event_name == 'pull_request' && contains(needs.*.result, 'failure')
+    needs: [provenance, commits, changelog, version-preflight]
+    steps:
+      - name: Post failure summary to PR
+        uses: actions/github-script@v7
+        env:
+          PROVENANCE_RESULT:        ${{ needs.provenance.result }}
+          COMMITS_RESULT:           ${{ needs.commits.result }}
+          CHANGELOG_RESULT:         ${{ needs.changelog.result }}
+          VERSION_PREFLIGHT_RESULT: ${{ needs.version-preflight.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const results = {
+              "provenance (REUSE lint)":           process.env.PROVENANCE_RESULT,
+              "commits (cocogitto check)":        process.env.COMMITS_RESULT,
+              "changelog (git-cliff consistency)": process.env.CHANGELOG_RESULT,
+              "version preflight":                 process.env.VERSION_PREFLIGHT_RESULT,
+            };
+            const rows = Object.entries(results)
+              .map(([n, r]) => `| ${n} | ${r} |`)
+              .join("\n");
+            const failed = Object.entries(results)
+              .filter(([_, r]) => r === "failure")
+              .map(([n]) => `\`${n}\``);
+            const body = [
+              `## Deterministic validation failed`,
+              ``,
+              `Failed checks: ${failed.join(", ") || "(none reported failure)"}`,
+              ``,
+              `| Check | Result |`,
+              `|---|---|`,
+              rows,
+              ``,
+              `Full run logs: ${process.env.RUN_URL}`,
+              ``,
+              `Per Axiom A5 this does not block merge mechanically; it ` +
+              `signals that the branch is not yet a valid candidate ` +
+              `extension of the development branch. Remediate per the ` +
+              `contract in \`docs/specs/compliance-pipeline.md\` and push.`,
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -61,6 +61,34 @@ jobs:
           args: --suppress-deprecation lint
 
   # ---------------------------------------------------------------------
+  # A1 (cont.): Apache-2.0 §4 mechanical requirements — verify license
+  # text presence, NOTICE non-empty, allow-list of license identifiers,
+  # and modification notices on PR-modified pre-existing files.
+  # ---------------------------------------------------------------------
+  apache-license:
+    name: apache-license (Apache-2.0 §4 gate)
+    runs-on: ubuntu-24.04
+    needs: provenance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Determine commit range
+        id: range
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "range=${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "range=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Apache-2.0 §4 mechanical gate
+        run: scripts/check_apache_license.sh "${{ steps.range.outputs.range }}"
+
+  # ---------------------------------------------------------------------
   # A2: Structured History — every commit on the PR branch must satisfy
   # Conventional Commits as parsed by cocogitto.
   # ---------------------------------------------------------------------
@@ -169,7 +197,7 @@ jobs:
   candidate-validity:
     name: candidate validity (A5)
     runs-on: ubuntu-24.04
-    needs: [provenance, commits, changelog, version-preflight]
+    needs: [provenance, apache-license, commits, changelog, version-preflight]
     steps:
       - name: All deterministic checks passed
         run: |
@@ -186,12 +214,13 @@ jobs:
     name: report failure (PR comment)
     runs-on: ubuntu-24.04
     if: always() && github.event_name == 'pull_request' && contains(needs.*.result, 'failure')
-    needs: [provenance, commits, changelog, version-preflight]
+    needs: [provenance, apache-license, commits, changelog, version-preflight]
     steps:
       - name: Post failure summary to PR
         uses: actions/github-script@v7
         env:
           PROVENANCE_RESULT:        ${{ needs.provenance.result }}
+          APACHE_LICENSE_RESULT:    ${{ needs.apache-license.result }}
           COMMITS_RESULT:           ${{ needs.commits.result }}
           CHANGELOG_RESULT:         ${{ needs.changelog.result }}
           VERSION_PREFLIGHT_RESULT: ${{ needs.version-preflight.result }}
@@ -200,6 +229,7 @@ jobs:
           script: |
             const results = {
               "provenance (REUSE lint)":           process.env.PROVENANCE_RESULT,
+              "apache-license (§4 gate)":          process.env.APACHE_LICENSE_RESULT,
               "commits (cocogitto check)":        process.env.COMMITS_RESULT,
               "changelog (git-cliff consistency)": process.env.CHANGELOG_RESULT,
               "version preflight":                 process.env.VERSION_PREFLIGHT_RESULT,

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,9 +33,9 @@ concurrency:
 # deterministic core and should be done in a dedicated PR.
 env:
   RUST_TOOLCHAIN: "1.84.0"
-  REUSE_TOOL_VERSION: "5.0.2"
-  COCOGITTO_VERSION: "6.2.0"
-  GIT_CLIFF_VERSION: "2.6.1"
+  REUSE_TOOL_VERSION: "6.2.0"
+  COCOGITTO_VERSION: "7.0.0"
+  GIT_CLIFF_VERSION: "2.13.1"
 
 jobs:
   # ---------------------------------------------------------------------
@@ -73,8 +73,9 @@ jobs:
 
       - name: Install cocogitto
         run: |
+          # Tarball layout: x86_64-unknown-linux-musl/{cog,LICENSE}
           curl -sSL "https://github.com/cocogitto/cocogitto/releases/download/${COCOGITTO_VERSION}/cocogitto-${COCOGITTO_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-            | tar -xz -C /usr/local/bin cog
+            | sudo tar -xz --strip-components=1 -C /usr/local/bin x86_64-unknown-linux-musl/cog
           cog --version
 
       - name: Determine commit range
@@ -117,8 +118,9 @@ jobs:
 
       - name: Install git-cliff
         run: |
+          # Tarball layout: git-cliff-${VERSION}/{git-cliff,LICENSE,...}
           curl -sSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-            | tar -xz --strip-components=1 -C /usr/local/bin "git-cliff-${GIT_CLIFF_VERSION}/git-cliff"
+            | sudo tar -xz --strip-components=1 -C /usr/local/bin "git-cliff-${GIT_CLIFF_VERSION}/git-cliff"
           git-cliff --version
 
       - name: Verify CHANGELOG.md [Unreleased] matches projection

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ fail_fast: false
 default_install_hook_types:
   - pre-commit
   - commit-msg
+  - pre-push
 
 repos:
   # ---------------------------------------------------------------------

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Local pre-commit hooks. These mirror the deterministic CI rules so that the
+# LLM agent receives fail-fast feedback before a commit is finalized. They are
+# a convenience layer; the source of truth is .github/workflows/validate.yml.
+#
+# Install once per clone:
+#
+#   pipx install pre-commit
+#   pre-commit install --install-hooks
+#   pre-commit install --hook-type commit-msg
+#
+# Run all hooks across the repo:
+#
+#   pre-commit run --all-files
+
+minimum_pre_commit_version: "3.7.0"
+fail_fast: false
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
+repos:
+  # ---------------------------------------------------------------------
+  # Provenance: every tracked path must be covered by REUSE.toml or carry
+  # an explicit SPDX header. Mirrors the `reuse-lint` step in CI.
+  # ---------------------------------------------------------------------
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v5.0.2
+    hooks:
+      - id: reuse
+
+  # ---------------------------------------------------------------------
+  # Commit message structure: cocogitto rejects malformed Conventional
+  # Commits headers and breaking-change notation. Pure structural check.
+  # ---------------------------------------------------------------------
+  - repo: https://github.com/cocogitto/cocogitto
+    rev: 6.2.0
+    hooks:
+      - id: cog-verify
+        stages: [commit-msg]
+
+  # ---------------------------------------------------------------------
+  # Whitespace / line-ending hygiene. Cheap, deterministic, repo-wide.
+  # ---------------------------------------------------------------------
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+      - id: check-yaml
+      - id: check-toml
+
+  # ---------------------------------------------------------------------
+  # Rust toolchain hooks. Must mirror `make ci` exactly. Hooks shell out
+  # to the local cargo so the version matches rust-toolchain.
+  # ---------------------------------------------------------------------
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt --all -- --check
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy --workspace --tests -- -D warnings
+        entry: cargo clippy --workspace --tests -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: changelog-consistency
+        name: changelog matches git-cliff output (Unreleased)
+        entry: scripts/check_changelog.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,19 +27,26 @@ repos:
   # an explicit SPDX header. Mirrors the `reuse-lint` step in CI.
   # ---------------------------------------------------------------------
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v5.0.2
+    rev: v6.2.0
     hooks:
       - id: reuse
 
   # ---------------------------------------------------------------------
   # Commit message structure: cocogitto rejects malformed Conventional
   # Commits headers and breaking-change notation. Pure structural check.
+  # Cocogitto does not ship a pre-commit hooks YAML upstream, so this is
+  # wired as a local hook that requires `cog` on PATH (see CI for the
+  # pinned version; install with `cargo install cocogitto --version 7.0.0`
+  # or download the matching release tarball).
   # ---------------------------------------------------------------------
-  - repo: https://github.com/cocogitto/cocogitto
-    rev: 6.2.0
+  - repo: local
     hooks:
       - id: cog-verify
+        name: cog verify (commit message)
+        entry: cog verify --file
+        language: system
         stages: [commit-msg]
+        pass_filenames: true
 
   # ---------------------------------------------------------------------
   # Whitespace / line-ending hygiene. Cheap, deterministic, repo-wide.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,13 @@ repos:
         types: [rust]
         pass_filenames: false
 
+      - id: apache-license
+        name: Apache-2.0 §4 mechanical gate
+        entry: scripts/check_apache_license.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
       - id: changelog-consistency
         name: changelog matches git-cliff output (Unreleased)
         entry: scripts/check_changelog.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+SPDX-FileCopyrightText: Copyright (C) 2026 Ian Douglas Lawrence Norman McLean
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,24 +9,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
-
-This file is treated as a deterministic projection of the validated
-Conventional Commits history. Entries under `[Unreleased]` are produced and
-verified by `git-cliff` against `cliff.toml`; do not author entries by hand
-in a way that diverges from what the transformer emits.
-
 ## [Unreleased]
 
 ### Added
 
-### Changed
-
-### Deprecated
-
-### Removed
+- Add Gemma 4 GGUF support + fix column-major loading and Q4_K dequantization (#1)
+- Add deterministic changelog and SemVer preflight checks
 
 ### Fixed
 
-### Security
+- Linux support — conditional BLAS and Q4 scalar fallback
+- Linux/WSL2 support + temperature parameter
+- Correct cog.toml schema, workflow flags, and review feedback
+- Correct tool release URLs and pre-commit hook wiring
 
-[Unreleased]: https://github.com/metavacua/larql-to-sparql/compare/HEAD...HEAD
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+<!--
+SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+This file is treated as a deterministic projection of the validated
+Conventional Commits history. Entries under `[Unreleased]` are produced and
+verified by `git-cliff` against `cliff.toml`; do not author entries by hand
+in a way that diverges from what the transformer emits.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+[Unreleased]: https://github.com/metavacua/larql-to-sparql/compare/HEAD...HEAD

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,24 @@
+larql-to-sparql
+
+Copyright (C) 2026 Chris Hay
+Copyright (C) 2026 Ian Douglas Lawrence Norman McLean
+
+This product is licensed under the Apache License, Version 2.0 (the "License");
+you may not use this software except in compliance with the License. You may
+obtain a copy of the License under LICENSES/Apache-2.0.txt or at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+The pre-existing LARQL codebase under this repository's `main` branch
+originates from https://github.com/chrishayuk/larql (created 2026) and is
+attributed to Chris Hay.
+
+The deterministic compliance toolchain added by PR
+`claude/implement-standardized-tool-PGol9` (REUSE.toml, NOTICE,
+CHANGELOG.md, cog.toml, cliff.toml, .pre-commit-config.yaml,
+.github/workflows/validate.yml, scripts/check_changelog.sh,
+scripts/version_preflight.sh, docs/specs/compliance-pipeline.md) is
+attributed to Ian Douglas Lawrence Norman McLean.
+
+Per-file SPDX provenance is recorded in REUSE.toml and verified by
+`reuse lint` in the deterministic PR validation workflow.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,89 @@
+version = 1
+
+# Explicit, machine-readable provenance for every file under version control,
+# per Foundational Axiom A1 (Explicit Provenance) of the project compliance
+# specification. Each [[annotations]] block below is an explicit declaration
+# recognized by repository policy in lieu of per-file SPDX headers, and is
+# checked deterministically by `reuse lint`.
+
+# ---------------------------------------------------------------------------
+# Default: all source-controlled files are Apache-2.0 with the project's
+# canonical copyright holder unless explicitly overridden by a more specific
+# annotation block below.
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = "**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Contributors to the larql-to-sparql project"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ---------------------------------------------------------------------------
+# Top-level project files (Cargo workspace, build, docs, governance).
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = [
+  "Cargo.toml",
+  "Cargo.lock",
+  "Makefile",
+  "README.md",
+  "ROADMAP.md",
+  "AGENTS.md",
+  "CLAUDE.md",
+  "CHANGELOG.md",
+  ".gitignore",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "Contributors to the larql-to-sparql project"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ---------------------------------------------------------------------------
+# Compliance toolchain configuration. Each of these files is part of the
+# deterministic validation pipeline; their provenance is recorded explicitly
+# so that `reuse lint` cannot regress on the toolchain itself.
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = [
+  "REUSE.toml",
+  "cliff.toml",
+  "cog.toml",
+  ".pre-commit-config.yaml",
+  ".github/**",
+  "scripts/check_changelog.sh",
+  "scripts/version_preflight.sh",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "Contributors to the larql-to-sparql project"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ---------------------------------------------------------------------------
+# Crate sources, examples, tests, probes, knowledge, memory, experiments.
+# Bulk-covered to avoid per-file headers while remaining deterministic.
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = [
+  "crates/**",
+  "examples/**",
+  "tests/**",
+  "probes/**",
+  "scripts/**",
+  "knowledge/**",
+  "memory/**",
+  "experiments/**",
+  "docs/**",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Contributors to the larql-to-sparql project"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ---------------------------------------------------------------------------
+# The verbatim Apache-2.0 license text shipped under LICENSES/ is itself
+# Apache-licensed boilerplate and is not separately copyrighted.
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = [
+  "LICENSE",
+  "LICENSES/Apache-2.0.txt",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "NONE"
+SPDX-License-Identifier = "Apache-2.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -2,82 +2,55 @@ version = 1
 
 # Explicit, machine-readable provenance for every file under version control,
 # per Foundational Axiom A1 (Explicit Provenance) of the project compliance
-# specification. Each [[annotations]] block below is an explicit declaration
-# recognized by repository policy in lieu of per-file SPDX headers, and is
-# checked deterministically by `reuse lint`.
+# specification, and per Apache-2.0 §4(c) (retain attribution notices).
+#
+# Two distinct copyright holders apply:
+#
+#   - The pre-existing LARQL codebase on `main` (origin:
+#     https://github.com/chrishayuk/larql, created 2026) is attributed to
+#     Chris Hay.
+#
+#   - The deterministic compliance toolchain added in PR
+#     `claude/implement-standardized-tool-PGol9` (2026) is attributed to
+#     Ian Douglas Lawrence Norman McLean.
+#
+# Both are licensed under Apache-2.0. The verbatim Apache-2.0 license text
+# under LICENSES/ is itself unattributed boilerplate (SPDX-FileCopyrightText
+# = NONE), per common REUSE practice.
 
 # ---------------------------------------------------------------------------
-# Default: all source-controlled files are Apache-2.0 with the project's
-# canonical copyright holder unless explicitly overridden by a more specific
-# annotation block below.
+# Default: pre-existing LARQL codebase from `main`. This is the broadest
+# match; specific overrides below carve out the PR-added paths.
 # ---------------------------------------------------------------------------
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "Contributors to the larql-to-sparql project"
+SPDX-FileCopyrightText = "Copyright (C) 2026 Chris Hay"
 SPDX-License-Identifier = "Apache-2.0"
 
 # ---------------------------------------------------------------------------
-# Top-level project files (Cargo workspace, build, docs, governance).
-# ---------------------------------------------------------------------------
-[[annotations]]
-path = [
-  "Cargo.toml",
-  "Cargo.lock",
-  "Makefile",
-  "README.md",
-  "ROADMAP.md",
-  "AGENTS.md",
-  "CLAUDE.md",
-  "CHANGELOG.md",
-  ".gitignore",
-]
-precedence = "override"
-SPDX-FileCopyrightText = "Contributors to the larql-to-sparql project"
-SPDX-License-Identifier = "Apache-2.0"
-
-# ---------------------------------------------------------------------------
-# Compliance toolchain configuration. Each of these files is part of the
-# deterministic validation pipeline; their provenance is recorded explicitly
-# so that `reuse lint` cannot regress on the toolchain itself.
+# Compliance-pipeline infrastructure added by PR
+# `claude/implement-standardized-tool-PGol9`.
 # ---------------------------------------------------------------------------
 [[annotations]]
 path = [
   "REUSE.toml",
+  "NOTICE",
+  "CHANGELOG.md",
   "cliff.toml",
   "cog.toml",
   ".pre-commit-config.yaml",
   ".github/**",
   "scripts/check_changelog.sh",
   "scripts/version_preflight.sh",
+  "docs/specs/compliance-pipeline.md",
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "Contributors to the larql-to-sparql project"
+SPDX-FileCopyrightText = "Copyright (C) 2026 Ian Douglas Lawrence Norman McLean"
 SPDX-License-Identifier = "Apache-2.0"
 
 # ---------------------------------------------------------------------------
-# Crate sources, examples, tests, probes, knowledge, memory, experiments.
-# Bulk-covered to avoid per-file headers while remaining deterministic.
-# ---------------------------------------------------------------------------
-[[annotations]]
-path = [
-  "crates/**",
-  "examples/**",
-  "tests/**",
-  "probes/**",
-  "scripts/**",
-  "knowledge/**",
-  "memory/**",
-  "experiments/**",
-  "docs/**",
-]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "Contributors to the larql-to-sparql project"
-SPDX-License-Identifier = "Apache-2.0"
-
-# ---------------------------------------------------------------------------
-# The verbatim Apache-2.0 license text shipped under LICENSES/ is itself
-# Apache-licensed boilerplate and is not separately copyrighted.
+# Verbatim Apache-2.0 license text. Boilerplate; not separately copyrighted.
 # ---------------------------------------------------------------------------
 [[annotations]]
 path = [

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+# SPDX-License-Identifier: Apache-2.0
+#
+# git-cliff configuration. Defines the deterministic projection from validated
+# Conventional Commits to a Keep a Changelog 1.1.0 fragment. The mapping is
+# fixed by repository policy; do not introduce conditional logic that depends
+# on commit author, time, or any non-commit-message input.
+#
+# Mapping policy (Conventional Commit type -> Keep a Changelog section):
+#
+#   feat     -> Added
+#   fix      -> Fixed
+#   perf     -> Changed
+#   refactor -> Changed
+#   revert   -> Removed
+#   docs     -> omitted
+#   chore    -> omitted
+#   build    -> omitted
+#   ci       -> omitted
+#   test     -> omitted
+#   style    -> omitted
+#
+# Any commit annotated with `BREAKING CHANGE` (footer) or `!` (header) is
+# additionally placed under Changed and prefixed with `BREAKING:`.
+
+[changelog]
+header = """
+<!--
+SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits | sort(attribute="message") %}
+- {% if commit.breaking %}**BREAKING:** {% endif %}{{ commit.message | upper_first }}\
+{% endfor %}
+{% endfor %}\n
+"""
+footer = ""
+trim = true
+postprocessors = []
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+protect_breaking_commits = true
+filter_commits = true
+tag_pattern = "v[0-9]*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"
+
+# Mapping is total and explicit. Anything not matched is dropped.
+commit_parsers = [
+  { message = "^feat",       group = "Added"   },
+  { message = "^fix",        group = "Fixed"   },
+  { message = "^perf",       group = "Changed" },
+  { message = "^refactor",   group = "Changed" },
+  { message = "^revert",     group = "Removed" },
+  { message = "^docs",       skip  = true      },
+  { message = "^chore",      skip  = true      },
+  { message = "^build",      skip  = true      },
+  { message = "^ci",         skip  = true      },
+  { message = "^test",       skip  = true      },
+  { message = "^style",      skip  = true      },
+  { message = ".*",          skip  = true      },
+]
+
+# No commit message preprocessing; the validator must not silently rewrite
+# commit text. If a commit needs reshaping it must be amended in source.
+commit_preprocessors = []

--- a/cliff.toml
+++ b/cliff.toml
@@ -26,7 +26,7 @@
 [changelog]
 header = """
 <!--
-SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+SPDX-FileCopyrightText: Copyright (C) 2026 Ian Douglas Lawrence Norman McLean
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/cog.toml
+++ b/cog.toml
@@ -5,49 +5,29 @@
 # accepted by both local pre-commit hooks (`cog verify`) and the PR validation
 # workflow (`cog check`). Commit-message structure is enforced; semantic
 # interpretation is not — see Foundational Axiom A2 (Structured History).
-
-# ---------------------------------------------------------------------------
-# Allowed commit types. Anything outside this set is rejected by `cog check`.
-# Mapping of types to changelog sections is defined in cliff.toml; cocogitto
-# is responsible only for grammar acceptance and SemVer derivation here.
-# ---------------------------------------------------------------------------
-[commit_types]
-feat     = { changelog_title = "Added"   }
-fix      = { changelog_title = "Fixed"   }
-perf     = { changelog_title = "Changed" }
-refactor = { changelog_title = "Changed" }
-revert   = { changelog_title = "Removed" }
-docs     = { changelog_title = "Documentation", omit_from_changelog = true }
-chore    = { changelog_title = "Chore",         omit_from_changelog = true }
-build    = { changelog_title = "Build",         omit_from_changelog = true }
-ci       = { changelog_title = "CI",            omit_from_changelog = true }
-test     = { changelog_title = "Tests",         omit_from_changelog = true }
-style    = { changelog_title = "Style",         omit_from_changelog = true }
-
-# ---------------------------------------------------------------------------
-# Repository-local SemVer rules. The bump kind is a deterministic function of
-# commit types in the range [last-tag..HEAD].
 #
-#   any commit with `!` or `BREAKING CHANGE` footer  -> major
-#   any `feat:`                                      -> minor
-#   any `fix:` / `perf:` / `refactor:` / `revert:`   -> patch
-#   none of the above                                -> no bump
-# ---------------------------------------------------------------------------
+# The default commit types accepted by cocogitto are exactly the standard
+# Conventional Commits set (feat, fix, perf, refactor, revert, docs, chore,
+# build, ci, test, style). They are not redefined here on purpose: changelog
+# section mapping is owned by `cliff.toml`, while cocogitto is responsible
+# only for grammar acceptance and SemVer derivation.
+
+#:schema https://docs.cocogitto.io/cog-schema.json
+
+# Tag prefix for SemVer derivation. Matches scripts/version_preflight.sh.
 tag_prefix = "v"
+
+# Merge commits do not satisfy Conventional Commits and are pre-existing in
+# history; ignore them at the parser level.
 ignore_merge_commits = true
 
 # Disabled by policy: cocogitto's optional bump-on-branch and pre-bump hooks
 # would introduce non-deterministic side effects that are out of scope for the
 # PR validation workflow. Version bumping is a separate, repository-local
-# release concern (see compliance-pipeline.md).
+# release concern (see docs/specs/compliance-pipeline.md).
 pre_bump_hooks  = []
 post_bump_hooks = []
 
-# ---------------------------------------------------------------------------
-# Branch whitelist. The local pre-commit hook does not enforce this; the PR
-# workflow does. Listed branches are the only ones from which a release tag
-# may be derived by `cog bump --auto`. PR branches are intentionally excluded.
-# ---------------------------------------------------------------------------
-[branch_whitelist]
-main    = "v[0-9]+.[0-9]+.[0-9]+"
-release = "release/.+"
+# Branches from which a release tag may be derived by `cog bump --auto`.
+# PR branches are intentionally excluded; bumping happens after merge.
+branch_whitelist = ["main", "release/*"]

--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cocogitto configuration. Defines the strict Conventional Commits grammar
+# accepted by both local pre-commit hooks (`cog verify`) and the PR validation
+# workflow (`cog check`). Commit-message structure is enforced; semantic
+# interpretation is not — see Foundational Axiom A2 (Structured History).
+
+# ---------------------------------------------------------------------------
+# Allowed commit types. Anything outside this set is rejected by `cog check`.
+# Mapping of types to changelog sections is defined in cliff.toml; cocogitto
+# is responsible only for grammar acceptance and SemVer derivation here.
+# ---------------------------------------------------------------------------
+[commit_types]
+feat     = { changelog_title = "Added"   }
+fix      = { changelog_title = "Fixed"   }
+perf     = { changelog_title = "Changed" }
+refactor = { changelog_title = "Changed" }
+revert   = { changelog_title = "Removed" }
+docs     = { changelog_title = "Documentation", omit_from_changelog = true }
+chore    = { changelog_title = "Chore",         omit_from_changelog = true }
+build    = { changelog_title = "Build",         omit_from_changelog = true }
+ci       = { changelog_title = "CI",            omit_from_changelog = true }
+test     = { changelog_title = "Tests",         omit_from_changelog = true }
+style    = { changelog_title = "Style",         omit_from_changelog = true }
+
+# ---------------------------------------------------------------------------
+# Repository-local SemVer rules. The bump kind is a deterministic function of
+# commit types in the range [last-tag..HEAD].
+#
+#   any commit with `!` or `BREAKING CHANGE` footer  -> major
+#   any `feat:`                                      -> minor
+#   any `fix:` / `perf:` / `refactor:` / `revert:`   -> patch
+#   none of the above                                -> no bump
+# ---------------------------------------------------------------------------
+tag_prefix = "v"
+ignore_merge_commits = true
+
+# Disabled by policy: cocogitto's optional bump-on-branch and pre-bump hooks
+# would introduce non-deterministic side effects that are out of scope for the
+# PR validation workflow. Version bumping is a separate, repository-local
+# release concern (see compliance-pipeline.md).
+pre_bump_hooks  = []
+post_bump_hooks = []
+
+# ---------------------------------------------------------------------------
+# Branch whitelist. The local pre-commit hook does not enforce this; the PR
+# workflow does. Listed branches are the only ones from which a release tag
+# may be derived by `cog bump --auto`. PR branches are intentionally excluded.
+# ---------------------------------------------------------------------------
+[branch_whitelist]
+main    = "v[0-9]+.[0-9]+.[0-9]+"
+release = "release/.+"

--- a/docs/specs/compliance-pipeline.md
+++ b/docs/specs/compliance-pipeline.md
@@ -1,0 +1,120 @@
+<!--
+SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Compliance Pipeline Specification
+
+This document is the operator's reference for the deterministic, rule-based
+validation toolchain. It maps each Foundational Axiom of the project
+compliance specification to the concrete artifact and tool that enforces it,
+and it defines the contract that the LLM coding agent must satisfy when
+remediating a failure.
+
+## Axiom-to-artifact map
+
+| Axiom | Tool | Configuration | Local hook | CI job |
+|---|---|---|---|---|
+| **A1: Explicit Provenance** | `reuse` (FSFE REUSE 3.3) | `REUSE.toml`, `LICENSES/` | `pre-commit` `reuse` | `validate.yml :: provenance` |
+| **A2: Structured History** | `cog` (cocogitto) | `cog.toml` | `pre-commit` `cog-verify` (commit-msg) | `validate.yml :: commits` |
+| **A3: Derived Documentation** | `git-cliff` + `scripts/check_changelog.sh` | `cliff.toml`, `CHANGELOG.md` | `pre-commit` `changelog-consistency` (pre-push) | `validate.yml :: changelog` |
+| **A2 (SemVer)** | `scripts/version_preflight.sh` | `cog.toml` (bump rules) | n/a (informational) | `validate.yml :: version-preflight` |
+| **A4: Verified Compliance** | aggregate gate | `validate.yml :: candidate-validity` | `make ci` | `validate.yml :: candidate-validity` |
+| **A5: Candidate Validity Only** | repository policy | branch protection | n/a | `candidate-validity` is a non-merging signal |
+
+## File inventory (compliance toolchain)
+
+```
+.github/workflows/validate.yml      # PR validation workflow (source of truth)
+.pre-commit-config.yaml             # local hooks mirroring CI
+REUSE.toml                          # bulk SPDX annotations
+LICENSES/Apache-2.0.txt             # canonical license text per REUSE 3.x
+cog.toml                            # Conventional Commits grammar + bump rules
+cliff.toml                          # commits -> Keep a Changelog projection
+CHANGELOG.md                        # Keep a Changelog 1.1.0, with [Unreleased]
+scripts/check_changelog.sh          # deterministic [Unreleased] consistency
+scripts/version_preflight.sh        # deterministic SemVer preflight
+docs/specs/compliance-pipeline.md   # this file
+```
+
+## Determinism guarantees
+
+Every validator and transformer in the pipeline is reproducible: same input
+SHA, same tool versions, same verdict. To preserve this:
+
+1. **Tool versions are pinned** in `.github/workflows/validate.yml` (`env:`)
+   and in `.pre-commit-config.yaml` (`rev:`). Bumps go through a dedicated
+   PR so the change is explicit in history.
+2. **No probabilistic logic.** Scripts shell out only to tools listed above
+   and standard POSIX utilities. No network calls except tool installation.
+3. **No LLM-generated metadata.** The pipeline does not invoke any model;
+   the LLM coding agent's role is upstream of the gate, not inside it.
+4. **Idempotent transformers.** `git-cliff` against a fixed range produces
+   byte-stable output. `scripts/check_changelog.sh` compares to that.
+
+## Remediation contract
+
+When a check fails, the workflow output is the only authoritative description
+of what went wrong. The LLM agent must remediate by direct consequence of the
+failure message; it must not interpret intent.
+
+| Failing check | Deterministic remediation |
+|---|---|
+| `provenance` | Add the offending file's path to a matching `[[annotations]]` block in `REUSE.toml`, or insert a per-file SPDX header. Re-run `reuse lint`. |
+| `commits` | Amend the commit so its header matches the Conventional Commits grammar declared in `cog.toml`. Force-push to the PR branch. |
+| `changelog` | Run `git-cliff --config cliff.toml --unreleased --strip header --prepend CHANGELOG.md`, commit the result with `docs(changelog): regenerate unreleased`, and re-push. Do not hand-edit the `[Unreleased]` block. |
+| `version-preflight` | This job is informational. A non-zero exit indicates an unparseable commit, which is also caught by `commits`; remediate there. |
+
+## Out-of-scope (explicit non-goals)
+
+Per Axiom A5 and the Scope section of the formal specification, the pipeline
+**does not** perform or decide:
+
+- merging, closing, or rebasing pull requests
+- release tagging, GitHub Releases, or git tag creation
+- crate publication to crates.io
+- container image publication to any registry
+- deployment to any environment
+- artifact signing or attestation generation
+- security scanning or vulnerability triage
+
+If a future repository policy adopts any of the above, it must live in a
+**separate** workflow file and must not call into `validate.yml`. The PR gate
+is intentionally scoped to candidate-validity only.
+
+## Local developer workflow
+
+```bash
+# One-time setup (per clone).
+pipx install pre-commit
+pre-commit install --install-hooks
+pre-commit install --hook-type commit-msg
+
+# Per-change loop.
+git checkout -b feat/short-description
+# ... edit ...
+git add -p
+git commit -m "feat(scope): short imperative subject"
+# pre-commit runs reuse + fmt + clippy automatically
+# commit-msg hook runs cog-verify automatically
+
+# Before pushing:
+git-cliff --config cliff.toml --unreleased --strip header --prepend CHANGELOG.md
+git add CHANGELOG.md
+git commit -m "docs(changelog): regenerate unreleased"
+git push -u origin "$(git branch --show-current)"
+```
+
+## CI workflow shape
+
+```
+pull_request -> [provenance] [commits]
+                                   \
+                                    +--> [changelog]
+                                    +--> [version-preflight]
+                                                       \
+                                                        +--> [candidate-validity]
+```
+
+`candidate-validity` is the single required check on branch protection. It is
+green iff every prior job is green; nothing more, nothing less.

--- a/docs/specs/compliance-pipeline.md
+++ b/docs/specs/compliance-pipeline.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+SPDX-FileCopyrightText: Copyright (C) 2026 Ian Douglas Lawrence Norman McLean
 SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -16,11 +16,42 @@ remediating a failure.
 | Axiom | Tool | Configuration | Local hook | CI job |
 |---|---|---|---|---|
 | **A1: Explicit Provenance** | `reuse` (FSFE REUSE 3.3) | `REUSE.toml`, `LICENSES/` | `pre-commit` `reuse` | `validate.yml :: provenance` |
+| **A1 (Apache-2.0 §4)** | `scripts/check_apache_license.sh` | `LICENSE`, `NOTICE`, REUSE.toml allow-list | n/a (CI-only) | `validate.yml :: apache-license` |
 | **A2: Structured History** | `cog` (cocogitto) | `cog.toml` | `pre-commit` `cog-verify` (commit-msg) | `validate.yml :: commits` |
 | **A3: Derived Documentation** | `git-cliff` + `scripts/check_changelog.sh` | `cliff.toml`, `CHANGELOG.md` | `pre-commit` `changelog-consistency` (pre-push) | `validate.yml :: changelog` |
 | **A2 (SemVer)** | `scripts/version_preflight.sh` | `cog.toml` (bump rules) | n/a (informational) | `validate.yml :: version-preflight` |
 | **A4: Verified Compliance** | aggregate gate | `validate.yml :: candidate-validity` | `make ci` | `validate.yml :: candidate-validity` |
 | **A5: Candidate Validity Only** | repository policy | branch protection | n/a | `candidate-validity` is a non-merging signal |
+
+## Apache-2.0 mechanical requirements
+
+The `apache-license` job reduces Apache License 2.0 §4 to deterministic,
+file-state predicates. Each clause maps to a single `bash`/`grep` check:
+
+| § | Requirement | Mechanical check |
+|---|---|---|
+| §4(a) | Distribute a copy of the License | `LICENSE` and `LICENSES/Apache-2.0.txt` exist and are non-empty |
+| §4(b) | Modified files carry a prominent modification notice | For every file in `git diff --diff-filter=M $base..$head`, require an `SPDX-FileContributor:` line, a `Modifications:`/`Modified by:` comment, or an explicit path entry in `REUSE.toml` |
+| §4(c) | Retain copyright/license notices in source | Every file has `SPDX-FileCopyrightText` and `SPDX-License-Identifier` (delegated to `reuse lint`) |
+| §4(d) | Propagate `NOTICE` to redistributions | `NOTICE` exists and is non-empty |
+| §4 | License compatibility | Every `SPDX-License-Identifier:` value is in the allow-list `{Apache-2.0}` |
+
+§§1–3 (definitions, copyright/patent grants), §5 (contribution license),
+§6 (trademarks), §7 (warranty disclaimer), §8 (limitation of liability),
+and §9 (additional liability) are legal effects rather than file-state
+predicates and are not mechanically checkable; the deterministic core does
+not attempt to verify them.
+
+## Provenance assignment
+
+| Path scope | Copyright | Origin |
+|---|---|---|
+| Pre-existing LARQL codebase on `main` | Copyright (C) 2026 Chris Hay | <https://github.com/chrishayuk/larql> |
+| Compliance toolchain added by PR `claude/implement-standardized-tool-PGol9` | Copyright (C) 2026 Ian Douglas Lawrence Norman McLean | this PR |
+| `LICENSE`, `LICENSES/Apache-2.0.txt` | `NONE` (license text boilerplate) | upstream Apache Software Foundation |
+
+REUSE.toml is the authoritative manifest; per-file SPDX headers are
+informational and may be aggregated or overridden by the manifest.
 
 ## File inventory (compliance toolchain)
 
@@ -29,9 +60,11 @@ remediating a failure.
 .pre-commit-config.yaml             # local hooks mirroring CI
 REUSE.toml                          # bulk SPDX annotations
 LICENSES/Apache-2.0.txt             # canonical license text per REUSE 3.x
+NOTICE                              # Apache-2.0 §4(d) attribution notice
 cog.toml                            # Conventional Commits grammar + bump rules
 cliff.toml                          # commits -> Keep a Changelog projection
 CHANGELOG.md                        # Keep a Changelog 1.1.0, with [Unreleased]
+scripts/check_apache_license.sh     # Apache-2.0 §4 mechanical gate
 scripts/check_changelog.sh          # deterministic [Unreleased] consistency
 scripts/version_preflight.sh        # deterministic SemVer preflight
 docs/specs/compliance-pipeline.md   # this file
@@ -61,8 +94,12 @@ failure message; it must not interpret intent.
 | Failing check | Deterministic remediation |
 |---|---|
 | `provenance` | Add the offending file's path to a matching `[[annotations]]` block in `REUSE.toml`, or insert a per-file SPDX header. Re-run `reuse lint`. |
+| `apache-license` (§4(a)) | Restore `LICENSE` and `LICENSES/Apache-2.0.txt` from upstream Apache-2.0 boilerplate. |
+| `apache-license` (§4(b)) | For each listed modified file, add an `SPDX-FileContributor:` line, a `Modified by:` comment, or an explicit `[[annotations]]` block in `REUSE.toml`. |
+| `apache-license` (§4(d)) | Restore `NOTICE` to a non-empty file containing project attribution lines. |
+| `apache-license` (allow-list) | Replace the offending `SPDX-License-Identifier:` value with `Apache-2.0`, or update the allow-list in `scripts/check_apache_license.sh` if a new license is intentionally adopted. |
 | `commits` | Amend the commit so its header matches the Conventional Commits grammar declared in `cog.toml`. Force-push to the PR branch. |
-| `changelog` | Run `git-cliff --config cliff.toml --unreleased --strip header --prepend CHANGELOG.md`, commit the result with `docs(changelog): regenerate unreleased`, and re-push. Do not hand-edit the `[Unreleased]` block. |
+| `changelog` | Run `git-cliff --config cliff.toml --unreleased --output CHANGELOG.md`, commit the result with `docs(changelog): regenerate unreleased`, and re-push. Do not hand-edit the `[Unreleased]` block. |
 | `version-preflight` | This job is informational. A non-zero exit indicates an unparseable commit, which is also caught by `commits`; remediate there. |
 
 ## Out-of-scope (explicit non-goals)

--- a/docs/specs/compliance-pipeline.md
+++ b/docs/specs/compliance-pipeline.md
@@ -88,7 +88,7 @@ is intentionally scoped to candidate-validity only.
 # One-time setup (per clone).
 pipx install pre-commit
 pre-commit install --install-hooks
-pre-commit install --hook-type commit-msg
+pre-commit install --hook-type commit-msg --hook-type pre-push
 
 # Per-change loop.
 git checkout -b feat/short-description

--- a/scripts/check_apache_license.sh
+++ b/scripts/check_apache_license.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (C) 2026 Ian Douglas Lawrence Norman McLean
+# SPDX-License-Identifier: Apache-2.0
+#
+# Apache-2.0 §4 mechanical gate.
+#
+# Enforces the file-state predicates that are deterministically checkable
+# from the Apache License, Version 2.0:
+#
+#   §4(a)  A copy of the License is distributed with the Work.
+#   §4(b)  Modified files carry a prominent modification notice.
+#   §4(c)  Source forms retain copyright/license notices (delegated to
+#          `reuse lint`; this script only spot-checks the identifier).
+#   §4(d)  If the Work has a NOTICE file, redistributions include it.
+#
+# The license-identifier allow-list is currently {Apache-2.0}. Any other
+# value is rejected.
+#
+# Usage:
+#   scripts/check_apache_license.sh                  # strict, no §4(b)
+#   scripts/check_apache_license.sh BASE..HEAD       # also runs §4(b)
+#
+# Exit codes:
+#   0   all checked clauses satisfied
+#   1   at least one clause violated (diagnostics printed)
+#   2   toolchain/repository misconfiguration
+
+set -euo pipefail
+
+ALLOWED_LICENSE_IDS=("Apache-2.0")
+range="${1:-}"
+fail=0
+
+# ---------------------------------------------------------------------------
+# §4(a): canonical license text present and non-empty.
+# ---------------------------------------------------------------------------
+if [[ ! -s LICENSE ]]; then
+  echo "::error file=LICENSE::Apache-2.0 §4(a): LICENSE file missing or empty" >&2
+  fail=1
+fi
+if [[ ! -s LICENSES/Apache-2.0.txt ]]; then
+  echo "::error file=LICENSES/Apache-2.0.txt::Apache-2.0 §4(a): canonical license text missing" >&2
+  fail=1
+fi
+
+# ---------------------------------------------------------------------------
+# §4(d): NOTICE file present and non-empty. Adopting a NOTICE file is a
+# project policy decision; once present it must propagate.
+# ---------------------------------------------------------------------------
+if [[ ! -s NOTICE ]]; then
+  echo "::error file=NOTICE::Apache-2.0 §4(d): NOTICE file missing or empty" >&2
+  fail=1
+fi
+
+# ---------------------------------------------------------------------------
+# §4 (license-identifier allow-list): every SPDX-License-Identifier
+# declaration in the repo must be in ALLOWED_LICENSE_IDS.
+# ---------------------------------------------------------------------------
+allowed_re="$(IFS='|'; echo "${ALLOWED_LICENSE_IDS[*]}")"
+# A line is an actual SPDX declaration (rather than a prose mention in
+# documentation) iff, after the `path:lineno:` prefix, the only characters
+# before `SPDX-License-Identifier:` are whitespace and standard
+# single-line/block comment markers (#, //, <!--, *, ;, --). Markdown
+# table cells and inline code fences contain `|` or backticks before the
+# token and are correctly skipped.
+declaration_re='^[^:]+:[0-9]+:[[:space:]]*([#;*<!/-]|//|<!--)?[[:space:]]*SPDX-License-Identifier:'
+violations="$(
+  grep -RIn 'SPDX-License-Identifier:' \
+    --exclude-dir=.git \
+    --exclude-dir=target \
+    --exclude-dir=node_modules \
+    --exclude-dir=LICENSES \
+    --exclude=LICENSE \
+    --exclude="check_apache_license.sh" \
+    . \
+  | grep -E "$declaration_re" \
+  | grep -vE "SPDX-License-Identifier:[[:space:]]*(${allowed_re})([[:space:]]|$)" \
+  || true
+)"
+if [[ -n "$violations" ]]; then
+  echo "::error::Apache-2.0 license-identifier allow-list violation (allowed: ${ALLOWED_LICENSE_IDS[*]}):" >&2
+  printf '%s\n' "$violations" >&2
+  fail=1
+fi
+
+# ---------------------------------------------------------------------------
+# §4(b): modification notices on PR-modified pre-existing files.
+#
+# Only runs when an explicit base..head range is supplied; on push to main
+# we do not have a meaningful base to diff against.
+# ---------------------------------------------------------------------------
+if [[ -n "$range" ]]; then
+  modified="$(git diff --diff-filter=M --name-only "$range" || true)"
+  if [[ -z "$modified" ]]; then
+    echo "check_apache_license: §4(b) vacuous (no pre-existing files modified)"
+  else
+    missing=()
+    while IFS= read -r f; do
+      [[ -f "$f" ]] || continue
+      if grep -qE '(SPDX-FileContributor|Modifications:|Modified by:)' "$f"; then
+        continue
+      fi
+      # REUSE.toml-driven attribution is acceptable: an explicit path entry
+      # in REUSE.toml signals a deliberate provenance declaration.
+      if grep -qF "\"$f\"" REUSE.toml; then
+        continue
+      fi
+      missing+=("$f")
+    done <<<"$modified"
+    if (( ${#missing[@]} > 0 )); then
+      echo "::error::Apache-2.0 §4(b): modified files lack a modification notice:" >&2
+      printf '  %s\n' "${missing[@]}" >&2
+      echo "Remediation: add an SPDX-FileContributor line, a 'Modified by:' comment," >&2
+      echo "or an explicit REUSE.toml [[annotations]] block for each listed file." >&2
+      fail=1
+    fi
+  fi
+fi
+
+if (( fail )); then
+  exit 1
+fi
+echo "check_apache_license: OK"

--- a/scripts/check_changelog.sh
+++ b/scripts/check_changelog.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deterministic changelog consistency check.
+#
+# Computes the canonical Keep a Changelog `[Unreleased]` block from the
+# validated Conventional Commits in the range (LAST_TAG..HEAD] using
+# git-cliff, then compares it byte-for-byte against the `[Unreleased]` block
+# currently committed to CHANGELOG.md. Exits non-zero with a unified diff if
+# they differ.
+#
+# Inputs:
+#   - cliff.toml          (transformer rules)
+#   - CHANGELOG.md        (source-of-truth file in the working tree)
+#   - git history         (validated commits)
+#
+# This script is pure: same inputs => same output. Do not introduce any
+# probabilistic logic, network calls, or LLM-generated content.
+#
+# Exit codes:
+#   0  CHANGELOG.md `[Unreleased]` matches git-cliff output exactly
+#   1  Mismatch (a unified diff is printed to stderr)
+#   2  Toolchain misconfiguration (git-cliff missing, etc.)
+
+set -euo pipefail
+
+CHANGELOG_FILE="${CHANGELOG_FILE:-CHANGELOG.md}"
+CLIFF_CONFIG="${CLIFF_CONFIG:-cliff.toml}"
+
+if ! command -v git-cliff >/dev/null 2>&1; then
+  echo "check_changelog: git-cliff is not installed or not on PATH" >&2
+  exit 2
+fi
+
+if [[ ! -f "$CLIFF_CONFIG" ]]; then
+  echo "check_changelog: missing transformer config: $CLIFF_CONFIG" >&2
+  exit 2
+fi
+
+if [[ ! -f "$CHANGELOG_FILE" ]]; then
+  echo "check_changelog: missing changelog file: $CHANGELOG_FILE" >&2
+  exit 2
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+expected="$workdir/expected.md"
+actual="$workdir/actual.md"
+
+# Render the unreleased section deterministically from validated commits.
+# `--unreleased` restricts to commits past the last tag.
+# `--strip header` keeps only the body so we can compare to the [Unreleased]
+# block of CHANGELOG.md without preamble noise.
+git-cliff \
+  --config "$CLIFF_CONFIG" \
+  --unreleased \
+  --strip header \
+  --output "$expected"
+
+# Extract the existing [Unreleased] block from the committed CHANGELOG.md.
+# Inclusive of the heading; terminates at the next `## [` heading or EOF.
+awk '
+  /^## \[Unreleased\]/        { in_block = 1; print; next }
+  in_block && /^## \[/        { in_block = 0 }
+  in_block                    { print }
+' "$CHANGELOG_FILE" > "$actual"
+
+if ! diff -u "$expected" "$actual" >/dev/null; then
+  {
+    echo "check_changelog: CHANGELOG.md [Unreleased] does not match the"
+    echo "                 deterministic projection of validated commits."
+    echo "                 Expected vs. actual diff:"
+    echo
+    diff -u "$expected" "$actual" || true
+    echo
+    echo "Remediation: regenerate with"
+    echo "  git-cliff --config $CLIFF_CONFIG --unreleased --strip header \\"
+    echo "    --prepend $CHANGELOG_FILE"
+    echo "or amend the offending commit so its Conventional Commits header"
+    echo "matches the rules in cog.toml / cliff.toml."
+  } >&2
+  exit 1
+fi
+
+echo "check_changelog: OK"

--- a/scripts/check_changelog.sh
+++ b/scripts/check_changelog.sh
@@ -62,9 +62,9 @@ git-cliff \
 # Extract the existing [Unreleased] block from the committed CHANGELOG.md.
 # Inclusive of the heading; terminates at the next `## [` heading or EOF.
 awk '
-  /^## \[Unreleased\]/        { in_block = 1; print; next }
-  in_block && /^## \[/        { in_block = 0 }
-  in_block                    { print }
+  /^## \[Unreleased\]/                 { in_block = 1; print; next }
+  in_block && (/^## \[/ || /^\[.*\]:/) { in_block = 0 }
+  in_block                             { print }
 ' "$CHANGELOG_FILE" > "$actual"
 
 if ! diff -u "$expected" "$actual" >/dev/null; then

--- a/scripts/version_preflight.sh
+++ b/scripts/version_preflight.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deterministic SemVer preflight.
+#
+# Computes the next SemVer string for the repository as a pure function of:
+#   - the current tag (last `v[0-9]+.[0-9]+.[0-9]+`, or v0.0.0 if none)
+#   - the validated Conventional Commits in the range (last_tag..HEAD]
+#
+# Bump rules (matching cog.toml policy):
+#   any commit with `!` header or `BREAKING CHANGE:` footer  -> major
+#   else any `feat:`                                         -> minor
+#   else any `fix:` / `perf:` / `refactor:` / `revert:`      -> patch
+#   else                                                     -> no bump
+#
+# This script is informational by default. It writes the computed version
+# to stdout and a structured summary to ${GITHUB_OUTPUT:-/dev/null} as
+# `next_version=...` and `bump_kind=...`. It exits 0 even on a no-bump
+# result; it only exits non-zero on a malformed commit it cannot classify.
+#
+# Exit codes:
+#   0  preflight succeeded (next version printed)
+#   1  encountered an unparseable commit in range
+#   2  toolchain misconfiguration
+
+set -euo pipefail
+
+last_tag="$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1 || true)"
+if [[ -z "$last_tag" ]]; then
+  base_version="0.0.0"
+  range="HEAD"
+else
+  base_version="${last_tag#v}"
+  range="${last_tag}..HEAD"
+fi
+
+IFS='.' read -r major minor patch <<<"$base_version"
+if [[ -z "${major:-}" || -z "${minor:-}" || -z "${patch:-}" ]]; then
+  echo "version_preflight: cannot parse base version '$base_version'" >&2
+  exit 2
+fi
+
+bump="none"
+
+# `-z` makes git emit a NUL between commits (NUL embedded in --format= would
+# be truncated at exec()). `%B` gives the full message including footers, so
+# multi-line bodies do not break the loop.
+while IFS= read -r -d '' commit; do
+  header="$(printf '%s\n' "$commit" | head -n1)"
+
+  # Skip merge commits per cog.toml policy.
+  if [[ "$header" =~ ^Merge\  ]]; then
+    continue
+  fi
+
+  # Strict Conventional Commits header grammar:
+  #   type(scope)?!?: subject
+  if [[ ! "$header" =~ ^(feat|fix|perf|refactor|revert|docs|chore|build|ci|test|style)(\([^\)]+\))?(!)?:[[:space:]].+ ]]; then
+    echo "version_preflight: unparseable commit header: $header" >&2
+    exit 1
+  fi
+
+  type="${BASH_REMATCH[1]}"
+  bang="${BASH_REMATCH[3]}"
+
+  if [[ -n "$bang" ]] || printf '%s\n' "$commit" | grep -qE '^BREAKING CHANGE:'; then
+    bump="major"
+    break  # major dominates; no need to keep scanning
+  fi
+
+  case "$type" in
+    feat)
+      [[ "$bump" == "none" || "$bump" == "patch" ]] && bump="minor"
+      ;;
+    fix|perf|refactor|revert)
+      [[ "$bump" == "none" ]] && bump="patch"
+      ;;
+  esac
+done < <(git log --reverse -z --format='%B' "$range")
+
+case "$bump" in
+  major) major=$((major + 1)); minor=0; patch=0 ;;
+  minor) minor=$((minor + 1)); patch=0 ;;
+  patch) patch=$((patch + 1)) ;;
+  none)  : ;;
+esac
+
+next_version="${major}.${minor}.${patch}"
+
+echo "version_preflight: base=$base_version bump=$bump next=$next_version"
+echo "$next_version"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "next_version=${next_version}"
+    echo "bump_kind=${bump}"
+    echo "base_version=${base_version}"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/version_preflight.sh
+++ b/scripts/version_preflight.sh
@@ -26,16 +26,41 @@
 
 set -euo pipefail
 
+# Range resolution priority:
+#   1. explicit positional argument (e.g. "$base_sha..$head_sha")
+#   2. last v-tag..HEAD if a tag exists
+#   3. fall back to "no bump" with version 0.0.0 (pre-policy history is
+#      grandfathered and must not be classified by this script)
+explicit_range="${1:-}"
 last_tag="$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1 || true)"
-if [[ -z "$last_tag" ]]; then
-  base_version="0.0.0"
-  range="HEAD"
-else
+if [[ -n "$explicit_range" ]]; then
+  range="$explicit_range"
+  base_version="${last_tag#v}"
+  base_version="${base_version:-0.0.0}"
+elif [[ -n "$last_tag" ]]; then
   base_version="${last_tag#v}"
   range="${last_tag}..HEAD"
+else
+  echo "version_preflight: no v-tag found and no range given; reporting no bump" >&2
+  base_version="0.0.0"
+  next_version="0.0.0"
+  echo "version_preflight: base=$base_version bump=none next=$next_version"
+  echo "$next_version"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "next_version=${next_version}"
+      echo "bump_kind=none"
+      echo "base_version=${base_version}"
+    } >> "$GITHUB_OUTPUT"
+  fi
+  exit 0
 fi
 
-IFS='.' read -r major minor patch <<<"$base_version"
+IFS='.' read -r major minor patch_raw <<<"$base_version"
+# Strip any pre-release / build-metadata suffix from the patch component
+# (e.g. `1.2.3-rc1` -> patch=3) so the arithmetic increment below cannot
+# trip on a non-numeric value.
+patch="${patch_raw%%[^0-9]*}"
 if [[ -z "${major:-}" || -z "${minor:-}" || -z "${patch:-}" ]]; then
   echo "version_preflight: cannot parse base version '$base_version'" >&2
   exit 2
@@ -64,7 +89,9 @@ while IFS= read -r -d '' commit; do
   type="${BASH_REMATCH[1]}"
   bang="${BASH_REMATCH[3]}"
 
-  if [[ -n "$bang" ]] || printf '%s\n' "$commit" | grep -qE '^BREAKING CHANGE:'; then
+  # Conventional Commits permits both `BREAKING CHANGE:` (space) and
+  # `BREAKING-CHANGE:` (hyphen) as footer tokens.
+  if [[ -n "$bang" ]] || printf '%s\n' "$commit" | grep -qE '^BREAKING[ -]CHANGE:'; then
     bump="major"
     break  # major dominates; no need to keep scanning
   fi


### PR DESCRIPTION
## Summary

Brings the repository into conformance with the formal compliance specification by wiring in a deterministic, rule-based validation toolchain. Each Foundational Axiom is now enforced by exactly one tool and surfaced as exactly one CI job, aggregated under a single `candidate-validity` gate. The pipeline decides only whether a branch is a valid candidate extension of `main`; merge, close, release, and publication remain explicitly out of scope (Axiom A5).

## Axiom-to-artifact map

| Axiom | Tool | Config | CI job |
|---|---|---|---|
| A1 Explicit Provenance | `reuse` 5.0.2 | `REUSE.toml`, `LICENSES/Apache-2.0.txt` | `provenance` |
| A2 Structured History | `cog` 6.2.0 | `cog.toml` | `commits` |
| A3 Derived Documentation | `git-cliff` 2.6.1 + `scripts/check_changelog.sh` | `cliff.toml`, `CHANGELOG.md` | `changelog` |
| A2 (SemVer) | `scripts/version_preflight.sh` | `cog.toml` (bump rules) | `version-preflight` |
| A4 Verified Compliance | aggregate gate | — | `candidate-validity` |
| A5 Candidate Validity Only | repository policy | branch protection | `candidate-validity` is non-merging |

## Files added

- `REUSE.toml` + `LICENSES/Apache-2.0.txt` — bulk SPDX annotations covering every tracked path
- `cog.toml` — strict Conventional Commits grammar and SemVer bump policy
- `cliff.toml` — total, explicit projection from commit types to Keep a Changelog sections
- `CHANGELOG.md` — Keep a Changelog 1.1.0 with empty `[Unreleased]` block
- `scripts/check_changelog.sh` — diffs `[Unreleased]` against the `git-cliff` projection
- `scripts/version_preflight.sh` — pure-function SemVer preflight from commits in range
- `.pre-commit-config.yaml` — local hooks mirroring the CI rules
- `.github/workflows/validate.yml` — pinned-version PR validation workflow
- `docs/specs/compliance-pipeline.md` — operator reference and remediation contract

## Determinism notes

- All tool versions are pinned in `validate.yml` `env:` and `.pre-commit-config.yaml` `rev:`. Bumps are deliberate, dedicated PRs.
- `scripts/version_preflight.sh` uses `git log -z` rather than an in-format NUL (which would be truncated at `exec()`).
- The cocogitto `commits` job validates only the PR range, or `HEAD~1..HEAD` on push to `main`. Pre-existing non-conventional history is grandfathered.
- The `changelog` job compares byte-for-byte against the deterministic `git-cliff --unreleased --strip header` output.

## Out of scope (explicit non-goals)

No merging, tagging, releasing, publishing, signing, deploying, or registry interaction. If a future policy adopts any of these, it must live in a separate workflow and must not call into `validate.yml`.

## Test plan

- [ ] `provenance` job passes (every tracked path matches a `REUSE.toml` annotation)
- [ ] `commits` job passes (the five commits on this branch are Conventional Commits-conformant)
- [ ] `changelog` job passes once `git-cliff` is available in CI (this PR's commits are all `chore`/`docs`/`ci`/`feat(scripts)` — only the `feat` produces an `Added` entry, which the next push will need to land in `CHANGELOG.md`)
- [ ] `version-preflight` job emits a `feat`-induced minor bump notice
- [ ] `candidate-validity` aggregate is green
- [ ] Local: `pre-commit run --all-files` succeeds after `pre-commit install`

https://claude.ai/code/session_01PqpApbJfuzwF6iwfBfiTQE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqpApbJfuzwF6iwfBfiTQE)_