### PR TITLE
fix: gate 370K token test to 64-bit, document 32-bit KV cache ceiling

### DIFF
--- a/.github/workflows/bench-regress.yml
+++ b/.github/workflows/bench-regress.yml
@@ -164,10 +164,12 @@ jobs:
 
       - name: Save baseline (main only)
         if: github.ref == 'refs/heads/main'
+        shell: bash
         run: make bench-save
 
       - name: Check vs baseline (PRs + manual)
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        shell: bash
         run: |
           # Cold cache → bench-check prints "no baseline found" and
           # exits 2. Treat as neutral: the first PR after CI is stood

--- a/.github/workflows/kv-cache-benchmark.yml
+++ b/.github/workflows/kv-cache-benchmark.yml
@@ -145,7 +145,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-boundary.yml
+++ b/.github/workflows/larql-boundary.yml
@@ -131,7 +131,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -146,7 +146,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -194,8 +194,13 @@ jobs:
         if: matrix.platform == 'macos'
         run: cargo check -p larql-cli --target ${{ matrix.target }} --bins --tests
 
-      - name: Tests (CPU only) on Linux/Windows/ChromeOS/Android
+      - name: Tests (CPU only) on Linux/Windows/ChromeOS
+        if: matrix.platform != 'android' && matrix.platform != 'macos'
         run: cargo test -p larql-cli --target ${{ matrix.target }} --no-default-features
+
+      - name: Tests (CPU only, Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-cli --target ${{ matrix.target }} --no-default-features --lib --tests
 
       - name: Tests (default features) on macOS
         if: matrix.platform == 'macos'

--- a/.github/workflows/larql-compute.yml
+++ b/.github/workflows/larql-compute.yml
@@ -133,7 +133,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-compute.yml
+++ b/.github/workflows/larql-compute.yml
@@ -193,10 +193,17 @@ jobs:
         run: cargo clippy -p larql-compute --target ${{ matrix.target }} --all-targets --features metal -- -D warnings
 
       - name: Unit tests
+        if: matrix.platform != 'android'
         run: cargo test -p larql-compute --target ${{ matrix.target }} --lib
 
       - name: Backend contract tests
+        if: matrix.platform != 'android'
         run: cargo test -p larql-compute --target ${{ matrix.target }} --test test_backend_matmul_quant
 
       - name: Pipeline and MoE contract tests
+        if: matrix.platform != 'android'
         run: cargo test -p larql-compute --target ${{ matrix.target }} --test test_pipeline_and_moe
+
+      - name: Tests (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-compute --target ${{ matrix.target }} --lib --tests

--- a/.github/workflows/larql-core.yml
+++ b/.github/workflows/larql-core.yml
@@ -128,7 +128,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-experts.yml
+++ b/.github/workflows/larql-experts.yml
@@ -129,7 +129,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-experts.yml
+++ b/.github/workflows/larql-experts.yml
@@ -152,8 +152,14 @@ jobs:
         run: cargo clippy --target ${{ matrix.target }} --all --all-targets -- -D warnings
 
       - name: Tests
+        if: matrix.platform != 'android'
         working-directory: crates/larql-experts
         run: cargo test --target ${{ matrix.target }} --all
+
+      - name: Tests (Android)
+        if: matrix.platform == 'android'
+        working-directory: crates/larql-experts
+        run: cargo test --target ${{ matrix.target }} --all --lib --tests
 
   coverage:
     name: coverage · ubuntu

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -142,7 +142,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -189,7 +189,12 @@ jobs:
         run: cargo clippy -p larql-inference --target ${{ matrix.target }} --lib --tests --benches --no-deps -- -D warnings
 
       - name: Tests
+        if: matrix.platform != 'android'
         run: cargo test -p larql-inference --target ${{ matrix.target }}
+
+      - name: Tests (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-inference --target ${{ matrix.target }} --lib --tests
 
   coverage:
     name: coverage - ubuntu

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -199,7 +199,12 @@ jobs:
         run: cargo clippy -p larql-kv --target ${{ matrix.target }} --all-targets --no-deps -- -D warnings
 
       - name: Tests
+        if: matrix.platform != 'android'
         run: cargo test -p larql-kv --target ${{ matrix.target }}
+
+      - name: Tests (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-kv --target ${{ matrix.target }} --lib --tests
 
       - name: Benchmark compile/tests
         run: cargo test -p larql-kv --target ${{ matrix.target }} --benches

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -149,7 +149,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -184,7 +184,12 @@ jobs:
         run: cargo clippy -p larql-lql --target ${{ matrix.target }} --all-targets --no-deps -- -D warnings
 
       - name: Tests
+        if: matrix.platform != 'android'
         run: cargo test -p larql-lql --target ${{ matrix.target }}
+
+      - name: Tests (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-lql --target ${{ matrix.target }} --lib --tests
 
       - name: Benchmark compile/tests
         run: cargo test -p larql-lql --target ${{ matrix.target }} --benches

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -137,7 +137,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-models.yml
+++ b/.github/workflows/larql-models.yml
@@ -131,7 +131,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-router.yml
+++ b/.github/workflows/larql-router.yml
@@ -166,10 +166,20 @@ jobs:
         run: cargo clippy -p larql-router-protocol --target ${{ matrix.target }} --lib --no-deps -- -D warnings
 
       - name: Tests
+        if: matrix.platform != 'android'
         run: cargo test -p larql-router --target ${{ matrix.target }}
 
+      - name: Tests (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-router --target ${{ matrix.target }} --lib --tests
+
       - name: Tests (protocol)
+        if: matrix.platform != 'android'
         run: cargo test -p larql-router-protocol --target ${{ matrix.target }}
+
+      - name: Tests (protocol, Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-router-protocol --target ${{ matrix.target }} --lib --tests
 
       - name: Benchmark compile/tests
         run: cargo test -p larql-router --target ${{ matrix.target }} --benches

--- a/.github/workflows/larql-router.yml
+++ b/.github/workflows/larql-router.yml
@@ -136,7 +136,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -147,7 +147,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -194,7 +194,12 @@ jobs:
         run: cargo clippy -p larql-server --target ${{ matrix.target }} --lib --bins --tests --no-deps -- -D warnings
 
       - name: Tests
+        if: matrix.platform != 'android'
         run: cargo test -p larql-server --target ${{ matrix.target }}
+
+      - name: Tests (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-server --target ${{ matrix.target }} --lib --tests
 
   coverage:
     name: coverage - ubuntu

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -183,7 +183,12 @@ jobs:
         run: cargo clippy -p larql-vindex --target ${{ matrix.target }} --all-targets -- -D warnings
 
       - name: Tests
+        if: matrix.platform != 'android'
         run: cargo test -p larql-vindex --target ${{ matrix.target }}
+
+      - name: Tests (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-vindex --target ${{ matrix.target }} --lib --tests
 
       - name: Benchmark compile/tests
         run: cargo test -p larql-vindex --target ${{ matrix.target }} --benches

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -139,7 +139,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.github/workflows/model-compute.yml
+++ b/.github/workflows/model-compute.yml
@@ -129,7 +129,7 @@ jobs:
           NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
           LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
-          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${LIBUNWIND_AARCH64})" \
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
             > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
           echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
             > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 target/
 coverage/
 **/*.rs.bk
+*.rlib
 .cargo/
 
 # Python / maturin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Add modular Nix flake with demos, OCI containers, and model catalog
 - Cap down_meta feature count via LARQL_SUMMARY_FEATURES_PER_EXPERT
 - Cross-platform CI/CD foundation (Phase 1)
+- Enable aarch64-linux-android cross-compilation
 - Implement Android (Phase 2b) cross-platform CI/CD support
 - Implement ChromeOS (Phase 2a) cross-platform CI/CD support
 - Implement macOS (Phase 3) cross-platform CI/CD support
@@ -28,42 +29,79 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Per-expert dequantization for DeepSeek-V4 layout
 - Per-expert top-K SVD summary tier for many-experts MoE
 - Support F8_E4M3 / F8_E5M2 / F8_E8M0 / I8 dtypes
+- Wasmi migration, arm32 atomics, REUSE compliance
+
+### Changed
+
+- Move Python testing to per-crate workflow, fix cargo-deny wildcards
 
 ### Fixed
 
 - Linux support — conditional BLAS and Q4 scalar fallback
 - Linux/WSL2 support + temperature parameter
 - MSRV truth, OpenBLAS, version-preflight, changelog
+- Add -C link-arg=-static to eliminate Android PT_INTERP
 - Add Android NDK setup to cross-platform-build workflow
+- Add arithmetic overflow fix to changelog
+- Add libc++abi.a to aarch64 Android static link group
+- Add libc++abi.a to aarch64 GROUP in all Android workflows
 - Address code review feedback on CI scripts
 - Address review feedback and CI environment realities
+- Address second-wave windows-fix CI failures
 - Align license enforcement with audited multi-license tree
 - Allow pulling vindexes from HF model repos
+- Apply rustfmt and fix clippy::unnecessary_sort_by
 - Bump pinned versions and drop fmt CI duplication
 - Bump toolchain to 1.88 and unpin scanner-tool versions
 - Configure Android cross-compilation with linker and PATH setup
+- Configure BLAS for Android in larql-inference and larql-kv
+- Configure larql-compute BLAS for Android cross-compilation
 - Correct CHANGELOG.md structure and formatting
 - Correct cog.toml schema, workflow flags, and review feedback
 - Correct tool release URLs and pre-commit hook wiring
+- Drop --no-fail-fast from cargo build; regenerate CHANGELOG
 - Drop bogus `hidden_size % head_dim == 0` invariant
 - Drop §4(b) per-file re-walk; rely on REUSE.toml manifest
 - Error on missing config.json / required topology fields (#22)
+- Exclude doc-tests on Android and set TMPDIR for all workflows
+- Fix Android QEMU runner name and libc++_shared static linking across all workflows
+- Gate 370K token test to 64-bit, document 32-bit KV cache ceiling
+- Gate UDS listener bind behind cfg(unix)
+- Gate UDS shard transport behind cfg(unix)
+- Gate forward_raw_logits imports alongside their sole user
 - Gate metal-only code behind target_os = "macos" (#48)
-- Gate metal-only code behind target_os = "macos" so the workspace builds on Linux
+- Gate orphan items in vindex test + cover second lql bench
+- Gate sdot on dotprod feature and add QEMU emulation for tests
+- Gate trace_final_residual_matches_raw_forward_logits
 - Narrow `cog check` PR range to first-parent + no-merges
+- Pin evalexpr to v11.3.1 (MIT) to avoid AGPL-3.0 at v12
+- Prevent arithmetic overflow in lm_head vocab calculation on 32-bit platforms
 - Pull Q4K vindex weight artifacts
+- Remove BLIS dependency due to yanked transitive versions
+- Remove duplicate timeout-minutes in larql-vindex coverage job
+- Remove explicit QEMU runner, rely on binfmt_misc transparent execution
+- Remove extra-platforms, switch reqwest to rustls-tls, upgrade wasmtime, fix fmt
 - Restore cfg-gated imports removed by PR #48
 - Restore deleted extract/build.rs and align stale test/example initializers
 - Restore extract/build.rs and align stale test/example initializers (#46)
-- Restore extract/build.rs lost in d3a8bc6 + reconcile API drift
 - Revert manual CHANGELOG edit; let git-cliff regenerate from commits
 - Scope cron to advisory scanners and harden SARIF upload
 - Silence unused cfg param in validate_one_layer
+- Six platform-specific test/build failures on windows-latest
+- Skip BLAS entirely for Android cross-compilation
+- Skip CodeQL suggestion commits in cog check
+- Skip default features check for Android in larql-compute
+- Skip default features check for Android in larql-core
 - Unblock CI tests broken by e67b4f3
 - Unblock cargo, bump wasmtime past CVEs, require MSRV
+- Update runtime to use Engine with Config
+- Use BLIS (pure-Rust BLAS) for Android cross-compilation
+- Use blas-src netlib feature for Android BLAS
 - Use checked_div for head_dim derivation
 - Use checked_div for head_dim derivation
 - Use checked_div for head_dim derivation (#50)
 - Use matmul_transb for MoE expert scoring
+- Use netlib (pure-Rust BLAS) for Android builds
+- Use versioned NDK r27 linker/ar names for Android targets
 
 

--- a/crates/kv-cache-benchmark/tests/test_standard.rs
+++ b/crates/kv-cache-benchmark/tests/test_standard.rs
@@ -62,7 +62,7 @@ fn test_standard_kv_memory_formula() {
     #[cfg(target_pointer_width = "64")]
     {
         let mem_370k = StandardKv.memory_bytes(&config, 370_000);
-        let expected_370k = 370_000 * 34 * 2 * 2 * 256 * 2;
+        let expected_370k = 370_000 * config.kv_bytes_per_token();
         assert_eq!(mem_370k, expected_370k);
         // 370K × 34L × 2(KV) × 2 heads × 256 dim × 2 bytes = ~25.8 GB
         assert!(mem_370k > 20_000_000_000);
@@ -74,12 +74,12 @@ fn test_standard_kv_memory_formula() {
     // Verify the boundary: max_tokens fits, max_tokens+1 wraps.
     #[cfg(target_pointer_width = "32")]
     {
-        let bytes_per_token: usize = 34 * 2 * 2 * 256 * 2; // 69_632
+        let bytes_per_token = config.kv_bytes_per_token(); // 69_632
         let max_tokens = usize::MAX / bytes_per_token; // 61_681
         assert_eq!(max_tokens, 61_681);
         assert!((max_tokens + 1).checked_mul(bytes_per_token).is_none());
         let mem_max = StandardKv.memory_bytes(&config, max_tokens);
-        assert!(mem_max <= usize::MAX);
+        assert_eq!(mem_max, max_tokens * bytes_per_token);
     }
 }
 

--- a/crates/kv-cache-benchmark/tests/test_standard.rs
+++ b/crates/kv-cache-benchmark/tests/test_standard.rs
@@ -57,13 +57,30 @@ fn test_standard_kv_memory_formula() {
     let expected = 4096 * 34 * 2 * 2 * 256 * 2;
     assert_eq!(mem, expected);
 
-    // 370K tokens
-    let mem_370k = StandardKv.memory_bytes(&config, 370_000);
-    let expected_370k = 370_000 * 34 * 2 * 2 * 256 * 2;
-    assert_eq!(mem_370k, expected_370k);
-    // 370K × 34L × 2(KV) × 2 heads × 256 dim × 2 bytes = ~25.8 GB
-    assert!(mem_370k > 20_000_000_000);
-    assert!(mem_370k < 30_000_000_000);
+    // 370K tokens: ~25.8 GB — only valid on 64-bit (x86_64, aarch64).
+    // On 32-bit (ARMv7, WASM), usize::MAX ≈ 4.3 GB so 370K tokens overflows.
+    #[cfg(target_pointer_width = "64")]
+    {
+        let mem_370k = StandardKv.memory_bytes(&config, 370_000);
+        let expected_370k = 370_000 * 34 * 2 * 2 * 256 * 2;
+        assert_eq!(mem_370k, expected_370k);
+        // 370K × 34L × 2(KV) × 2 heads × 256 dim × 2 bytes = ~25.8 GB
+        assert!(mem_370k > 20_000_000_000);
+        assert!(mem_370k < 30_000_000_000);
+    }
+
+    // On 32-bit targets (ARMv7, WASM in-browser), the maximum representable
+    // KV cache without usize overflow is 61_681 tokens (~4.29 GB).
+    // Verify the boundary: max_tokens fits, max_tokens+1 wraps.
+    #[cfg(target_pointer_width = "32")]
+    {
+        let bytes_per_token: usize = 34 * 2 * 2 * 256 * 2; // 69_632
+        let max_tokens = usize::MAX / bytes_per_token; // 61_681
+        assert_eq!(max_tokens, 61_681);
+        assert!((max_tokens + 1).checked_mul(bytes_per_token).is_none());
+        let mem_max = StandardKv.memory_bytes(&config, max_tokens);
+        assert!(mem_max <= usize::MAX);
+    }
 }
 
 #[test]

--- a/crates/larql-router-protocol/proto/buf.yaml
+++ b/crates/larql-router-protocol/proto/buf.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+# SPDX-License-Identifier: Apache-2.0
+version: v2
+lint:
+  use:
+    - DEFAULT

--- a/crates/larql-server/proto/buf.yaml
+++ b/crates/larql-server/proto/buf.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+# SPDX-License-Identifier: Apache-2.0
+version: v2
+lint:
+  use:
+    - DEFAULT

--- a/crates/model-compute/src/wasm/runtime.rs
+++ b/crates/model-compute/src/wasm/runtime.rs
@@ -2,7 +2,7 @@
 //! `wasmi::Engine`; each `Session::new` creates a fresh `Store` with
 //! the configured limits so calls are isolated.
 
-use wasmi::{Engine, Module};
+use wasmi::{Config, Engine, Module};
 
 use super::error::SolverError;
 use super::session::Session;
@@ -35,7 +35,9 @@ impl SolverRuntime {
     }
 
     pub fn with_limits(limits: SolverLimits) -> Result<Self, SolverError> {
-        let engine = Engine::default();
+        let mut config = Config::default();
+        config.consume_fuel(true);
+        let engine = Engine::new(&config);
         Ok(Self { engine, limits })
     }
 

--- a/scripts/bench-regress.sh
+++ b/scripts/bench-regress.sh
@@ -18,7 +18,12 @@ set -euo pipefail
 
 BASELINE_NAME="${BASELINE_NAME:-main}"
 THRESHOLD="${THRESHOLD:-0.10}"   # 10 % slowdown = regression
-FEATURES="${FEATURES:---features metal}"
+# metal is an Apple-only dependency (dep:metal, dep:objc); only enable it on macOS.
+if [[ "$(uname)" == "Darwin" ]]; then
+    FEATURES="${FEATURES:---features metal}"
+else
+    FEATURES="${FEATURES:-}"
+fi
 # Benches to gate on. Override with `BENCHES="quant_matvec"` to focus.
 BENCHES="${BENCHES:-quant_matvec matmul linalg}"
 


### PR DESCRIPTION
## Summary

- Gates the 370K-token memory assertions in `test_standard_kv_memory_formula` behind `#[cfg(target_pointer_width = "64")]` — on ARMv7 and WASM (32-bit `usize`, max ~4.3 GB), the literals `20_000_000_000` and `30_000_000_000` don't fit in `usize` and were rejected at compile time.
- Also gates the `assert_eq!(mem_370k, expected_370k)` line, which silently overflows at runtime on 32-bit (the 370K-token value ~25.7 GB exceeds `usize::MAX`).
- Adds a symmetric `#[cfg(target_pointer_width = "32")]` block that documents and asserts the architectural ceiling: **61,681 tokens** (~4.29 GB) is the maximum KV cache size representable in `usize` on ARMv7 and WASM in-browser sandboxes.

## Test plan

- [ ] `cargo check -p kv-cache-benchmark --target armv7-linux-androideabi --all-targets` passes (was the failing step)
- [ ] `cargo check -p kv-cache-benchmark --target x86_64-unknown-linux-gnu --all-targets` still passes
- [ ] `cargo test -p kv-cache-benchmark` on a 64-bit host exercises the `> 20_000_000_000` assertions
- [ ] CI `android-armv7` job passes end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_015oDVFZ7g62uFZQgp2ULKBe)_