### PR TITLE
ci: optimize CI/CD — cancellation, draft-PR scoping, and changelog re-architecture

### DIFF
--- a/.github/workflows/bench-regress.yml
+++ b/.github/workflows/bench-regress.yml
@@ -18,17 +18,35 @@ name: bench-regress
 on:
   push:
     branches: [main, ci/workflows-complete]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.reuse/**'
+      - 'CHANGELOG*'
+      - 'LICENSE*'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.reuse/**'
+      - 'CHANGELOG*'
+      - 'LICENSE*'
   # Manual trigger so a maintainer can re-baseline after intentional
   # perf changes without waiting for the next merge to main.
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 permissions:
   contents: read
 
 jobs:
   bench:
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     name: bench - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90

--- a/.github/workflows/bench-regress.yml
+++ b/.github/workflows/bench-regress.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   bench:
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
     name: bench - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90

--- a/.github/workflows/kv-cache-benchmark.yml
+++ b/.github/workflows/kv-cache-benchmark.yml
@@ -17,6 +17,7 @@ on:
       - 'Makefile'
       - '.github/workflows/kv-cache-benchmark.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/kv-cache-benchmark/**'
@@ -27,8 +28,13 @@ on:
       - '.github/workflows/kv-cache-benchmark.yml'
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
 jobs:
   test:
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35

--- a/.github/workflows/kv-cache-benchmark.yml
+++ b/.github/workflows/kv-cache-benchmark.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35

--- a/.github/workflows/larql-boundary.yml
+++ b/.github/workflows/larql-boundary.yml
@@ -20,6 +20,7 @@ on:
       - 'Cargo.lock'
       - '.github/workflows/larql-boundary.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-boundary/**'
@@ -27,6 +28,10 @@ on:
       - 'Cargo.lock'
       - '.github/workflows/larql-boundary.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test:

--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -29,6 +29,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-cli.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-cli/**'
@@ -42,6 +43,10 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-cli.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test:

--- a/.github/workflows/larql-compute.yml
+++ b/.github/workflows/larql-compute.yml
@@ -20,6 +20,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-compute.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-compute/**'
@@ -29,6 +30,10 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-compute.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test:

--- a/.github/workflows/larql-core.yml
+++ b/.github/workflows/larql-core.yml
@@ -16,6 +16,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-core.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-core/**'
@@ -24,6 +25,10 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-core.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test:

--- a/.github/workflows/larql-experts.yml
+++ b/.github/workflows/larql-experts.yml
@@ -17,6 +17,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-experts.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-experts/**'
@@ -25,6 +26,10 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-experts.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test:

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -26,6 +26,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-inference.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-inference/**'
@@ -39,8 +40,13 @@ on:
       - '.github/workflows/larql-inference.yml'
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
 jobs:
   test:
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     name: test - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
@@ -192,6 +198,8 @@ jobs:
         run: cargo test -p larql-inference --target ${{ matrix.target }}
 
   coverage:
+    needs: [test]
+    if: success() && (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     name: coverage - ubuntu
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -46,7 +46,7 @@ concurrency:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
     name: test - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
@@ -199,7 +199,7 @@ jobs:
 
   coverage:
     needs: [test]
-    if: success() && (github.event.pull_request.draft == false || github.event_name != 'pull_request')
+    if: success() && (github.event.pull_request.draft != true || github.event_name != 'pull_request')
     name: coverage - ubuntu
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -26,6 +26,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-kv.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-kv/**'
@@ -42,6 +43,10 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-kv.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
   LARQL_KV_COVERAGE_MIN: 85

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -21,6 +21,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-lql.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-lql/**'
@@ -33,6 +34,10 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-lql.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test:

--- a/.github/workflows/larql-models.yml
+++ b/.github/workflows/larql-models.yml
@@ -20,6 +20,7 @@ on:
       - 'Cargo.lock'
       - '.github/workflows/larql-models.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-models/**'
@@ -27,6 +28,10 @@ on:
       - 'Cargo.lock'
       - '.github/workflows/larql-models.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test:

--- a/.github/workflows/larql-python.yml
+++ b/.github/workflows/larql-python.yml
@@ -20,6 +20,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-python.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-python/**'
@@ -30,6 +31,10 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-python.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test:

--- a/.github/workflows/larql-router.yml
+++ b/.github/workflows/larql-router.yml
@@ -17,6 +17,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-router.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-router/**'
@@ -26,6 +27,10 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-router.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test:

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -51,7 +51,7 @@ env:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
     name: test - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35
@@ -204,7 +204,7 @@ jobs:
 
   coverage:
     needs: [test]
-    if: success() && (github.event.pull_request.draft == false || github.event_name != 'pull_request')
+    if: success() && (github.event.pull_request.draft != true || github.event_name != 'pull_request')
     name: coverage - ubuntu
     runs-on: ubuntu-24.04
     timeout-minutes: 35

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -25,6 +25,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-server.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-server/**'
@@ -38,6 +39,10 @@ on:
       - '.github/workflows/larql-server.yml'
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
 env:
   # Existing baseline measured 2026-05-10 in Makefile (see
   # `LARQL_SERVER_COVERAGE_MIN`). Keep just under the live value to
@@ -46,6 +51,7 @@ env:
 
 jobs:
   test:
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     name: test - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35
@@ -197,6 +203,8 @@ jobs:
         run: cargo test -p larql-server --target ${{ matrix.target }}
 
   coverage:
+    needs: [test]
+    if: success() && (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     name: coverage - ubuntu
     runs-on: ubuntu-24.04
     timeout-minutes: 35

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -22,6 +22,7 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-vindex.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/larql-vindex/**'
@@ -32,6 +33,10 @@ on:
       - 'Makefile'
       - '.github/workflows/larql-vindex.yml'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
   LARQL_VINDEX_COVERAGE_MIN: 71

--- a/.github/workflows/model-compute.yml
+++ b/.github/workflows/model-compute.yml
@@ -17,6 +17,7 @@ on:
       - 'Makefile'
       - '.github/workflows/model-compute.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
     paths:
       - 'crates/model-compute/**'
@@ -26,8 +27,13 @@ on:
       - '.github/workflows/model-compute.yml'
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
 jobs:
   test:
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -182,6 +188,8 @@ jobs:
         run: cargo test -p model-compute --target ${{ matrix.target }} --benches
 
   coverage:
+    needs: [test]
+    if: success() && (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     name: coverage · ubuntu
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/model-compute.yml
+++ b/.github/workflows/model-compute.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
     name: test · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -189,7 +189,7 @@ jobs:
 
   coverage:
     needs: [test]
-    if: success() && (github.event.pull_request.draft == false || github.event_name != 'pull_request')
+    if: success() && (github.event.pull_request.draft != true || github.event_name != 'pull_request')
     name: coverage · ubuntu
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,6 +27,7 @@ name: quality
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
   push:
     branches: [main, ci/workflows-complete]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,6 +16,7 @@ name: validate
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, ci/workflows-complete]
   push:
     branches: [main, ci/workflows-complete]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 ### Added
@@ -39,12 +40,9 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 - Linux support — conditional BLAS and Q4 scalar fallback
 - Linux/WSL2 support + temperature parameter
-- MSRV truth, OpenBLAS, version-preflight, changelog
 - Add -C link-arg=-static to eliminate Android PT_INTERP
 - Add Android NDK setup to cross-platform-build workflow
 - Add arithmetic overflow fix to changelog
-- Add libc++abi.a to aarch64 Android static link group
-- Add libc++abi.a to aarch64 GROUP in all Android workflows
 - Add missing down_meta.bin header in test fixture
 - Address code review feedback on CI scripts
 - Address review feedback and CI environment realities
@@ -58,15 +56,9 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Configure BLAS for Android in larql-inference and larql-kv
 - Configure larql-compute BLAS for Android cross-compilation
 - Correct CHANGELOG.md structure and formatting
-- Correct buf lint exception for router-protocol multi-package directory
-- Correct cog.toml schema, workflow flags, and review feedback
-- Correct tool release URLs and pre-commit hook wiring
-- Drop --no-fail-fast from cargo build; regenerate CHANGELOG
 - Drop bogus `hidden_size % head_dim == 0` invariant
 - Drop §4(b) per-file re-walk; rely on REUSE.toml manifest
 - Error on missing config.json / required topology fields (#22)
-- Exclude doc-tests on Android and set TMPDIR for all workflows
-- Fix Android QEMU runner name and libc++_shared static linking across all workflows
 - Gate UDS listener bind behind cfg(unix)
 - Gate UDS shard transport behind cfg(unix)
 - Gate forward_raw_logits imports alongside their sole user
@@ -75,15 +67,10 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Gate orphan items in vindex test + cover second lql bench
 - Gate sdot on dotprod feature and add QEMU emulation for tests
 - Gate trace_final_residual_matches_raw_forward_logits
-- Install protoc on Windows for kv-cache-benchmark workflow
-- Narrow `cog check` PR range to first-parent + no-merges
 - Pin evalexpr to v11.3.1 (MIT) to avoid AGPL-3.0 at v12
 - Prevent arithmetic overflow in lm_head vocab calculation on 32-bit platforms
 - Pull Q4K vindex weight artifacts
 - Remove BLIS dependency due to yanked transitive versions
-- Remove duplicate timeout-minutes in larql-vindex coverage job
-- Remove explicit QEMU runner, rely on binfmt_misc transparent execution
-- Remove extra-platforms, switch reqwest to rustls-tls, upgrade wasmtime, fix fmt
 - Restore cfg-gated imports removed by PR #48
 - Restore deleted extract/build.rs and align stale test/example initializers
 - Restore extract/build.rs and align stale test/example initializers (#46)
@@ -93,12 +80,9 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Silence unused cfg param in validate_one_layer
 - Six platform-specific test/build failures on windows-latest
 - Skip BLAS entirely for Android cross-compilation
-- Skip CodeQL suggestion commits in cog check
 - Skip default features check for Android in larql-compute
 - Skip default features check for Android in larql-core
-- Sync CHANGELOG and add buf.yaml for router-protocol proto
 - Unblock CI tests broken by e67b4f3
-- Unblock cargo, bump wasmtime past CVEs, require MSRV
 - Update runtime to use Engine with Config
 - Use BLIS (pure-Rust BLAS) for Android cross-compilation
 - Use blas-src netlib feature for Android BLAS
@@ -107,6 +91,5 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Use checked_div for head_dim derivation (#50)
 - Use matmul_transb for MoE expert scoring
 - Use netlib (pure-Rust BLAS) for Android builds
-- Use versioned NDK r27 linker/ar names for Android targets
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Add -C link-arg=-static to eliminate Android PT_INTERP
 - Add Android NDK setup to cross-platform-build workflow
 - Add arithmetic overflow fix to changelog
+- Add libc++abi.a to aarch64 Android static link group
+- Add libc++abi.a to aarch64 GROUP in all Android workflows
 - Add missing down_meta.bin header in test fixture
 - Address code review feedback on CI scripts
 - Address review feedback and CI environment realities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Configure BLAS for Android in larql-inference and larql-kv
 - Configure larql-compute BLAS for Android cross-compilation
 - Correct CHANGELOG.md structure and formatting
+- Correct buf lint exception for router-protocol multi-package directory
 - Correct cog.toml schema, workflow flags, and review feedback
 - Correct tool release URLs and pre-commit hook wiring
 - Drop --no-fail-fast from cargo build; regenerate CHANGELOG
@@ -95,6 +96,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Skip CodeQL suggestion commits in cog check
 - Skip default features check for Android in larql-compute
 - Skip default features check for Android in larql-core
+- Sync CHANGELOG and add buf.yaml for router-protocol proto
 - Unblock CI tests broken by e67b4f3
 - Unblock cargo, bump wasmtime past CVEs, require MSRV
 - Update runtime to use Engine with Config

--- a/cliff.toml
+++ b/cliff.toml
@@ -8,8 +8,10 @@
 #
 # Mapping policy (Conventional Commit type -> Keep a Changelog section):
 #
-#   feat     -> Added
-#   fix      -> Fixed
+#   feat          -> Added
+#   fix           -> Fixed
+#   fix(ci)       -> omitted  (CI infra, not user-facing; same treatment as ci:)
+#   fix(cd)       -> omitted  (CD infra, not user-facing)
 #   perf     -> Changed
 #   refactor -> Changed
 #   revert   -> Removed
@@ -69,6 +71,11 @@ sort_commits = "oldest"
 # Mapping is total and explicit. Anything not matched is dropped.
 commit_parsers = [
   { message = "^feat",       group = "Added"   },
+  # CI/CD infrastructure fixes (fix(ci):, fix(cd):) are excluded because they
+  # are not user-facing changes. They are treated the same as `ci:` commits.
+  # Rules are evaluated in order; these must precede the generic `^fix` rule.
+  { message = "^fix\\(ci\\)", skip = true      },
+  { message = "^fix\\(cd\\)", skip = true      },
   { message = "^fix",        group = "Fixed"   },
   { message = "^perf",       group = "Changed" },
   { message = "^refactor",   group = "Changed" },

--- a/crates/larql-router-protocol/proto/buf.yaml
+++ b/crates/larql-router-protocol/proto/buf.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Contributors to the larql-to-sparql project
+# SPDX-License-Identifier: Apache-2.0
+version: v2
+lint:
+  use:
+    - STANDARD
+  except:
+    # Proto files live flat in proto/ rather than proto/larql/{expert,grid}/v1/;
+    # relocating them would break generated-code import paths.
+    - PACKAGE_DIRECTORY_MATCH
+    # GridService.Join uses ServerMessage/RouterMessage and ExpertService.ExpertStream
+    # uses ExpertLayerInput/ExpertLayerOutput — non-standard names that are part
+    # of the existing public API surface.
+    - RPC_REQUEST_STANDARD_NAME
+    - RPC_RESPONSE_STANDARD_NAME

--- a/crates/larql-router-protocol/proto/buf.yaml
+++ b/crates/larql-router-protocol/proto/buf.yaml
@@ -5,8 +5,10 @@ lint:
   use:
     - STANDARD
   except:
-    # Proto files live flat in proto/ rather than proto/larql/{expert,grid}/v1/;
-    # relocating them would break generated-code import paths.
+    # expert.proto (larql.expert.v1) and grid.proto (larql.grid.v1) share the
+    # same flat proto/ directory; splitting them into per-package subdirectories
+    # would break generated-code import paths.
+    - DIRECTORY_SAME_PACKAGE
     - PACKAGE_DIRECTORY_MATCH
     # GridService.Join uses ServerMessage/RouterMessage and ExpertService.ExpertStream
     # uses ExpertLayerInput/ExpertLayerOutput — non-standard names that are part


### PR DESCRIPTION
## Summary

### Category 1 — Concurrency + cancellation (16 workflows)

All 16 workflows that lacked a `concurrency:` block now cancel superseded runs on the same ref, preventing queue pile-up from rapid commits. `workflow_dispatch` runs are explicitly protected: `cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}`.

### Category 2 — Draft PR event filtering (all 18 workflows)

All 18 workflows gain `types: [opened, synchronize, reopened, ready_for_review]` on their `pull_request` trigger. The 5 most expensive workflows (`bench-regress`, `kv-cache-benchmark`, `larql-inference`, `larql-server`, `model-compute`) additionally skip all jobs on draft PRs via a job-level `if:` guard, preventing 35–90 min × 6-platform runs from consuming runners on WIP branches.

### Category 3 — Path filtering for `bench-regress`

`bench-regress` (the only workflow with no path filter) gains `paths-ignore` for documentation-only changes (`.md`, `docs/`, `.reuse/`, `CHANGELOG*`, `LICENSE*`), preventing 90-min benchmark runs on non-code commits.

### Category 4 — Coverage job dependencies (3 workflows)

Coverage jobs in `larql-inference`, `larql-server`, and `model-compute` now depend on their `test` job (`needs: [test]`, `if: success()`) so coverage computation is skipped when tests are already failing.

### Changelog re-architecture

Root cause: `fix(ci):` and `fix(cd):` commits (type=`fix`, scope=`ci`/`cd`) were being captured by the generic `^fix` rule in `cliff.toml` and placed in the user-facing `Fixed` section of the CHANGELOG. Every CI infrastructure commit triggered a `check_changelog` failure, which prompted another `fix(ci):` sync commit, creating an unbounded cycle.

Fix: added two scope-specific `skip` rules in `cliff.toml` **before** the generic `^fix` rule. git-cliff evaluates parsers in order and stops at the first match, so `fix(ci):` and `fix(cd):` commits are now silently dropped. The CHANGELOG has been regenerated from the corrected projection.

---

No job steps, build commands, matrix configurations, environment variables, or tool version pins were modified. Branch is rebased onto `origin/main` (incorporates PR #52 Android `libc++abi.a` fix).

## Test plan

- [ ] Push two commits in quick succession to a PR → first run's jobs show "Cancelled" in GitHub Actions UI
- [ ] Trigger a workflow manually (`workflow_dispatch`) then push a commit → manual run continues uninterrupted
- [ ] Mark a PR as draft, push a commit → `bench-regress`, `kv-cache-benchmark`, `larql-inference`, `larql-server`, `model-compute` jobs are skipped; other per-crate workflows still run
- [ ] Push a commit that only changes a `.md` file to `main` → `bench-regress` does not trigger
- [ ] Convert a draft PR to ready → all workflows fire (`ready_for_review` event type)
- [ ] Cause tests to fail in `larql-inference` → `coverage` job does not start
- [ ] Push a `fix(ci): …` commit → `check_changelog` still passes (no new CHANGELOG entry generated)

https://claude.ai/code/session_0132F9fNeTEyLgQLZFXEWyJH