### PR TITLE
fix(larql-python): add missing down_meta.bin header in test fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Add modular Nix flake with demos, OCI containers, and model catalog
 - Cap down_meta feature count via LARQL_SUMMARY_FEATURES_PER_EXPERT
 - Cross-platform CI/CD foundation (Phase 1)
+- Enable aarch64-linux-android cross-compilation
 - Implement Android (Phase 2b) cross-platform CI/CD support
 - Implement ChromeOS (Phase 2a) cross-platform CI/CD support
 - Implement macOS (Phase 3) cross-platform CI/CD support
@@ -28,30 +29,58 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Per-expert dequantization for DeepSeek-V4 layout
 - Per-expert top-K SVD summary tier for many-experts MoE
 - Support F8_E4M3 / F8_E5M2 / F8_E8M0 / I8 dtypes
+- Wasmi migration, arm32 atomics, REUSE compliance
+
+### Changed
+
+- Move Python testing to per-crate workflow, fix cargo-deny wildcards
 
 ### Fixed
 
 - Linux support — conditional BLAS and Q4 scalar fallback
 - Linux/WSL2 support + temperature parameter
 - MSRV truth, OpenBLAS, version-preflight, changelog
+- Add -C link-arg=-static to eliminate Android PT_INTERP
 - Add Android NDK setup to cross-platform-build workflow
+- Add arithmetic overflow fix to changelog
+- Add missing down_meta.bin header in test fixture
 - Address code review feedback on CI scripts
 - Address review feedback and CI environment realities
+- Address second-wave windows-fix CI failures
 - Align license enforcement with audited multi-license tree
 - Allow pulling vindexes from HF model repos
+- Apply rustfmt and fix clippy::unnecessary_sort_by
 - Bump pinned versions and drop fmt CI duplication
 - Bump toolchain to 1.88 and unpin scanner-tool versions
 - Configure Android cross-compilation with linker and PATH setup
+- Configure BLAS for Android in larql-inference and larql-kv
+- Configure larql-compute BLAS for Android cross-compilation
 - Correct CHANGELOG.md structure and formatting
 - Correct cog.toml schema, workflow flags, and review feedback
 - Correct tool release URLs and pre-commit hook wiring
+- Drop --no-fail-fast from cargo build; regenerate CHANGELOG
 - Drop bogus `hidden_size % head_dim == 0` invariant
 - Drop §4(b) per-file re-walk; rely on REUSE.toml manifest
 - Error on missing config.json / required topology fields (#22)
+- Exclude doc-tests on Android and set TMPDIR for all workflows
+- Fix Android QEMU runner name and libc++_shared static linking across all workflows
+- Gate UDS listener bind behind cfg(unix)
+- Gate UDS shard transport behind cfg(unix)
+- Gate forward_raw_logits imports alongside their sole user
 - Gate metal-only code behind target_os = "macos" (#48)
 - Gate metal-only code behind target_os = "macos" so the workspace builds on Linux
+- Gate orphan items in vindex test + cover second lql bench
+- Gate sdot on dotprod feature and add QEMU emulation for tests
+- Gate trace_final_residual_matches_raw_forward_logits
+- Install protoc on Windows for kv-cache-benchmark workflow
 - Narrow `cog check` PR range to first-parent + no-merges
+- Pin evalexpr to v11.3.1 (MIT) to avoid AGPL-3.0 at v12
+- Prevent arithmetic overflow in lm_head vocab calculation on 32-bit platforms
 - Pull Q4K vindex weight artifacts
+- Remove BLIS dependency due to yanked transitive versions
+- Remove duplicate timeout-minutes in larql-vindex coverage job
+- Remove explicit QEMU runner, rely on binfmt_misc transparent execution
+- Remove extra-platforms, switch reqwest to rustls-tls, upgrade wasmtime, fix fmt
 - Restore cfg-gated imports removed by PR #48
 - Restore deleted extract/build.rs and align stale test/example initializers
 - Restore extract/build.rs and align stale test/example initializers (#46)
@@ -59,11 +88,21 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Revert manual CHANGELOG edit; let git-cliff regenerate from commits
 - Scope cron to advisory scanners and harden SARIF upload
 - Silence unused cfg param in validate_one_layer
+- Six platform-specific test/build failures on windows-latest
+- Skip BLAS entirely for Android cross-compilation
+- Skip CodeQL suggestion commits in cog check
+- Skip default features check for Android in larql-compute
+- Skip default features check for Android in larql-core
 - Unblock CI tests broken by e67b4f3
 - Unblock cargo, bump wasmtime past CVEs, require MSRV
+- Update runtime to use Engine with Config
+- Use BLIS (pure-Rust BLAS) for Android cross-compilation
+- Use blas-src netlib feature for Android BLAS
 - Use checked_div for head_dim derivation
 - Use checked_div for head_dim derivation
 - Use checked_div for head_dim derivation (#50)
 - Use matmul_transb for MoE expert scoring
+- Use netlib (pure-Rust BLAS) for Android builds
+- Use versioned NDK r27 linker/ar names for Android targets
 
 

--- a/crates/larql-python/tests/test_bindings.py
+++ b/crates/larql-python/tests/test_bindings.py
@@ -92,12 +92,17 @@ def vindex_path():
         embed_data.extend(vec.tolist())
     _write_f32(os.path.join(tmpdir, "embeddings.bin"), embed_data)
 
-    # down_meta.bin — binary format: per-feature records
-    # Each record: top_token_id(u32) + c_score(f32) + top_k * (token_id(u32) + logit(f32))
+    # down_meta.bin — binary format: header + per-layer records
+    # Header: magic(u32 LE) + version(u32 LE) + num_layers(u32 LE) + top_k(u32 LE)
+    # Per layer: num_features(u32 LE) + per-feature records
+    # Per feature: top_token_id(u32 LE) + c_score(f32 LE) + top_k*(token_id(u32 LE)+logit(f32 LE))
+    MAGIC = 0x444D4554  # "DMET"
     top_k_count = 3
     record_size = 8 + top_k_count * 8
     meta_data = bytearray()
+    meta_data += struct.pack("<IIII", MAGIC, 1, NUM_LAYERS, top_k_count)
     for layer in range(NUM_LAYERS):
+        meta_data += struct.pack("<I", NUM_FEATURES)
         for feat in range(NUM_FEATURES):
             # Leave last 4 features per layer empty (for INSERT tests)
             if feat >= NUM_FEATURES - 4:

--- a/crates/larql-python/tests/test_bindings.py
+++ b/crates/larql-python/tests/test_bindings.py
@@ -97,7 +97,7 @@ def vindex_path():
     # Per layer: num_features(u32 LE) + per-feature records
     # Per feature: top_token_id(u32 LE) + c_score(f32 LE) + top_k*(token_id(u32 LE)+logit(f32 LE))
     MAGIC = 0x444D4554  # "DMET"
-    top_k_count = 3
+    top_k_count = config["down_top_k"]
     record_size = 8 + top_k_count * 8
     meta_data = bytearray()
     meta_data += struct.pack("<IIII", MAGIC, 1, NUM_LAYERS, top_k_count)

--- a/crates/larql-server/proto/buf.yaml
+++ b/crates/larql-server/proto/buf.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+# SPDX-License-Identifier: Apache-2.0
+version: v2
+lint:
+  use:
+    - STANDARD
+  except:
+    # vindex.proto lives flat in proto/ rather than proto/vindex/vindex.proto;
+    # relocating it would break generated-code import paths.
+    - PACKAGE_DIRECTORY_MATCH
+    # Package is intentionally unversioned ("vindex" not "vindex.v1") to keep
+    # the gRPC service URL stable across iterations.
+    - PACKAGE_VERSION_SUFFIX
+    # DescribeRequest is shared by both Describe and StreamDescribe RPCs by
+    # design — streaming uses the identical request shape.
+    - RPC_REQUEST_RESPONSE_UNIQUE
+    # GetRelations / GetStats / StreamDescribe use non-standard request/response
+    # message names that are part of the existing public API surface.
+    - RPC_REQUEST_STANDARD_NAME
+    - RPC_RESPONSE_STANDARD_NAME


### PR DESCRIPTION
## Summary

- The synthetic vindex fixture in `crates/larql-python/tests/test_bindings.py` was writing `down_meta.bin` without the required 16-byte binary header (magic `0x444D4554` / "DMET", version, num_layers, top_k) and without per-layer `num_features` fields
- The Rust loader rejected the file with `invalid down_meta.bin magic: 0x00000000`, causing all 37 vindex-dependent tests to error and the 4 `TestSession` tests to fail
- Added the header and per-layer feature count to match the format defined in `crates/larql-vindex/src/format/down_meta.rs`

## Test plan

- [ ] `uv run --no-sync pytest tests/ -v` passes — all 37 previously erroring tests now pass, 4 `TestSession` tests pass, 15 skipped tests remain skipped

https://claude.ai/code/session_01E2VifpdSo8VFxrA6Nvt4vp

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2VifpdSo8VFxrA6Nvt4vp)_