### PR TITLE
Add OpenBlas dependency

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,5 @@
 # Cargo configuration for cross-platform builds
 
-[build]
-# Use parallel jobs by default
-jobs = 0
-
 # Android cross-compilation configuration
 [target.aarch64-linux-android]
 linker = "aarch64-linux-android-clang"

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -56,6 +56,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install system dependencies (OpenBlas)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
+
       - name: Install Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" \
@@ -130,6 +135,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install system dependencies (OpenBlas)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
+
       - name: Install Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" \
@@ -193,6 +203,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install system dependencies (build tools + OpenBlas)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
+
       - name: Install Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" \
@@ -255,6 +270,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Install system dependencies (Accelerate framework is built-in on macOS)
+        run: |
+          # Accelerate framework is built-in to macOS, no installation needed
+          # But we can verify it's available
+          ls -la /System/Library/Frameworks/Accelerate.framework/ || echo "Accelerate framework not found"
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -104,6 +104,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install system dependencies (OpenBlas)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
+
       - name: Install Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" \
@@ -173,6 +178,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Install system dependencies (OpenBlas)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
 
       - name: Install Rust toolchain
         run: |
@@ -300,6 +310,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install system dependencies (OpenBlas)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
+
       - name: Install Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" \
@@ -342,6 +357,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Install system dependencies (OpenBlas)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
 
       - name: Install Rust toolchain
         run: |
@@ -386,6 +406,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Install system dependencies (OpenBlas)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
 
       - name: Install rustup (no toolchain pin)
         # cargo-msrv installs and switches toolchains itself; we only
@@ -436,6 +461,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Install system dependencies (OpenBlas)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
 
       - name: Install Rust toolchain
         run: |
@@ -503,6 +533,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Install system dependencies (OpenBlas)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
 
       - name: Install Rust toolchain
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 ### Fixed
 
 - Add Android NDK setup to cross-platform-build workflow
+- Add OpenBlas (libopenblas-dev) installation to CI workflows
+- Add OpenBlas to workspace dependencies for explicit BLAS requirement
 - Address code review feedback on CI scripts
 - Address review feedback and CI environment realities
 - Align license enforcement with audited multi-license tree
@@ -35,6 +37,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Drop §4(b) per-file re-walk; rely on REUSE.toml manifest
 - Linux support — conditional BLAS and Q4 scalar fallback
 - Linux/WSL2 support + temperature parameter
+- Remove invalid jobs = 0 from .cargo/config.toml
 - Revert manual CHANGELOG edit; let git-cliff regenerate from commits
 - Scope cron to advisory scanners and harden SARIF upload
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Add Android NDK setup to cross-platform-build workflow
 - Add OpenBlas (libopenblas-dev) installation to CI workflows
 - Add OpenBlas to workspace dependencies for explicit BLAS requirement
+- Add package section to root Cargo.toml for MSRV verification
 - Address code review feedback on CI scripts
 - Address review feedback and CI environment realities
 - Align license enforcement with audited multi-license tree

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,5 @@ repository = "https://github.com/chrishayuk/chuk-larql-rs"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+blas-src = { version = "0.10", default-features = false }
+openblas-src = { version = "0.10" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,12 @@
+[package]
+name = "larql-workspace"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+publish = false
+
 [workspace]
 resolver = "2"
 members = [


### PR DESCRIPTION
## Summary

Add OpenBlas as a system dependency to the project for BLAS-accelerated matrix operations.

### Changes

- **Fixed invalid Cargo config**: Removed the invalid `jobs = 0` configuration from `.cargo/config.toml` that was preventing builds
- **Added OpenBlas to CI workflows**: 
  - `quality.yml`: Added `libopenblas-dev` installation to clippy, test, doc, examples, msrv, mutants, and python jobs
  - `cross-platform-build.yml`: Added `libopenblas-dev` installation to ubuntu, chromeos, and android build jobs
  - macOS uses Apple's built-in Accelerate framework (no installation needed)

### Context

The `larql-compute` and `larql-inference` crates are configured to use BLAS-accelerated matrix operations through `openblas-src` with the `system` feature, which requires OpenBlas to be installed as a system dependency. The CI was failing because the GitHub Actions environments did not have OpenBlas installed.

### Testing

The CI workflows now properly install `libopenblas-dev` before running build, test, and linting jobs, which should resolve the dependency resolution failures on Linux platforms.