### PR TITLE
Add Windows cmake + zlib installation and force release CRT

### DIFF
--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -77,6 +77,14 @@ jobs:
           "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
           & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
 
+      - name: Install cmake + zlib (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install cmake zlib --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          # Force release CRT for protobuf-src (debug CRT lacks full math symbols)
+          echo "CMAKE_BUILD_TYPE=Release" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v4
         with:

--- a/.github/workflows/larql-compute.yml
+++ b/.github/workflows/larql-compute.yml
@@ -67,6 +67,14 @@ jobs:
           "VCPKG_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "$root\installed\x64-windows\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Install cmake + zlib (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install cmake zlib --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          # Force release CRT for protobuf-src (debug CRT lacks full math symbols)
+          echo "CMAKE_BUILD_TYPE=Release" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v4
         with:

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -73,6 +73,14 @@ jobs:
           "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
           & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
 
+      - name: Install cmake + zlib (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install cmake zlib --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          # Force release CRT for protobuf-src (debug CRT lacks full math symbols)
+          echo "CMAKE_BUILD_TYPE=Release" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v4
         with:

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -80,6 +80,14 @@ jobs:
           "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
           & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
 
+      - name: Install cmake + zlib (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install cmake zlib --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          # Force release CRT for protobuf-src (debug CRT lacks full math symbols)
+          echo "CMAKE_BUILD_TYPE=Release" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v4
         with:

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -68,6 +68,14 @@ jobs:
           "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
           & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
 
+      - name: Install cmake + zlib (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install cmake zlib --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          # Force release CRT for protobuf-src (debug CRT lacks full math symbols)
+          echo "CMAKE_BUILD_TYPE=Release" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v4
         with:

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -78,6 +78,14 @@ jobs:
           "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
           & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
 
+      - name: Install cmake + zlib (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install cmake zlib --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          # Force release CRT for protobuf-src (debug CRT lacks full math symbols)
+          echo "CMAKE_BUILD_TYPE=Release" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v4
         with:

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -70,6 +70,14 @@ jobs:
           "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
           & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
 
+      - name: Install cmake + zlib (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install cmake zlib --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          # Force release CRT for protobuf-src (debug CRT lacks full math symbols)
+          echo "CMAKE_BUILD_TYPE=Release" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary

Install cmake and zlib on Windows runners before the cargo cache step, and force CMAKE_BUILD_TYPE=Release to ensure protobuf-src has access to full math symbols in the release CRT.

## Changes

- Added "Install cmake + zlib (Windows)" step to all cross-platform CI/CD workflows
- Sets CMAKE_BUILD_TYPE=Release environment variable for protobuf builds
- Applies to all per-crate workflows that test on Windows:
  - larql-cli
  - larql-compute
  - larql-inference
  - larql-kv
  - larql-lql
  - larql-server
  - larql-vindex

## Test plan

- [x] Workflows compile without syntax errors
- [ ] Windows CI jobs pass with cmake + zlib installed
- [ ] protobuf-src builds successfully with release CRT

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1QbabX9uc1wAVQV2pfqR1)_