### PR TITLE
ci(wasm): gate all Android builds on wasm backend health

### DIFF
--- a/.github/workflows/bench-regress.yml
+++ b/.github/workflows/bench-regress.yml
@@ -28,6 +28,9 @@ permissions:
   contents: read
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   bench:
     name: bench - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -60,16 +63,6 @@ jobs:
             platform: macos
             target: aarch64-apple-darwin
 
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
-
     steps:
       - uses: actions/checkout@v6
 
@@ -77,43 +70,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-
-      - name: Install Android NDK
-        if: matrix.platform == 'android'
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r27
-          link-to-sdk: true
-
-      - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
-        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
-
-      - name: Add Android target
-        if: matrix.platform == 'android'
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Install OpenBLAS (Linux/ChromeOS)
         if: matrix.platform == 'ubuntu' || matrix.platform == 'chromeos'
@@ -129,6 +85,133 @@ jobs:
           if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
           "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
           & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      # Cargo deps are big and stable across PRs — separate cache.
+      - name: Cache cargo deps
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-bench-
+
+      # Criterion baselines: write-through on main, read-only on PRs.
+      # Keyed by the run number so each main push refreshes the cache.
+      - name: Cache criterion baseline (main only)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache@v5
+        with:
+          path: target/criterion
+          key: ${{ runner.os }}-${{ matrix.target }}-criterion-baseline-${{ github.run_number }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-criterion-baseline-
+
+      - name: Restore criterion baseline (PRs only)
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v5
+        with:
+          path: target/criterion
+          key: ${{ runner.os }}-${{ matrix.target }}-criterion-baseline-
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-criterion-baseline-
+
+      - name: Save baseline (main only)
+        if: github.ref == 'refs/heads/main'
+        run: make bench-save
+
+      - name: Check vs baseline (PRs + manual)
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        run: |
+          # Cold cache → bench-check prints "no baseline found" and
+          # exits 2. Treat as neutral: the first PR after CI is stood
+          # up shouldn't fail just because there's no baseline yet.
+          set +e
+          make bench-check
+          rc=$?
+          set -e
+          if [ "$rc" -eq 2 ]; then
+            echo "::warning::no criterion baseline cached; skipping regression check"
+            exit 0
+          fi
+          exit "$rc"
+
+      # On regression, attach the criterion HTML report so reviewers
+      # can see the per-cell delta without re-running locally.
+      - name: Upload criterion report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: criterion-report
+          path: target/criterion/
+          retention-days: 14
+
+  bench-android:
+    name: bench - ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       # Cargo deps are big and stable across PRs — separate cache.
       - name: Cache cargo deps

--- a/.github/workflows/kv-cache-benchmark.yml
+++ b/.github/workflows/kv-cache-benchmark.yml
@@ -16,6 +16,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/kv-cache-benchmark.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -25,9 +26,13 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/kv-cache-benchmark.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -43,33 +48,19 @@ jobs:
         include:
           - name: ubuntu-24.04
             runner: ubuntu-24.04
-            platform: ubuntu
             target: x86_64-unknown-linux-gnu
 
           - name: chromeos-24.04
             runner: ubuntu-24.04
-            platform: chromeos
             target: x86_64-unknown-linux-gnu
 
           - name: windows-latest
             runner: windows-latest
-            platform: windows
             target: x86_64-pc-windows-msvc
 
           - name: macos-15-arm64
             runner: macos-15
-            platform: macos
             target: aarch64-apple-darwin
-
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
 
     steps:
       - uses: actions/checkout@v6
@@ -80,13 +71,13 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install OpenBLAS (Linux/ChromeOS)
-        if: matrix.platform == 'ubuntu' || matrix.platform == 'chromeos'
+        if: matrix.name == 'ubuntu-24.04' || matrix.name == 'chromeos-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libopenblas-dev pkg-config
 
       - name: Install OpenBLAS (Windows)
-        if: matrix.platform == 'windows'
+        if: matrix.name == 'windows-latest'
         shell: pwsh
         run: |
           $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
@@ -94,23 +85,72 @@ jobs:
           "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
           & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
 
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ matrix.target }}-cargo-kv-bench
+
+      - name: Format check
+        run: cargo fmt -p kv-cache-benchmark -- --check
+
+      - name: Check
+        run: cargo check -p kv-cache-benchmark --target ${{ matrix.target }} --all-targets
+
+      - name: Clippy
+        run: cargo clippy -p kv-cache-benchmark --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Tests
+        run: cargo test -p kv-cache-benchmark --target ${{ matrix.target }}
+
+      - name: Benchmark compile/tests
+        run: cargo test -p kv-cache-benchmark --target ${{ matrix.target }} --benches
+
+  test-android:
+    name: test · ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
       - name: Install Android NDK
-        if: matrix.platform == 'android'
         uses: nttld/setup-ndk@v1
         with:
           ndk-version: r27
           link-to-sdk: true
 
       - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
         run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
 
       - name: Add Android target
-        if: matrix.platform == 'android'
         run: rustup target add ${{ matrix.target }}
 
       - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        if: matrix.target == 'aarch64-linux-android'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
@@ -121,7 +161,7 @@ jobs:
           echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        if: matrix.target == 'armv7-linux-androideabi'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
@@ -132,13 +172,11 @@ jobs:
           echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,arm
 
       - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
         run: |
           echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
           echo "TMPDIR=/tmp" >> $GITHUB_ENV
@@ -165,11 +203,6 @@ jobs:
         run: cargo clippy -p kv-cache-benchmark --target ${{ matrix.target }} --all-targets -- -D warnings
 
       - name: Tests
-        if: matrix.platform != 'android'
-        run: cargo test -p kv-cache-benchmark --target ${{ matrix.target }}
-
-      - name: Tests (Android)
-        if: matrix.platform == 'android'
         run: cargo test -p kv-cache-benchmark --target ${{ matrix.target }} --lib --tests
 
       - name: Benchmark compile/tests

--- a/.github/workflows/larql-boundary.yml
+++ b/.github/workflows/larql-boundary.yml
@@ -19,6 +19,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/larql-boundary.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -26,9 +27,13 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/larql-boundary.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -40,33 +45,19 @@ jobs:
         include:
           - name: ubuntu-24.04
             runner: ubuntu-24.04
-            platform: ubuntu
             target: x86_64-unknown-linux-gnu
 
           - name: chromeos-24.04
             runner: ubuntu-24.04
-            platform: chromeos
             target: x86_64-unknown-linux-gnu
 
           - name: windows-latest
             runner: windows-latest
-            platform: windows
             target: x86_64-pc-windows-msvc
 
           - name: macos-15-arm64
             runner: macos-15
-            platform: macos
             target: aarch64-apple-darwin
-
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
 
     permissions:
       contents: read
@@ -80,23 +71,83 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-boundary-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-boundary-
+
+      - name: Format check
+        run: cargo fmt -p larql-boundary -- --check
+
+      - name: Check (all targets)
+        run: cargo check -p larql-boundary --target ${{ matrix.target }} --all-targets
+
+      - name: Clippy (warnings as errors)
+        run: cargo clippy -p larql-boundary --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Unit + integration tests
+        run: cargo test -p larql-boundary --target ${{ matrix.target }}
+
+      - name: Test benchmarks (compile + smoke)
+        run: cargo test -p larql-boundary --target ${{ matrix.target }} --benches
+
+      - name: Run examples
+        run: |
+          cargo run -p larql-boundary --target ${{ matrix.target }} --example encode_decode
+          cargo run -p larql-boundary --target ${{ matrix.target }} --example gate_decision
+
+  test-android:
+    name: test · ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
       - name: Install Android NDK
-        if: matrix.platform == 'android'
         uses: nttld/setup-ndk@v1
         with:
           ndk-version: r27
           link-to-sdk: true
 
       - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
         run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
 
       - name: Add Android target
-        if: matrix.platform == 'android'
         run: rustup target add ${{ matrix.target }}
 
       - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        if: matrix.target == 'aarch64-linux-android'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
@@ -107,7 +158,7 @@ jobs:
           echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        if: matrix.target == 'armv7-linux-androideabi'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
@@ -118,13 +169,11 @@ jobs:
           echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,arm
 
       - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
         run: |
           echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
           echo "TMPDIR=/tmp" >> $GITHUB_ENV
@@ -157,11 +206,6 @@ jobs:
         run: cargo clippy -p larql-boundary --target ${{ matrix.target }} --all-targets -- -D warnings
 
       - name: Unit + integration tests
-        if: matrix.platform != 'android'
-        run: cargo test -p larql-boundary --target ${{ matrix.target }}
-
-      - name: Unit + integration tests (Android)
-        if: matrix.platform == 'android'
         run: cargo test -p larql-boundary --target ${{ matrix.target }} --lib --tests
 
       - name: Test benchmarks (compile + smoke)

--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -28,6 +28,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-cli.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -41,9 +42,13 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-cli.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -77,16 +82,6 @@ jobs:
             platform: macos
             target: aarch64-apple-darwin
 
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
-
     steps:
       - uses: actions/checkout@v6
 
@@ -94,62 +89,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-
-      - name: Install Android NDK
-        if: matrix.platform == 'android'
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r27
-          link-to-sdk: true
-
-      - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
-        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
-
-      - name: Add Android target
-        if: matrix.platform == 'android'
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,arm
-
-      - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
-        run: |
-          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
-          echo "TMPDIR=/tmp" >> $GITHUB_ENV
-          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
-          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
-          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
-            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
-            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Install OpenBLAS (Linux/ChromeOS)
         if: matrix.platform == 'ubuntu' || matrix.platform == 'chromeos'
@@ -186,7 +125,7 @@ jobs:
       - name: Format check
         run: cargo fmt -p larql-cli -- --check
 
-      - name: Check (CPU only) on Linux/Windows/ChromeOS/Android
+      - name: Check (CPU only) on Linux/Windows/ChromeOS
         if: matrix.platform != 'macos'
         run: cargo check -p larql-cli --target ${{ matrix.target }} --bins --tests --no-default-features
 
@@ -194,12 +133,116 @@ jobs:
         if: matrix.platform == 'macos'
         run: cargo check -p larql-cli --target ${{ matrix.target }} --bins --tests
 
-      - name: Tests (CPU only) on Linux/Windows/ChromeOS/Android
+      - name: Tests (CPU only) on Linux/Windows/ChromeOS
+        if: matrix.platform != 'macos'
         run: cargo test -p larql-cli --target ${{ matrix.target }} --no-default-features
 
       - name: Tests (default features) on macOS
         if: matrix.platform == 'macos'
         run: cargo test -p larql-cli --target ${{ matrix.target }}
+
+  test-android:
+    name: test - ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-cli-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-cli-
+
+      - name: Format check
+        run: cargo fmt -p larql-cli -- --check
+
+      - name: Check (CPU only) on Linux/Windows/ChromeOS/Android
+        run: cargo check -p larql-cli --target ${{ matrix.target }} --bins --tests --no-default-features
+
+      - name: Tests (CPU only) on Linux/Windows/ChromeOS/Android
+        run: cargo test -p larql-cli --target ${{ matrix.target }} --no-default-features
 
   coverage:
     name: coverage - ubuntu

--- a/.github/workflows/larql-compute.yml
+++ b/.github/workflows/larql-compute.yml
@@ -19,6 +19,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-compute.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -28,9 +29,13 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-compute.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -64,16 +69,6 @@ jobs:
             platform: macos
             target: aarch64-apple-darwin
 
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
-
     steps:
       - uses: actions/checkout@v6
 
@@ -81,62 +76,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-
-      - name: Install Android NDK
-        if: matrix.platform == 'android'
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r27
-          link-to-sdk: true
-
-      - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
-        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
-
-      - name: Add Android target
-        if: matrix.platform == 'android'
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,arm
-
-      - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
-        run: |
-          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
-          echo "TMPDIR=/tmp" >> $GITHUB_ENV
-          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
-          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
-          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
-            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
-            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Install OpenBLAS (Linux/ChromeOS)
         if: matrix.platform == 'ubuntu' || matrix.platform == 'chromeos'
@@ -173,7 +112,7 @@ jobs:
       - name: Check default features
         run: cargo check -p larql-compute --target ${{ matrix.target }} --all-targets
 
-      - name: Check all features on Linux/Windows/ChromeOS/Android
+      - name: Check all features on Linux/Windows/ChromeOS
         if: matrix.platform != 'macos'
         run: cargo check -p larql-compute --target ${{ matrix.target }} --all-targets --all-features
 
@@ -184,13 +123,131 @@ jobs:
       - name: Clippy default features
         run: cargo clippy -p larql-compute --target ${{ matrix.target }} --all-targets -- -D warnings
 
-      - name: Clippy all features on Linux/Windows/ChromeOS/Android
+      - name: Clippy all features on Linux/Windows/ChromeOS
         if: matrix.platform != 'macos'
         run: cargo clippy -p larql-compute --target ${{ matrix.target }} --all-targets --all-features -- -D warnings
 
       - name: Clippy Metal feature on macOS
         if: matrix.platform == 'macos'
         run: cargo clippy -p larql-compute --target ${{ matrix.target }} --all-targets --features metal -- -D warnings
+
+      - name: Unit tests
+        run: cargo test -p larql-compute --target ${{ matrix.target }} --lib
+
+      - name: Backend contract tests
+        run: cargo test -p larql-compute --target ${{ matrix.target }} --test test_backend_matmul_quant
+
+      - name: Pipeline and MoE contract tests
+        run: cargo test -p larql-compute --target ${{ matrix.target }} --test test_pipeline_and_moe
+
+  test-android:
+    name: test · ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-compute-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-compute-
+
+      - name: Format check
+        run: cargo fmt -p larql-compute -- --check
+
+      - name: Check default features
+        run: cargo check -p larql-compute --target ${{ matrix.target }} --all-targets
+
+      - name: Check all features on Linux/Windows/ChromeOS/Android
+        run: cargo check -p larql-compute --target ${{ matrix.target }} --all-targets --all-features
+
+      - name: Clippy default features
+        run: cargo clippy -p larql-compute --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Clippy all features on Linux/Windows/ChromeOS/Android
+        run: cargo clippy -p larql-compute --target ${{ matrix.target }} --all-targets --all-features -- -D warnings
 
       - name: Unit tests
         run: cargo test -p larql-compute --target ${{ matrix.target }} --lib

--- a/.github/workflows/larql-core.yml
+++ b/.github/workflows/larql-core.yml
@@ -15,6 +15,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-core.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -23,9 +24,13 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-core.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -37,33 +42,19 @@ jobs:
         include:
           - name: ubuntu-24.04
             runner: ubuntu-24.04
-            platform: ubuntu
             target: x86_64-unknown-linux-gnu
 
           - name: chromeos-24.04
             runner: ubuntu-24.04
-            platform: chromeos
             target: x86_64-unknown-linux-gnu
 
           - name: windows-latest
             runner: windows-latest
-            platform: windows
             target: x86_64-pc-windows-msvc
 
           - name: macos-15-arm64
             runner: macos-15
-            platform: macos
             target: aarch64-apple-darwin
-
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
 
     permissions:
       contents: read
@@ -77,23 +68,97 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-core-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-core-
+
+      - name: Format check
+        run: cargo fmt -p larql-core -- --check
+
+      - name: Check default features
+        run: cargo check -p larql-core --target ${{ matrix.target }} --all-targets
+
+      - name: Check no default features
+        run: cargo check -p larql-core --target ${{ matrix.target }} --no-default-features --all-targets
+
+      - name: Check msgpack-only feature
+        run: cargo check -p larql-core --target ${{ matrix.target }} --no-default-features --features msgpack --all-targets
+
+      - name: Clippy default features
+        run: cargo clippy -p larql-core --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Unit + integration tests
+        run: cargo test -p larql-core --target ${{ matrix.target }}
+
+      - name: Feature matrix tests
+        run: |
+          cargo test -p larql-core --target ${{ matrix.target }} --no-default-features
+          cargo test -p larql-core --target ${{ matrix.target }} --no-default-features --features msgpack
+
+      - name: Test benchmarks
+        run: cargo test -p larql-core --target ${{ matrix.target }} --benches
+
+      - name: Run examples
+        run: |
+          cargo run -p larql-core --target ${{ matrix.target }} --example edge_demo
+          cargo run -p larql-core --target ${{ matrix.target }} --example graph_demo
+          cargo run -p larql-core --target ${{ matrix.target }} --example algorithm_demo
+          cargo run -p larql-core --target ${{ matrix.target }} --example filter_demo
+          cargo run -p larql-core --target ${{ matrix.target }} --example serialization_demo
+
+  test-android:
+    name: test · ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
       - name: Install Android NDK
-        if: matrix.platform == 'android'
         uses: nttld/setup-ndk@v1
         with:
           ndk-version: r27
           link-to-sdk: true
 
       - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
         run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
 
       - name: Add Android target
-        if: matrix.platform == 'android'
         run: rustup target add ${{ matrix.target }}
 
       - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        if: matrix.target == 'aarch64-linux-android'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
@@ -104,7 +169,7 @@ jobs:
           echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        if: matrix.target == 'armv7-linux-androideabi'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
@@ -115,13 +180,11 @@ jobs:
           echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,arm
 
       - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
         run: |
           echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
           echo "TMPDIR=/tmp" >> $GITHUB_ENV
@@ -160,21 +223,9 @@ jobs:
         run: cargo clippy -p larql-core --target ${{ matrix.target }} --all-targets -- -D warnings
 
       - name: Unit + integration tests
-        if: matrix.platform != 'android'
-        run: cargo test -p larql-core --target ${{ matrix.target }}
-
-      - name: Unit + integration tests (Android)
-        if: matrix.platform == 'android'
         run: cargo test -p larql-core --target ${{ matrix.target }} --lib --tests
 
       - name: Feature matrix tests
-        if: matrix.platform != 'android'
-        run: |
-          cargo test -p larql-core --target ${{ matrix.target }} --no-default-features
-          cargo test -p larql-core --target ${{ matrix.target }} --no-default-features --features msgpack
-
-      - name: Feature matrix tests (Android)
-        if: matrix.platform == 'android'
         run: |
           cargo test -p larql-core --target ${{ matrix.target }} --no-default-features --lib --tests
           cargo test -p larql-core --target ${{ matrix.target }} --no-default-features --features msgpack --lib --tests

--- a/.github/workflows/larql-experts.yml
+++ b/.github/workflows/larql-experts.yml
@@ -16,6 +16,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-experts.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -24,9 +25,13 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-experts.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -42,32 +47,71 @@ jobs:
         include:
           - name: ubuntu-24.04
             runner: ubuntu-24.04
-            platform: ubuntu
             target: x86_64-unknown-linux-gnu
 
           - name: chromeos-24.04
             runner: ubuntu-24.04
-            platform: chromeos
             target: x86_64-unknown-linux-gnu
 
           - name: windows-latest
             runner: windows-latest
-            platform: windows
             target: x86_64-pc-windows-msvc
 
           - name: macos-15-arm64
             runner: macos-15
-            platform: macos
             target: aarch64-apple-darwin
 
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ matrix.target }}-cargo-experts
+
+      - name: Format check (workspace)
+        working-directory: crates/larql-experts
+        run: cargo fmt --all -- --check
+
+      - name: Check workspace members
+        working-directory: crates/larql-experts
+        run: cargo check --target ${{ matrix.target }} --all --all-targets
+
+      - name: Clippy (workspace)
+        working-directory: crates/larql-experts
+        run: cargo clippy --target ${{ matrix.target }} --all --all-targets -- -D warnings
+
+      - name: Tests
+        working-directory: crates/larql-experts
+        run: cargo test --target ${{ matrix.target }} --all
+
+  test-android:
+    name: test · ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
             target: aarch64-linux-android
 
           - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
             target: armv7-linux-androideabi
 
     steps:
@@ -79,22 +123,19 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install Android NDK
-        if: matrix.platform == 'android'
         uses: nttld/setup-ndk@v1
         with:
           ndk-version: r27
           link-to-sdk: true
 
       - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
         run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
 
       - name: Add Android target
-        if: matrix.platform == 'android'
         run: rustup target add ${{ matrix.target }}
 
       - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        if: matrix.target == 'aarch64-linux-android'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
@@ -105,7 +146,7 @@ jobs:
           echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        if: matrix.target == 'armv7-linux-androideabi'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
@@ -116,13 +157,11 @@ jobs:
           echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,arm
 
       - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
         run: |
           echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
           echo "TMPDIR=/tmp" >> $GITHUB_ENV

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -25,6 +25,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-inference.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -37,9 +38,13 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-inference.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -73,16 +78,6 @@ jobs:
             platform: macos
             target: aarch64-apple-darwin
 
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
-
     steps:
       - uses: actions/checkout@v6
 
@@ -90,62 +85,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-
-      - name: Install Android NDK
-        if: matrix.platform == 'android'
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r27
-          link-to-sdk: true
-
-      - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
-        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
-
-      - name: Add Android target
-        if: matrix.platform == 'android'
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,arm
-
-      - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
-        run: |
-          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
-          echo "TMPDIR=/tmp" >> $GITHUB_ENV
-          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
-          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
-          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
-            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
-            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Install OpenBLAS (Linux/ChromeOS)
         if: matrix.platform == 'ubuntu' || matrix.platform == 'chromeos'
@@ -167,6 +106,112 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-inference-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-inference-
+
+      - name: Format check
+        run: cargo fmt -p larql-inference -- --check
+
+      - name: Check lib + tests + benches
+        run: cargo check -p larql-inference --target ${{ matrix.target }} --lib --tests --benches
+
+      - name: Clippy
+        run: cargo clippy -p larql-inference --target ${{ matrix.target }} --lib --tests --benches --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-inference --target ${{ matrix.target }}
+
+  test-android:
+    name: test - ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v5

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -25,6 +25,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-kv.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -41,12 +42,16 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-kv.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 env:
   LARQL_KV_COVERAGE_MIN: 85
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -80,16 +85,6 @@ jobs:
             platform: macos
             target: aarch64-apple-darwin
 
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
-
     steps:
       - uses: actions/checkout@v6
 
@@ -97,62 +92,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-
-      - name: Install Android NDK
-        if: matrix.platform == 'android'
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r27
-          link-to-sdk: true
-
-      - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
-        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
-
-      - name: Add Android target
-        if: matrix.platform == 'android'
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,arm
-
-      - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
-        run: |
-          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
-          echo "TMPDIR=/tmp" >> $GITHUB_ENV
-          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
-          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
-          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
-            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
-            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Install OpenBLAS (Linux/ChromeOS)
         if: matrix.platform == 'ubuntu' || matrix.platform == 'chromeos'
@@ -174,6 +113,118 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-kv-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-kv-
+
+      - name: Format check
+        run: cargo fmt -p larql-kv -- --check
+
+      - name: Check all targets
+        run: cargo check -p larql-kv --target ${{ matrix.target }} --all-targets
+
+      - name: Check examples
+        run: cargo check -p larql-kv --target ${{ matrix.target }} --examples
+
+      - name: Clippy
+        run: cargo clippy -p larql-kv --target ${{ matrix.target }} --all-targets --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-kv --target ${{ matrix.target }}
+
+      - name: Benchmark compile/tests
+        run: cargo test -p larql-kv --target ${{ matrix.target }} --benches
+
+  test-android:
+    name: test - ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v5

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -20,6 +20,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-lql.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -32,9 +33,13 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-lql.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -68,16 +73,6 @@ jobs:
             platform: macos
             target: aarch64-apple-darwin
 
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
-
     steps:
       - uses: actions/checkout@v6
 
@@ -85,62 +80,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-
-      - name: Install Android NDK
-        if: matrix.platform == 'android'
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r27
-          link-to-sdk: true
-
-      - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
-        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
-
-      - name: Add Android target
-        if: matrix.platform == 'android'
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,arm
-
-      - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
-        run: |
-          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
-          echo "TMPDIR=/tmp" >> $GITHUB_ENV
-          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
-          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
-          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
-            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
-            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Install OpenBLAS (Linux/ChromeOS)
         if: matrix.platform == 'ubuntu' || matrix.platform == 'chromeos'
@@ -162,6 +101,115 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-lql-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-lql-
+
+      - name: Format check
+        run: cargo fmt -p larql-lql -- --check
+
+      - name: Check all targets
+        run: cargo check -p larql-lql --target ${{ matrix.target }} --all-targets
+
+      - name: Clippy
+        run: cargo clippy -p larql-lql --target ${{ matrix.target }} --all-targets --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-lql --target ${{ matrix.target }}
+
+      - name: Benchmark compile/tests
+        run: cargo test -p larql-lql --target ${{ matrix.target }} --benches
+
+  test-android:
+    name: test - ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v5

--- a/.github/workflows/larql-models.yml
+++ b/.github/workflows/larql-models.yml
@@ -19,6 +19,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/larql-models.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -26,9 +27,13 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/larql-models.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -44,32 +49,76 @@ jobs:
         include:
           - name: ubuntu-24.04
             runner: ubuntu-24.04
-            platform: ubuntu
             target: x86_64-unknown-linux-gnu
 
           - name: chromeos-24.04
             runner: ubuntu-24.04
-            platform: chromeos
             target: x86_64-unknown-linux-gnu
 
           - name: windows-latest
             runner: windows-latest
-            platform: windows
             target: x86_64-pc-windows-msvc
 
           - name: macos-15-arm64
             runner: macos-15
-            platform: macos
             target: aarch64-apple-darwin
 
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-models-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-models-
+
+      - name: Format check
+        run: cargo fmt -p larql-models -- --check
+
+      - name: Check (all targets)
+        run: cargo check -p larql-models --target ${{ matrix.target }} --all-targets
+
+      - name: Clippy (warnings as errors)
+        run: cargo clippy -p larql-models --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test -p larql-models --target ${{ matrix.target }}
+
+      - name: Test benches
+        run: cargo test -p larql-models --target ${{ matrix.target }} --benches
+
+  test-android:
+    name: test · ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
             target: aarch64-linux-android
 
           - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
             target: armv7-linux-androideabi
 
     steps:
@@ -81,22 +130,19 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install Android NDK
-        if: matrix.platform == 'android'
         uses: nttld/setup-ndk@v1
         with:
           ndk-version: r27
           link-to-sdk: true
 
       - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
         run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
 
       - name: Add Android target
-        if: matrix.platform == 'android'
         run: rustup target add ${{ matrix.target }}
 
       - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        if: matrix.target == 'aarch64-linux-android'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
@@ -107,7 +153,7 @@ jobs:
           echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        if: matrix.target == 'armv7-linux-androideabi'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
@@ -118,13 +164,11 @@ jobs:
           echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,arm
 
       - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
         run: |
           echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
           echo "TMPDIR=/tmp" >> $GITHUB_ENV
@@ -156,12 +200,7 @@ jobs:
       - name: Clippy (warnings as errors)
         run: cargo clippy -p larql-models --target ${{ matrix.target }} --all-targets -- -D warnings
 
-      - name: Test
-        if: matrix.platform != 'android'
-        run: cargo test -p larql-models --target ${{ matrix.target }}
-
       - name: Test (Android)
-        if: matrix.platform == 'android'
         run: cargo test -p larql-models --target ${{ matrix.target }} --lib --tests
 
       - name: Test benches

--- a/.github/workflows/larql-router.yml
+++ b/.github/workflows/larql-router.yml
@@ -16,6 +16,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-router.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -25,9 +26,13 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-router.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -61,16 +66,6 @@ jobs:
             platform: macos
             target: aarch64-apple-darwin
 
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
-
     steps:
       - uses: actions/checkout@v6
 
@@ -85,23 +80,85 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ matrix.target }}-cargo-router
+          cache-directories: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+
+      - name: Format check
+        run: cargo fmt -p larql-router -p larql-router-protocol -- --check
+
+      - name: Check lib + tests + benches
+        run: cargo check -p larql-router --target ${{ matrix.target }} --lib --tests --benches
+
+      - name: Check protocol
+        run: cargo check -p larql-router-protocol --target ${{ matrix.target }} --lib
+
+      - name: Clippy (router)
+        run: cargo clippy -p larql-router --target ${{ matrix.target }} --lib --tests --benches --no-deps -- -D warnings
+
+      - name: Clippy (protocol)
+        run: cargo clippy -p larql-router-protocol --target ${{ matrix.target }} --lib --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-router --target ${{ matrix.target }}
+
+      - name: Tests (protocol)
+        run: cargo test -p larql-router-protocol --target ${{ matrix.target }}
+
+      - name: Benchmark compile/tests
+        run: cargo test -p larql-router --target ${{ matrix.target }} --benches
+
+  test-android:
+    name: test · ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
       - name: Install Android NDK
-        if: matrix.platform == 'android'
         uses: nttld/setup-ndk@v1
         with:
           ndk-version: r27
           link-to-sdk: true
 
       - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
         run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
 
       - name: Add Android target
-        if: matrix.platform == 'android'
         run: rustup target add ${{ matrix.target }}
 
       - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        if: matrix.target == 'aarch64-linux-android'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
@@ -112,7 +169,7 @@ jobs:
           echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        if: matrix.target == 'armv7-linux-androideabi'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
@@ -123,13 +180,11 @@ jobs:
           echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,arm
 
       - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
         run: |
           echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
           echo "TMPDIR=/tmp" >> $GITHUB_ENV

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -24,6 +24,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-server.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -36,6 +37,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-server.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 env:
@@ -45,6 +47,9 @@ env:
   LARQL_SERVER_COVERAGE_MIN: 65
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -78,16 +83,6 @@ jobs:
             platform: macos
             target: aarch64-apple-darwin
 
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
-
     steps:
       - uses: actions/checkout@v6
 
@@ -95,62 +90,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-
-      - name: Install Android NDK
-        if: matrix.platform == 'android'
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r27
-          link-to-sdk: true
-
-      - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
-        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
-
-      - name: Add Android target
-        if: matrix.platform == 'android'
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,arm
-
-      - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
-        run: |
-          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
-          echo "TMPDIR=/tmp" >> $GITHUB_ENV
-          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
-          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
-          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
-            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
-            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Install OpenBLAS (Linux/ChromeOS)
         if: matrix.platform == 'ubuntu' || matrix.platform == 'chromeos'
@@ -172,6 +111,112 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-server-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-server-
+
+      - name: Format check
+        run: cargo fmt -p larql-server -- --check
+
+      - name: Check lib + bins + tests
+        run: cargo check -p larql-server --target ${{ matrix.target }} --lib --bins --tests
+
+      - name: Clippy
+        run: cargo clippy -p larql-server --target ${{ matrix.target }} --lib --bins --tests --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-server --target ${{ matrix.target }}
+
+  test-android:
+    name: test - ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v5

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -21,6 +21,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-vindex.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -31,12 +32,16 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/larql-vindex.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 env:
   LARQL_VINDEX_COVERAGE_MIN: 71
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -70,16 +75,6 @@ jobs:
             platform: macos
             target: aarch64-apple-darwin
 
-          - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
-            target: aarch64-linux-android
-
-          - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
-            target: armv7-linux-androideabi
-
     steps:
       - uses: actions/checkout@v6
 
@@ -87,62 +82,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-
-      - name: Install Android NDK
-        if: matrix.platform == 'android'
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r27
-          link-to-sdk: true
-
-      - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
-        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
-
-      - name: Add Android target
-        if: matrix.platform == 'android'
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
-          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
-          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
-        run: |
-          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
-          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
-          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
-
-      - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,arm
-
-      - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
-        run: |
-          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
-          echo "TMPDIR=/tmp" >> $GITHUB_ENV
-          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
-          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
-          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
-            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
-            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Install OpenBLAS (Linux/ChromeOS)
         if: matrix.platform == 'ubuntu' || matrix.platform == 'chromeos'
@@ -158,6 +97,118 @@ jobs:
           if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
           "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
           & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-vindex-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-vindex-
+
+      - name: Format check
+        run: cargo fmt -p larql-vindex -- --check
+
+      - name: Check all targets
+        run: cargo check -p larql-vindex --target ${{ matrix.target }} --all-targets
+
+      - name: Check examples
+        run: cargo check -p larql-vindex --target ${{ matrix.target }} --examples
+
+      - name: Clippy
+        run: cargo clippy -p larql-vindex --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-vindex --target ${{ matrix.target }}
+
+      - name: Benchmark compile/tests
+        run: cargo test -p larql-vindex --target ${{ matrix.target }} --benches
+
+  test-android:
+    name: test - ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: android-aarch64
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
 
       - name: Cache cargo registry + build artefacts
         uses: actions/cache@v5

--- a/.github/workflows/model-compute.yml
+++ b/.github/workflows/model-compute.yml
@@ -4,6 +4,10 @@
 # and macOS. The WASM backend uses wasmi (pure-Rust interpreter, runs on all
 # targets including arm32). The optional wasm-jit feature (wasmtime) only runs
 # on 64-bit platforms.
+#
+# Android targets are gated on wasm-gate.yml:
+#   armv7  — needs wasmi gate (Cranelift has no arm32 backend)
+#   aarch64 — needs wasmi + wasmtime gate (Cranelift supports aarch64)
 
 name: model-compute
 
@@ -16,6 +20,7 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/model-compute.yml'
+      - '.github/workflows/wasm-gate.yml'
   pull_request:
     branches: [main, ci/workflows-complete]
     paths:
@@ -24,9 +29,13 @@ on:
       - 'Cargo.lock'
       - 'Makefile'
       - '.github/workflows/model-compute.yml'
+      - '.github/workflows/wasm-gate.yml'
   workflow_dispatch: {}
 
 jobs:
+  wasm-gate:
+    uses: ./.github/workflows/wasm-gate.yml
+
   test:
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -42,32 +51,82 @@ jobs:
         include:
           - name: ubuntu-24.04
             runner: ubuntu-24.04
-            platform: ubuntu
             target: x86_64-unknown-linux-gnu
 
           - name: chromeos-24.04
             runner: ubuntu-24.04
-            platform: chromeos
             target: x86_64-unknown-linux-gnu
 
           - name: windows-latest
             runner: windows-latest
-            platform: windows
             target: x86_64-pc-windows-msvc
 
           - name: macos-15-arm64
             runner: macos-15
-            platform: macos
             target: aarch64-apple-darwin
 
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ matrix.target }}-cargo-model-compute
+
+      - name: Format check
+        run: cargo fmt -p model-compute -- --check
+
+      - name: Check (default features)
+        run: cargo check -p model-compute --target ${{ matrix.target }} --all-targets
+
+      - name: Check (native feature)
+        run: cargo check -p model-compute --target ${{ matrix.target }} --no-default-features --features native --all-targets
+
+      - name: Check (wasm feature)
+        run: cargo check -p model-compute --target ${{ matrix.target }} --no-default-features --features wasm --all-targets
+
+      - name: Clippy
+        run: cargo clippy -p model-compute --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Tests (default features)
+        run: cargo test -p model-compute --target ${{ matrix.target }}
+
+      - name: Tests (native feature)
+        run: cargo test -p model-compute --target ${{ matrix.target }} --no-default-features --features native
+
+      - name: Tests (wasm feature)
+        run: cargo test -p model-compute --target ${{ matrix.target }} --no-default-features --features wasm
+
+      - name: Benchmark compile/tests
+        run: cargo test -p model-compute --target ${{ matrix.target }} --benches
+
+  test-android:
+    name: test · ${{ matrix.name }}
+    needs: [wasm-gate]
+    if: |
+      always() &&
+      needs.wasm-gate.outputs.wasmi == 'success' &&
+      (matrix.target != 'aarch64-linux-android' || needs.wasm-gate.outputs.wasmtime == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - name: android-aarch64
-            runner: ubuntu-24.04
-            platform: android
             target: aarch64-linux-android
 
           - name: android-armv7
-            runner: ubuntu-24.04
-            platform: android
             target: armv7-linux-androideabi
 
     steps:
@@ -79,22 +138,19 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install Android NDK
-        if: matrix.platform == 'android'
         uses: nttld/setup-ndk@v1
         with:
           ndk-version: r27
           link-to-sdk: true
 
       - name: Add Android NDK to PATH
-        if: matrix.platform == 'android'
         run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
 
       - name: Add Android target
-        if: matrix.platform == 'android'
         run: rustup target add ${{ matrix.target }}
 
       - name: Set Android NDK compiler vars (aarch64)
-        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        if: matrix.target == 'aarch64-linux-android'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
@@ -105,7 +161,7 @@ jobs:
           echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set Android NDK compiler vars (armv7)
-        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        if: matrix.target == 'armv7-linux-androideabi'
         run: |
           NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
           echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
@@ -116,13 +172,11 @@ jobs:
           echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
 
       - name: Set up QEMU for Android emulation
-        if: matrix.platform == 'android'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,arm
 
       - name: Enable static CRT and redirect libc++_shared for Android
-        if: matrix.platform == 'android'
         run: |
           echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
           echo "TMPDIR=/tmp" >> $GITHUB_ENV
@@ -155,27 +209,12 @@ jobs:
         run: cargo clippy -p model-compute --target ${{ matrix.target }} --all-targets -- -D warnings
 
       - name: Tests (default features)
-        if: matrix.platform != 'android'
-        run: cargo test -p model-compute --target ${{ matrix.target }}
-
-      - name: Tests (default features, Android)
-        if: matrix.platform == 'android'
         run: cargo test -p model-compute --target ${{ matrix.target }} --lib --tests
 
       - name: Tests (native feature)
-        if: matrix.platform != 'android'
-        run: cargo test -p model-compute --target ${{ matrix.target }} --no-default-features --features native
-
-      - name: Tests (native feature, Android)
-        if: matrix.platform == 'android'
         run: cargo test -p model-compute --target ${{ matrix.target }} --no-default-features --features native --lib --tests
 
       - name: Tests (wasm feature)
-        if: matrix.platform != 'android'
-        run: cargo test -p model-compute --target ${{ matrix.target }} --no-default-features --features wasm
-
-      - name: Tests (wasm feature, Android)
-        if: matrix.platform == 'android'
         run: cargo test -p model-compute --target ${{ matrix.target }} --no-default-features --features wasm --lib --tests
 
       - name: Benchmark compile/tests

--- a/.github/workflows/wasm-gate.yml
+++ b/.github/workflows/wasm-gate.yml
@@ -1,0 +1,90 @@
+# Reusable WASM backend gate.
+#
+# Called by every workflow that carries Android targets. Runs the wasmi and
+# wasmtime backend checks on the host before any cross-compiled Android build
+# is attempted, so a broken WASM backend fails fast rather than burning NDK
+# compile time across the whole matrix.
+#
+# Outputs
+#   wasmi    — result of the wasmi job   ('success' | 'failure' | 'skipped' | 'cancelled')
+#   wasmtime — result of the wasmtime job
+#
+# Callers gate Android targets like this:
+#   armv7:   if: always() && needs.wasm-gate.outputs.wasmi == 'success'
+#   aarch64: if: always() && needs.wasm-gate.outputs.wasmi == 'success'
+#                         && needs.wasm-gate.outputs.wasmtime == 'success'
+#
+# Why the split:
+#   wasmi   — pure-Rust interpreter, works on all targets including arm32.
+#             Active runtime backend for all Android builds.
+#   wasmtime — Cranelift JIT. Cranelift has no arm32 code-generator, so
+#              armv7 can never use it; aarch64 can. The wasmtime gate
+#              verifies the Cranelift aarch64 path compiles correctly even
+#              when wasmi is the active runtime.
+
+name: wasm-gate
+
+on:
+  workflow_call:
+    outputs:
+      wasmi:
+        description: "Result of the wasmi roundtrip gate"
+        value: ${{ jobs.wasmi.result }}
+      wasmtime:
+        description: "Result of the wasmtime compile gate"
+        value: ${{ jobs.wasmtime.result }}
+
+jobs:
+  wasmi:
+    name: wasm gate · wasmi
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ubuntu-x86_64-wasm-gate-wasmi-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ubuntu-x86_64-wasm-gate-wasmi-
+
+      - name: Compile (wasm feature)
+        run: cargo build -p model-compute --no-default-features --features wasm
+
+      - name: Test wasm_roundtrip
+        run: cargo test -p model-compute --no-default-features --features wasm --tests
+
+  wasmtime:
+    name: wasm gate · wasmtime (aarch64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ubuntu-x86_64-wasm-gate-wasmtime-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ubuntu-x86_64-wasm-gate-wasmtime-
+
+      - name: Compile (wasm-jit feature)
+        run: cargo build -p model-compute --no-default-features --features wasm-jit
+
+      - name: Test (wasm-jit feature)
+        run: cargo test -p model-compute --no-default-features --features wasm-jit

--- a/crates/model-compute/src/wasm/runtime.rs
+++ b/crates/model-compute/src/wasm/runtime.rs
@@ -60,3 +60,22 @@ impl SolverRuntime {
         Session::new(&self.engine, module, self.limits)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SolverRuntime;
+
+    // Verify that the engine produced by SolverRuntime has fuel metering
+    // enabled. set_fuel() errors immediately if Config::consume_fuel(true)
+    // was not set; catching that here gives a single clear failure point
+    // instead of cryptic panics spread across every wasm_roundtrip test.
+    #[test]
+    fn engine_fuel_metering_is_enabled() {
+        struct Dummy;
+        let runtime = SolverRuntime::new().expect("runtime");
+        let mut store = wasmi::Store::new(runtime.engine(), Dummy);
+        store
+            .set_fuel(1_000)
+            .expect("Engine must have fuel metering enabled (Config::consume_fuel(true))");
+    }
+}

--- a/crates/model-compute/src/wasm/runtime.rs
+++ b/crates/model-compute/src/wasm/runtime.rs
@@ -2,7 +2,7 @@
 //! `wasmi::Engine`; each `Session::new` creates a fresh `Store` with
 //! the configured limits so calls are isolated.
 
-use wasmi::{Engine, Module};
+use wasmi::{Config, Engine, Module};
 
 use super::error::SolverError;
 use super::session::Session;
@@ -35,7 +35,9 @@ impl SolverRuntime {
     }
 
     pub fn with_limits(limits: SolverLimits) -> Result<Self, SolverError> {
-        let engine = Engine::default();
+        let mut config = Config::default();
+        config.consume_fuel(true);
+        let engine = Engine::new(&config);
         Ok(Self { engine, limits })
     }
 


### PR DESCRIPTION
## Summary

- Introduces **`wasm-gate.yml`** — a reusable workflow with two parallel host-side gate jobs:
  - `wasmi` — compiles and runs `wasm_roundtrip` tests (`--features wasm`). The pure-Rust interpreter is the only viable backend for arm32; Cranelift has no arm32 code-generator.
  - `wasmtime` — compiles `model-compute --features wasm-jit`. Cranelift supports aarch64 so the JIT path must stay compilable even though wasmi is the active runtime.
- All 15 workflows that carry Android targets now call `wasm-gate` and split Android into a dedicated `test-android` / `bench-android` job with explicit per-target conditions:
  - `armv7`: skipped unless `wasmi == 'success'`
  - `aarch64`: skipped unless `wasmi == 'success' && wasmtime == 'success'`
- Non-Android matrix entries remain in the original `test` job with **no added dependency** — they run in parallel with the gate and pay no latency penalty.
- Adds `engine_fuel_metering_is_enabled` unit test to `runtime.rs` so a missing `Config::consume_fuel(true)` fails immediately at the engine level rather than producing cryptic panics spread across every `wasm_roundtrip` test.

## Motivation

PR #47 showed all 8 `wasm_roundtrip` tests failing across every OS (Android aarch64/armv7, macOS, Ubuntu, ChromeOS, Windows) with `Engine("fuel metering is disabled")`. Because the wasm and Android tests ran in the same undifferentiated matrix job, the failures looked like platform-specific flakiness rather than a single broken engine config. This PR makes the wasm backends a first-class gate so that failure is immediately visible and Android builds are not attempted when the wasm foundation is known-broken.

## Depends on

PR #48 (`fix/wasmi-fuel-metering`) — cherry-picked into this branch. The `engine_fuel_metering_is_enabled` test verifies the fix remains in place.

## Test plan

- [ ] `wasm gate · wasmi` — `wasm_roundtrip` 8/8 pass
- [ ] `wasm gate · wasmtime (aarch64)` — `wasm-jit` feature compiles and tests run
- [ ] `test-android · android-armv7` — skips if wasmi gate fails, runs if it passes
- [ ] `test-android · android-aarch64` — skips if either gate fails, runs if both pass
- [ ] Non-Android matrix entries start immediately without waiting for the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)