### PR TITLE
fix(wasm): enable fuel metering on wasmi Engine

### DIFF
--- a/crates/model-compute/src/wasm/runtime.rs
+++ b/crates/model-compute/src/wasm/runtime.rs
@@ -2,7 +2,7 @@
 //! `wasmi::Engine`; each `Session::new` creates a fresh `Store` with
 //! the configured limits so calls are isolated.
 
-use wasmi::{Engine, Module};
+use wasmi::{Config, Engine, Module};
 
 use super::error::SolverError;
 use super::session::Session;
@@ -35,7 +35,9 @@ impl SolverRuntime {
     }
 
     pub fn with_limits(limits: SolverLimits) -> Result<Self, SolverError> {
-        let engine = Engine::default();
+        let mut config = Config::default();
+        config.consume_fuel(true);
+        let engine = Engine::new(&config);
         Ok(Self { engine, limits })
     }
 


### PR DESCRIPTION
## Summary

- `Engine::default()` in `runtime.rs` does not enable fuel metering, so every call to `store.set_fuel()` in `session.rs` returned `Err(Engine("fuel metering is disabled"))` — causing all 8 tests in `wasm_roundtrip.rs` to fail on **every platform** (Android aarch64/armv7, macOS, Ubuntu, ChromeOS, Windows)
- Fix: pass a `Config` with `consume_fuel(true)` to `Engine::new()`, mirroring what `runtime_jit.rs` already does for the wasmtime path
- The failures appeared inconsistent across non-Android platforms in PR #47 only because different CI workflow runs exercised different commits, not because the failure itself was flaky — it is fully deterministic

## Root cause

```rust
// before — fuel metering silently disabled
let engine = Engine::default();

// after — matches the wasmtime path in runtime_jit.rs
let mut config = Config::default();
config.consume_fuel(true);
let engine = Engine::new(&config);
```

## Test plan

- [x] `cargo test -p model-compute --no-default-features --features wasm --test wasm_roundtrip` — 8/8 pass locally
- [ ] CI matrix: `test · android-aarch64`, `test · android-armv7`, `test · ubuntu-24.04`, `test · macos-15-arm64`, `test · chromeos-24.04`, `test · windows-latest` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)