### PR TITLE
fix(wasm): source-level cfg guards for larql-router-protocol, larql-router, larql-server

### DIFF
--- a/.github/workflows/bench-regress.yml
+++ b/.github/workflows/bench-regress.yml
@@ -1,0 +1,206 @@
+# Bench regression detector — runs `make bench-check` on every PR
+# against a baseline saved on `main`. Fails the workflow if any cell
+# in the criterion bench suite regresses past Criterion's noise
+# threshold.
+#
+# Surface covered (`make bench-save` / `make bench-check`):
+#   - `quant_matvec`: Q4_0 / Q4_K / Q4_KF / Q6_K × 3 shapes × cpu/metal
+#   - `matmul`: f32 matmul + f32_gemv (lm-head) — cpu vs metal
+#   - `linalg`: cholesky + ridge solve (cpu only)
+#
+# That's the surface where the next throughput cliff would show up
+# first. The 75 %-row drop in `q4_matvec_v4` would have shown as a 4×
+# regression at `quant_matvec_q4_0/metal/lm_head_262144` weeks before
+# goldens caught it.
+
+name: bench-regress
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.reuse/**'
+      - 'CHANGELOG*'
+      - 'LICENSE*'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.reuse/**'
+      - 'CHANGELOG*'
+      - 'LICENSE*'
+  # Manual trigger so a maintainer can re-baseline after intentional
+  # perf changes without waiting for the next merge to main.
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
+    name: bench - ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Install OpenBLAS (Linux)
+        if: matrix.platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install OpenBLAS (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      # Cargo deps are big and stable across PRs — separate cache.
+      - name: Cache cargo deps
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-bench-
+
+      # Criterion baselines: write-through on main, read-only on PRs.
+      # Keyed by the run number so each main push refreshes the cache.
+      - name: Cache criterion baseline (main only)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache@v5
+        with:
+          path: target/criterion
+          key: ${{ runner.os }}-${{ matrix.target }}-criterion-baseline-${{ github.run_number }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-criterion-baseline-
+
+      - name: Restore criterion baseline (PRs only)
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v5
+        with:
+          path: target/criterion
+          key: ${{ runner.os }}-${{ matrix.target }}-criterion-baseline-
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-criterion-baseline-
+
+      - name: Save baseline (main only)
+        if: github.ref == 'refs/heads/main'
+        run: make bench-save
+
+      - name: Check vs baseline (PRs + manual)
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        run: |
+          # Cold cache → bench-check prints "no baseline found" and
+          # exits 2. Treat as neutral: the first PR after CI is stood
+          # up shouldn't fail just because there's no baseline yet.
+          set +e
+          make bench-check
+          rc=$?
+          set -e
+          if [ "$rc" -eq 2 ]; then
+            echo "::warning::no criterion baseline cached; skipping regression check"
+            exit 0
+          fi
+          exit "$rc"
+
+      # On regression, attach the criterion HTML report so reviewers
+      # can see the per-cell delta without re-running locally.
+      - name: Upload criterion report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: criterion-report
+          path: target/criterion/
+          retention-days: 14

--- a/.github/workflows/bench-regress.yml
+++ b/.github/workflows/bench-regress.yml
@@ -17,7 +17,7 @@ name: bench-regress
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -26,7 +26,7 @@ on:
       - 'LICENSE*'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/kv-cache-benchmark.yml
+++ b/.github/workflows/kv-cache-benchmark.yml
@@ -8,7 +8,7 @@ name: kv-cache-benchmark
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/kv-cache-benchmark/**'
       - 'crates/larql-inference/**'
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/kv-cache-benchmark.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/kv-cache-benchmark/**'
       - 'crates/larql-inference/**'

--- a/.github/workflows/kv-cache-benchmark.yml
+++ b/.github/workflows/kv-cache-benchmark.yml
@@ -1,0 +1,183 @@
+# kv-cache-benchmark tool CI
+#
+# Benchmarks KV cache strategies: Standard KV vs TurboQuant vs Markov RS vs
+# Graph Walk. Uses criterion for reproducible benchmark comparisons across
+# platforms.
+
+name: kv-cache-benchmark
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/kv-cache-benchmark/**'
+      - 'crates/larql-inference/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/kv-cache-benchmark.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/kv-cache-benchmark/**'
+      - 'crates/larql-inference/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/kv-cache-benchmark.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
+    name: test · ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install protoc (Windows)
+        if: matrix.platform == 'windows'
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install OpenBLAS (Linux)
+        if: matrix.platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install OpenBLAS (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ matrix.target }}-cargo-kv-bench
+
+      - name: Format check
+        run: cargo fmt -p kv-cache-benchmark -- --check
+
+      - name: Check
+        run: cargo check -p kv-cache-benchmark --target ${{ matrix.target }} --all-targets
+
+      - name: Clippy
+        run: cargo clippy -p kv-cache-benchmark --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Tests
+        if: matrix.platform != 'android'
+        run: cargo test -p kv-cache-benchmark --target ${{ matrix.target }}
+
+      - name: Tests (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p kv-cache-benchmark --target ${{ matrix.target }} --lib --tests
+
+      - name: Benchmark compile/tests
+        run: cargo test -p kv-cache-benchmark --target ${{ matrix.target }} --benches

--- a/.github/workflows/larql-boundary.yml
+++ b/.github/workflows/larql-boundary.yml
@@ -13,7 +13,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-boundary/**'
       - 'Cargo.toml'
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/larql-boundary.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-boundary/**'
       - 'Cargo.toml'

--- a/.github/workflows/larql-boundary.yml
+++ b/.github/workflows/larql-boundary.yml
@@ -1,0 +1,193 @@
+# larql-boundary cross-platform CI
+#
+# Runs fmt + check + clippy + tests + bench test-mode on Linux, Windows, and macOS.
+# No model weights or MLX required — the crate is pure Rust.
+#   - Linux   (x86_64-unknown-linux-gnu)
+#   - Windows (x86_64-pc-windows-msvc)
+#   - macOS   (aarch64-apple-darwin)
+
+name: larql-boundary
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-boundary/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/larql-boundary.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-boundary/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/larql-boundary.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    name: test · ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    permissions:
+      contents: read
+      checks: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-boundary-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-boundary-
+
+      - name: Format check
+        run: cargo fmt -p larql-boundary -- --check
+
+      - name: Check (all targets)
+        run: cargo check -p larql-boundary --target ${{ matrix.target }} --all-targets
+
+      - name: Clippy (warnings as errors)
+        run: cargo clippy -p larql-boundary --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Unit + integration tests
+        if: matrix.platform != 'android'
+        run: cargo test -p larql-boundary --target ${{ matrix.target }}
+
+      - name: Unit + integration tests (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-boundary --target ${{ matrix.target }} --lib --tests
+
+      - name: Test benchmarks (compile + smoke)
+        run: cargo test -p larql-boundary --target ${{ matrix.target }} --benches
+
+      - name: Run examples
+        run: |
+          cargo run -p larql-boundary --target ${{ matrix.target }} --example encode_decode
+          cargo run -p larql-boundary --target ${{ matrix.target }} --example gate_decision
+
+  coverage:
+    name: coverage · ubuntu
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary
+        run: cargo llvm-cov --package larql-boundary --summary-only

--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -1,0 +1,227 @@
+# larql-cli cross-platform CI
+#
+# Top-level `larql` binary. Default features enable Metal on every
+# member crate, which only resolves on macOS. Linux/Windows runs use
+# `--no-default-features` so the CPU-only surface is exercised. macOS
+# runs include defaults so the Metal feature path is checked too.
+#
+# `convert_moe_to_per_layer` example currently doesn't build against
+# the post-refactor `larql-inference` API; CI checks bins + tests
+# instead of `--all-targets` until that example is repaired.
+
+name: larql-cli
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-cli/**'
+      - 'crates/larql-lql/**'
+      - 'crates/larql-kv/**'
+      - 'crates/larql-vindex/**'
+      - 'crates/larql-models/**'
+      - 'crates/larql-inference/src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-cli.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-cli/**'
+      - 'crates/larql-lql/**'
+      - 'crates/larql-kv/**'
+      - 'crates/larql-vindex/**'
+      - 'crates/larql-models/**'
+      - 'crates/larql-inference/src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-cli.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    name: test - ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Install OpenBLAS (Linux)
+        if: matrix.platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install OpenBLAS (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      - name: Install protoc (Windows)
+        if: matrix.platform == 'windows'
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-cli-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-cli-
+
+      - name: Format check
+        run: cargo fmt -p larql-cli -- --check
+
+      - name: Check (CPU only) on Linux/Windows/Android
+        if: matrix.platform != 'macos'
+        run: cargo check -p larql-cli --target ${{ matrix.target }} --bins --tests --no-default-features
+
+      - name: Check (default features incl. metal) on macOS
+        if: matrix.platform == 'macos'
+        run: cargo check -p larql-cli --target ${{ matrix.target }} --bins --tests
+
+      - name: Tests (CPU only) on Linux/Windows/Android
+        run: cargo test -p larql-cli --target ${{ matrix.target }} --no-default-features
+
+      - name: Tests (default features) on macOS
+        if: matrix.platform == 'macos'
+        run: cargo test -p larql-cli --target ${{ matrix.target }}
+
+  coverage:
+    name: coverage - ubuntu
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary
+        run: cargo llvm-cov --package larql-cli --no-default-features --summary-only

--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -16,7 +16,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-cli/**'
       - 'crates/larql-lql/**'
@@ -30,7 +30,7 @@ on:
       - '.github/workflows/larql-cli.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-cli/**'
       - 'crates/larql-lql/**'

--- a/.github/workflows/larql-compute.yml
+++ b/.github/workflows/larql-compute.yml
@@ -11,7 +11,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-compute/**'
       - 'crates/larql-models/**'
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/larql-compute.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-compute/**'
       - 'crates/larql-models/**'

--- a/.github/workflows/larql-compute.yml
+++ b/.github/workflows/larql-compute.yml
@@ -1,0 +1,202 @@
+# larql-compute cross-platform CI
+#
+# Validates the CPU baseline on Linux, Windows, and macOS, plus the macOS-only
+# Metal feature gate. Linux/Windows intentionally run `--all-features` too:
+# enabling the `metal` feature there must not expose macOS-only modules.
+
+name: larql-compute
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-compute/**'
+      - 'crates/larql-models/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-compute.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-compute/**'
+      - 'crates/larql-models/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-compute.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    name: test · ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Install OpenBLAS (Linux)
+        if: matrix.platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install OpenBLAS (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $root = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $root) {
+            $root = 'C:\vcpkg'
+          }
+          & "$root\vcpkg.exe" install openblas:x64-windows
+          "VCPKG_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$root\installed\x64-windows\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-compute-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-compute-
+
+      - name: Format check
+        run: cargo fmt -p larql-compute -- --check
+
+      - name: Check default features
+        run: cargo check -p larql-compute --target ${{ matrix.target }} --all-targets
+
+      - name: Check all features on Linux/Windows/Android
+        if: matrix.platform != 'macos'
+        run: cargo check -p larql-compute --target ${{ matrix.target }} --all-targets --all-features
+
+      - name: Check Metal feature on macOS
+        if: matrix.platform == 'macos'
+        run: cargo check -p larql-compute --target ${{ matrix.target }} --all-targets --features metal
+
+      - name: Clippy default features
+        run: cargo clippy -p larql-compute --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Clippy all features on Linux/Windows/Android
+        if: matrix.platform != 'macos'
+        run: cargo clippy -p larql-compute --target ${{ matrix.target }} --all-targets --all-features -- -D warnings
+
+      - name: Clippy Metal feature on macOS
+        if: matrix.platform == 'macos'
+        run: cargo clippy -p larql-compute --target ${{ matrix.target }} --all-targets --features metal -- -D warnings
+
+      - name: Unit tests
+        run: cargo test -p larql-compute --target ${{ matrix.target }} --lib
+
+      - name: Backend contract tests
+        run: cargo test -p larql-compute --target ${{ matrix.target }} --test test_backend_matmul_quant
+
+      - name: Pipeline and MoE contract tests
+        run: cargo test -p larql-compute --target ${{ matrix.target }} --test test_pipeline_and_moe

--- a/.github/workflows/larql-core.yml
+++ b/.github/workflows/larql-core.yml
@@ -8,7 +8,7 @@ name: larql-core
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-core/**'
       - 'Cargo.toml'
@@ -17,7 +17,7 @@ on:
       - '.github/workflows/larql-core.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-core/**'
       - 'Cargo.toml'

--- a/.github/workflows/larql-core.yml
+++ b/.github/workflows/larql-core.yml
@@ -1,0 +1,211 @@
+# larql-core cross-platform CI
+#
+# Runs fmt + feature matrix + clippy + tests + examples + bench test-mode on
+# Linux, Windows, and macOS. The crate is model-architecture agnostic and these
+# checks require no model weights or platform-specific backends.
+
+name: larql-core
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-core/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-core.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-core/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-core.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    name: test · ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    permissions:
+      contents: read
+      checks: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-core-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-core-
+
+      - name: Format check
+        run: cargo fmt -p larql-core -- --check
+
+      - name: Check default features
+        run: cargo check -p larql-core --target ${{ matrix.target }} --all-targets
+
+      - name: Check no default features
+        run: cargo check -p larql-core --target ${{ matrix.target }} --no-default-features --all-targets
+
+      - name: Check msgpack-only feature
+        run: cargo check -p larql-core --target ${{ matrix.target }} --no-default-features --features msgpack --all-targets
+
+      - name: Clippy default features
+        run: cargo clippy -p larql-core --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Unit + integration tests
+        if: matrix.platform != 'android'
+        run: cargo test -p larql-core --target ${{ matrix.target }}
+
+      - name: Unit + integration tests (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-core --target ${{ matrix.target }} --lib --tests
+
+      - name: Feature matrix tests
+        if: matrix.platform != 'android'
+        run: |
+          cargo test -p larql-core --target ${{ matrix.target }} --no-default-features
+          cargo test -p larql-core --target ${{ matrix.target }} --no-default-features --features msgpack
+
+      - name: Feature matrix tests (Android)
+        if: matrix.platform == 'android'
+        run: |
+          cargo test -p larql-core --target ${{ matrix.target }} --no-default-features --lib --tests
+          cargo test -p larql-core --target ${{ matrix.target }} --no-default-features --features msgpack --lib --tests
+
+      - name: Test benchmarks
+        run: cargo test -p larql-core --target ${{ matrix.target }} --benches
+
+      - name: Run examples
+        run: |
+          cargo run -p larql-core --target ${{ matrix.target }} --example edge_demo
+          cargo run -p larql-core --target ${{ matrix.target }} --example graph_demo
+          cargo run -p larql-core --target ${{ matrix.target }} --example algorithm_demo
+          cargo run -p larql-core --target ${{ matrix.target }} --example filter_demo
+          cargo run -p larql-core --target ${{ matrix.target }} --example serialization_demo
+
+  coverage:
+    name: coverage · ubuntu
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary
+        run: cargo llvm-cov --package larql-core --summary-only

--- a/.github/workflows/larql-experts.yml
+++ b/.github/workflows/larql-experts.yml
@@ -1,0 +1,177 @@
+# larql-experts WASM expert modules CI
+#
+# Tests the expert-interface and all expert modules (arithmetic, date, unit,
+# logic, dijkstra, statistics, geometry, trig, string_ops, hash, finance,
+# sql, element, http_status, isbn, luhn, markov, conway, graph).
+# These modules compile to WebAssembly and are loaded by larql-inference.
+
+name: larql-experts
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-experts/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-experts.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-experts/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-experts.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    name: test · ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ matrix.target }}-cargo-experts
+
+      - name: Format check (workspace)
+        working-directory: crates/larql-experts
+        run: cargo fmt --all -- --check
+
+      - name: Check workspace members
+        working-directory: crates/larql-experts
+        run: cargo check --target ${{ matrix.target }} --all --all-targets
+
+      - name: Clippy (workspace)
+        working-directory: crates/larql-experts
+        run: cargo clippy --target ${{ matrix.target }} --all --all-targets -- -D warnings
+
+      - name: Tests
+        working-directory: crates/larql-experts
+        run: cargo test --target ${{ matrix.target }} --all
+
+  coverage:
+    name: coverage · ubuntu
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary (workspace)
+        working-directory: crates/larql-experts
+        run: cargo llvm-cov --all --summary-only

--- a/.github/workflows/larql-experts.yml
+++ b/.github/workflows/larql-experts.yml
@@ -9,7 +9,7 @@ name: larql-experts
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-experts/**'
       - 'Cargo.toml'
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/larql-experts.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-experts/**'
       - 'Cargo.toml'

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -1,0 +1,220 @@
+# larql-inference cross-platform CI
+#
+# Transformer inference engine — forward pass, attention, FFN, layer
+# norm. Tests that need real model weights are gated `#[ignore]`
+# (test_arch_golden, test_logits_goldens, test_gemma3_smoke,
+# test_generate_q4k_cpu, test_layer_graph_integration); CI runs the
+# default test set only. Several diagnostic examples
+# (cpu_gpu_diag, debug_generate, debug_gpu_step, debug_layers,
+# decode_vs_prefill, residual_diff, stage_bisect) currently lag the
+# refactored `larql-compute` decode API and are excluded from the
+# `cargo check` surface — repair them and add `--examples` here.
+
+name: larql-inference
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-inference/**'
+      - 'crates/larql-compute/**'
+      - 'crates/larql-vindex/**'
+      - 'crates/larql-models/**'
+      - 'crates/larql-router-protocol/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-inference.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-inference/**'
+      - 'crates/larql-compute/**'
+      - 'crates/larql-vindex/**'
+      - 'crates/larql-models/**'
+      - 'crates/larql-router-protocol/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-inference.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
+    name: test - ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Install OpenBLAS (Linux)
+        if: matrix.platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install OpenBLAS (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      - name: Install protoc (Windows)
+        if: matrix.platform == 'windows'
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-inference-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-inference-
+
+      - name: Format check
+        run: cargo fmt -p larql-inference -- --check
+
+      - name: Check lib + tests + benches
+        run: cargo check -p larql-inference --target ${{ matrix.target }} --lib --tests --benches
+
+      - name: Clippy
+        run: cargo clippy -p larql-inference --target ${{ matrix.target }} --lib --tests --benches --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-inference --target ${{ matrix.target }}
+
+  coverage:
+    needs: [test]
+    if: success() && (github.event.pull_request.draft != true || github.event_name != 'pull_request')
+    name: coverage - ubuntu
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary
+        run: cargo llvm-cov --package larql-inference --summary-only

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -14,7 +14,7 @@ name: larql-inference
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-inference/**'
       - 'crates/larql-compute/**'
@@ -27,7 +27,7 @@ on:
       - '.github/workflows/larql-inference.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-inference/**'
       - 'crates/larql-compute/**'

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -1,0 +1,236 @@
+# larql-kv cross-platform CI
+#
+# Pluggable KV-cache engines (markov-rs, unlimited-context, turbo-quant,
+# apollo). The crate is model-architecture agnostic: tests use synthetic
+# `larql_inference::test_utils` fixtures, no real model weights, no
+# platform-specific GPU backends. Same surface runs on Linux, Windows,
+# and macOS.
+
+name: larql-kv
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-kv/**'
+      - 'crates/larql-inference/src/test_utils.rs'
+      - 'crates/larql-inference/src/forward/**'
+      - 'crates/larql-inference/src/attention/**'
+      - 'crates/larql-inference/src/ffn/**'
+      - 'crates/larql-inference/src/residual.rs'
+      - 'crates/larql-inference/src/vindex/**'
+      - 'crates/larql-inference/src/model.rs'
+      - 'crates/larql-inference/src/layer_graph/pipeline_layer.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-kv.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-kv/**'
+      - 'crates/larql-inference/src/test_utils.rs'
+      - 'crates/larql-inference/src/forward/**'
+      - 'crates/larql-inference/src/attention/**'
+      - 'crates/larql-inference/src/ffn/**'
+      - 'crates/larql-inference/src/residual.rs'
+      - 'crates/larql-inference/src/vindex/**'
+      - 'crates/larql-inference/src/model.rs'
+      - 'crates/larql-inference/src/layer_graph/pipeline_layer.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-kv.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+env:
+  LARQL_KV_COVERAGE_MIN: 85
+
+jobs:
+  test:
+    name: test - ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Install OpenBLAS (Linux)
+        if: matrix.platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install OpenBLAS (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      - name: Install protoc (Windows)
+        if: matrix.platform == 'windows'
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-kv-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-kv-
+
+      - name: Format check
+        run: cargo fmt -p larql-kv -- --check
+
+      - name: Check all targets
+        run: cargo check -p larql-kv --target ${{ matrix.target }} --all-targets
+
+      - name: Check examples
+        run: cargo check -p larql-kv --target ${{ matrix.target }} --examples
+
+      - name: Clippy
+        run: cargo clippy -p larql-kv --target ${{ matrix.target }} --all-targets --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-kv --target ${{ matrix.target }}
+
+      - name: Benchmark compile/tests
+        run: cargo test -p larql-kv --target ${{ matrix.target }} --benches
+
+  coverage:
+    name: coverage - ubuntu
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary
+        run: cargo llvm-cov --package larql-kv --summary-only --fail-under-lines "$LARQL_KV_COVERAGE_MIN"
+
+      - name: Coverage policy
+        run: |
+          mkdir -p coverage/larql-kv
+          cargo llvm-cov report --package larql-kv --json --summary-only --output-path coverage/larql-kv/summary.json
+          python3 scripts/check_coverage_policy.py coverage/larql-kv/summary.json crates/larql-kv/coverage-policy.json

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -10,7 +10,7 @@ name: larql-kv
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-kv/**'
       - 'crates/larql-inference/src/test_utils.rs'
@@ -27,7 +27,7 @@ on:
       - '.github/workflows/larql-kv.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-kv/**'
       - 'crates/larql-inference/src/test_utils.rs'

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -9,7 +9,7 @@ name: larql-lql
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-lql/**'
       - 'crates/larql-core/**'
@@ -22,7 +22,7 @@ on:
       - '.github/workflows/larql-lql.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-lql/**'
       - 'crates/larql-core/**'

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -1,0 +1,214 @@
+# larql-lql cross-platform CI
+#
+# LQL parser, executor, and REPL. The crate is model/architecture
+# agnostic — parser tests are pure, executor integration tests use
+# `mockito` to fake the Remote backend, and the metal feature is opt-in
+# (default = []). Same surface runs on Linux, Windows, and macOS.
+
+name: larql-lql
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-lql/**'
+      - 'crates/larql-core/**'
+      - 'crates/larql-vindex/**'
+      - 'crates/larql-models/**'
+      - 'crates/larql-inference/src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-lql.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-lql/**'
+      - 'crates/larql-core/**'
+      - 'crates/larql-vindex/**'
+      - 'crates/larql-models/**'
+      - 'crates/larql-inference/src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-lql.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    name: test - ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Install OpenBLAS (Linux)
+        if: matrix.platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install OpenBLAS (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      - name: Install protoc (Windows)
+        if: matrix.platform == 'windows'
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-lql-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-lql-
+
+      - name: Format check
+        run: cargo fmt -p larql-lql -- --check
+
+      - name: Check all targets
+        run: cargo check -p larql-lql --target ${{ matrix.target }} --all-targets
+
+      - name: Clippy
+        run: cargo clippy -p larql-lql --target ${{ matrix.target }} --all-targets --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-lql --target ${{ matrix.target }}
+
+      - name: Benchmark compile/tests
+        run: cargo test -p larql-lql --target ${{ matrix.target }} --benches
+
+  coverage:
+    name: coverage - ubuntu
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary
+        run: cargo llvm-cov --package larql-lql --summary-only

--- a/.github/workflows/larql-models.yml
+++ b/.github/workflows/larql-models.yml
@@ -1,0 +1,188 @@
+# larql-models cross-platform CI
+#
+# Runs fmt + check + clippy + tests + bench test-mode on Linux, Windows, and macOS
+# for every change to the larql-models crate. Validates cross-platform compatibility:
+#   - Linux  (x86_64-unknown-linux-gnu)
+#   - Windows (x86_64-pc-windows-msvc) — HF cache path, mmap, path separators
+#   - macOS  (aarch64-apple-darwin)    — NEON SIMD paths
+
+name: larql-models
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-models/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/larql-models.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-models/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/larql-models.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    name: test · ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-models-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-models-
+
+      - name: Format check
+        run: cargo fmt -p larql-models -- --check
+
+      - name: Check (all targets)
+        run: cargo check -p larql-models --target ${{ matrix.target }} --all-targets
+
+      - name: Clippy (warnings as errors)
+        run: cargo clippy -p larql-models --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Test
+        if: matrix.platform != 'android'
+        run: cargo test -p larql-models --target ${{ matrix.target }}
+
+      - name: Test (Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p larql-models --target ${{ matrix.target }} --lib --tests
+
+      - name: Test benches
+        run: cargo test -p larql-models --target ${{ matrix.target }} --benches
+
+  coverage:
+    name: coverage · ubuntu
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary
+        run: cargo llvm-cov --package larql-models --summary-only

--- a/.github/workflows/larql-models.yml
+++ b/.github/workflows/larql-models.yml
@@ -13,7 +13,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-models/**'
       - 'Cargo.toml'
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/larql-models.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-models/**'
       - 'Cargo.toml'

--- a/.github/workflows/larql-python.yml
+++ b/.github/workflows/larql-python.yml
@@ -10,7 +10,7 @@ name: larql-python
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-python/**'
       - 'crates/larql-core/**'
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/larql-python.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-python/**'
       - 'crates/larql-core/**'

--- a/.github/workflows/larql-python.yml
+++ b/.github/workflows/larql-python.yml
@@ -1,0 +1,96 @@
+# larql-python PyO3 bindings CI
+#
+# Builds the larql-python cdylib via maturin and runs pytest on the test
+# surface. Python bindings are platform-specific (requires libopenblas);
+# tests run on Linux only. Build is included in per-crate matrix to catch
+# dependency changes; tests are Linux-only since emulation/CI VMs add no
+# practical coverage beyond the host system.
+
+name: larql-python
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-python/**'
+      - 'crates/larql-core/**'
+      - 'crates/larql-inference/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-python.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-python/**'
+      - 'crates/larql-core/**'
+      - 'crates/larql-inference/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-python.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    name: test - ubuntu (maturin + pytest)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libopenblas-dev
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: larql-python-cargo
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Format check
+        run: cargo fmt -p larql-python -- --check
+
+      - name: Cargo check (Rust surface)
+        run: cargo check -p larql-python --lib
+
+      - name: Clippy
+        run: cargo clippy -p larql-python --lib --tests --benches --no-deps -- -D warnings
+
+      - name: uv sync (dev dependencies)
+        working-directory: crates/larql-python
+        run: uv sync --no-install-project --group dev
+
+      - name: maturin develop (build PyO3 bindings)
+        working-directory: crates/larql-python
+        run: uv run --no-sync maturin develop --release
+
+      - name: pytest (Python binding tests)
+        working-directory: crates/larql-python
+        run: uv run --no-sync pytest tests/ -v

--- a/.github/workflows/larql-router.yml
+++ b/.github/workflows/larql-router.yml
@@ -8,7 +8,7 @@ name: larql-router
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-router/**'
       - 'crates/larql-router-protocol/**'
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/larql-router.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-router/**'
       - 'crates/larql-router-protocol/**'

--- a/.github/workflows/larql-router.yml
+++ b/.github/workflows/larql-router.yml
@@ -1,0 +1,203 @@
+# larql-router distributed layer-sharding router CI
+#
+# Tests the router library and binary on Linux, Windows, and macOS.
+# The router is platform-agnostic (no GPU/BLAS dependencies) and runs
+# the same test surface across all platforms.
+
+name: larql-router
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-router/**'
+      - 'crates/larql-router-protocol/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-router.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-router/**'
+      - 'crates/larql-router-protocol/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-router.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    name: test · ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install protoc (Windows)
+        if: matrix.platform == 'windows'
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ matrix.target }}-cargo-router
+          cache-directories: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+
+      - name: Format check
+        run: cargo fmt -p larql-router -p larql-router-protocol -- --check
+
+      - name: Check lib + tests + benches
+        run: cargo check -p larql-router --target ${{ matrix.target }} --lib --tests --benches
+
+      - name: Check protocol
+        run: cargo check -p larql-router-protocol --target ${{ matrix.target }} --lib
+
+      - name: Clippy (router)
+        run: cargo clippy -p larql-router --target ${{ matrix.target }} --lib --tests --benches --no-deps -- -D warnings
+
+      - name: Clippy (protocol)
+        run: cargo clippy -p larql-router-protocol --target ${{ matrix.target }} --lib --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-router --target ${{ matrix.target }}
+
+      - name: Tests (protocol)
+        run: cargo test -p larql-router-protocol --target ${{ matrix.target }}
+
+      - name: Benchmark compile/tests
+        run: cargo test -p larql-router --target ${{ matrix.target }} --benches
+
+  coverage:
+    name: coverage · ubuntu
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary (router)
+        run: cargo llvm-cov --package larql-router --summary-only
+
+      - name: Coverage summary (protocol)
+        run: cargo llvm-cov --package larql-router-protocol --summary-only

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -1,0 +1,231 @@
+# larql-server cross-platform CI
+#
+# HTTP/gRPC inference server (vindex queries, OpenAI-compat, remote MoE
+# expert shards). Build script bundles `protoc` via `protobuf_src`, so
+# no system protoc install is required on any runner. Tests are split
+# across many `test_http_*`, `test_grpc`, and `test_unit_*` files; all
+# run cross-platform without real model weights.
+
+name: larql-server
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-server/**'
+      - 'crates/larql-router-protocol/**'
+      - 'crates/larql-vindex/**'
+      - 'crates/larql-inference/src/**'
+      - 'crates/larql-models/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-server.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-server/**'
+      - 'crates/larql-router-protocol/**'
+      - 'crates/larql-vindex/**'
+      - 'crates/larql-inference/src/**'
+      - 'crates/larql-models/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-server.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+env:
+  # Existing baseline measured 2026-05-10 in Makefile (see
+  # `LARQL_SERVER_COVERAGE_MIN`). Keep just under the live value to
+  # ratchet upward, never down.
+  LARQL_SERVER_COVERAGE_MIN: 65
+
+jobs:
+  test:
+    if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
+    name: test - ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Install OpenBLAS (Linux)
+        if: matrix.platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install OpenBLAS (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      - name: Install protoc (Windows)
+        if: matrix.platform == 'windows'
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-server-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-server-
+
+      - name: Format check
+        run: cargo fmt -p larql-server -- --check
+
+      - name: Check lib + bins + tests
+        run: cargo check -p larql-server --target ${{ matrix.target }} --lib --bins --tests
+
+      - name: Clippy
+        run: cargo clippy -p larql-server --target ${{ matrix.target }} --lib --bins --tests --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-server --target ${{ matrix.target }}
+
+  coverage:
+    needs: [test]
+    if: success() && (github.event.pull_request.draft != true || github.event_name != 'pull_request')
+    name: coverage - ubuntu
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary
+        run: cargo llvm-cov --package larql-server --summary-only --fail-under-lines "$LARQL_SERVER_COVERAGE_MIN"
+
+      - name: Coverage policy
+        run: |
+          mkdir -p coverage/larql-server
+          cargo llvm-cov report --package larql-server --json --summary-only --output-path coverage/larql-server/summary.json
+          python3 scripts/check_coverage_policy.py coverage/larql-server/summary.json crates/larql-server/coverage-policy.json

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -13,7 +13,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-server/**'
       - 'crates/larql-router-protocol/**'
@@ -26,7 +26,7 @@ on:
       - '.github/workflows/larql-server.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-server/**'
       - 'crates/larql-router-protocol/**'

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -1,0 +1,220 @@
+# larql-vindex cross-platform CI
+#
+# The crate checks here are model/model-architecture agnostic: no HuggingFace
+# downloads, no real model weights, and no platform-specific GPU backends.
+# Tests and examples use synthetic fixtures or compile-only checks so the same
+# surface runs on Linux, Windows, and macOS.
+
+name: larql-vindex
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-vindex/**'
+      - 'crates/larql-lql/src/executor/lifecycle/compile/into_vindex.rs'
+      - 'crates/larql-compute/src/cpu/ops/q4k_q8k_dot.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-vindex.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/larql-vindex/**'
+      - 'crates/larql-lql/src/executor/lifecycle/compile/into_vindex.rs'
+      - 'crates/larql-compute/src/cpu/ops/q4k_q8k_dot.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/larql-vindex.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+env:
+  LARQL_VINDEX_COVERAGE_MIN: 71
+
+jobs:
+  test:
+    name: test - ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Install OpenBLAS (Linux)
+        if: matrix.platform == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install OpenBLAS (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          & "$vcpkgRoot\vcpkg.exe" install openblas:x64-windows
+
+      - name: Cache cargo registry + build artefacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-vindex-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-vindex-
+
+      - name: Format check
+        run: cargo fmt -p larql-vindex -- --check
+
+      - name: Check all targets
+        run: cargo check -p larql-vindex --target ${{ matrix.target }} --all-targets
+
+      - name: Check examples
+        run: cargo check -p larql-vindex --target ${{ matrix.target }} --examples
+
+      - name: Clippy
+        run: cargo clippy -p larql-vindex --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Tests
+        run: cargo test -p larql-vindex --target ${{ matrix.target }}
+
+      - name: Benchmark compile/tests
+        run: cargo test -p larql-vindex --target ${{ matrix.target }} --benches
+
+  coverage:
+    name: coverage - ubuntu
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary
+        run: cargo llvm-cov --package larql-vindex --summary-only --fail-under-lines "$LARQL_VINDEX_COVERAGE_MIN"
+
+      - name: Coverage policy
+        run: |
+          mkdir -p coverage/larql-vindex
+          cargo llvm-cov report --package larql-vindex --json --summary-only --output-path coverage/larql-vindex/summary.json
+          python3 scripts/check_coverage_policy.py coverage/larql-vindex/summary.json crates/larql-vindex/coverage-policy.json

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -12,7 +12,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-vindex/**'
       - 'crates/larql-lql/src/executor/lifecycle/compile/into_vindex.rs'
@@ -23,7 +23,7 @@ on:
       - '.github/workflows/larql-vindex.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-vindex/**'
       - 'crates/larql-lql/src/executor/lifecycle/compile/into_vindex.rs'

--- a/.github/workflows/model-compute.yml
+++ b/.github/workflows/model-compute.yml
@@ -9,7 +9,7 @@ name: model-compute
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/model-compute/**'
       - 'Cargo.toml'
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/model-compute.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/model-compute/**'
       - 'Cargo.toml'

--- a/.github/workflows/model-compute.yml
+++ b/.github/workflows/model-compute.yml
@@ -1,0 +1,205 @@
+# model-compute WASM + native kernels CI
+#
+# Tests both the native (default) and WASM compute backends on Linux, Windows,
+# and macOS. The WASM backend uses wasmi (pure-Rust interpreter, runs on all
+# targets including arm32). The optional wasm-jit feature (wasmtime) only runs
+# on 64-bit platforms.
+
+name: model-compute
+
+on:
+  push:
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/model-compute/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/model-compute.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, ci/workflows-complete]
+    paths:
+      - 'crates/model-compute/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Makefile'
+      - '.github/workflows/model-compute.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  test:
+    if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
+    name: test · ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            runner: ubuntu-24.04
+            platform: ubuntu
+            target: x86_64-unknown-linux-gnu
+
+          - name: windows-latest
+            runner: windows-latest
+            platform: windows
+            target: x86_64-pc-windows-msvc
+
+          - name: macos-15-arm64
+            runner: macos-15
+            platform: macos
+            target: aarch64-apple-darwin
+
+          - name: android-aarch64
+            runner: ubuntu-24.04
+            platform: android
+            target: aarch64-linux-android
+
+          - name: android-armv7
+            runner: ubuntu-24.04
+            platform: android
+            target: armv7-linux-androideabi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install Android NDK
+        if: matrix.platform == 'android'
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27
+          link-to-sdk: true
+
+      - name: Add Android NDK to PATH
+        if: matrix.platform == 'android'
+        run: echo "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Add Android target
+        if: matrix.platform == 'android'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Set Android NDK compiler vars (aarch64)
+        if: matrix.platform == 'android' && matrix.target == 'aarch64-linux-android'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CC=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang" >> $GITHUB_ENV
+          echo "CXX_aarch64_linux_android=${NDK_BIN}/aarch64-linux-android21-clang++" >> $GITHUB_ENV
+          echo "AR_aarch64_linux_android=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set Android NDK compiler vars (armv7)
+        if: matrix.platform == 'android' && matrix.target == 'armv7-linux-androideabi'
+        run: |
+          NDK_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CC=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_CXX=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_AR=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+          echo "CC_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang" >> $GITHUB_ENV
+          echo "CXX_armv7_linux_androideabi=${NDK_BIN}/armv7a-linux-androideabi21-clang++" >> $GITHUB_ENV
+          echo "AR_armv7_linux_androideabi=${NDK_BIN}/llvm-ar" >> $GITHUB_ENV
+
+      - name: Set up QEMU for Android emulation
+        if: matrix.platform == 'android'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Enable static CRT and redirect libc++_shared for Android
+        if: matrix.platform == 'android'
+        run: |
+          echo "RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static" >> $GITHUB_ENV
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+          NDK_SYSROOT="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          LIBUNWIND_AARCH64=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/aarch64*" | head -1)
+          LIBUNWIND_ARM=$(find "${ANDROID_NDK_HOME}" -name "libunwind.a" -path "*/linux/arm*" ! -path "*/aarch64*" | head -1)
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_static.a ${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++abi.a ${LIBUNWIND_AARCH64})" \
+            > "${NDK_SYSROOT}/usr/lib/aarch64-linux-android/libc++_shared.a"
+          echo "GROUP(${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_static.a ${LIBUNWIND_ARM})" \
+            > "${NDK_SYSROOT}/usr/lib/arm-linux-androideabi/libc++_shared.a"
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ matrix.target }}-cargo-model-compute
+
+      - name: Format check
+        run: cargo fmt -p model-compute -- --check
+
+      - name: Check (default features)
+        run: cargo check -p model-compute --target ${{ matrix.target }} --all-targets
+
+      - name: Check (native feature)
+        run: cargo check -p model-compute --target ${{ matrix.target }} --no-default-features --features native --all-targets
+
+      - name: Check (wasm feature)
+        run: cargo check -p model-compute --target ${{ matrix.target }} --no-default-features --features wasm --all-targets
+
+      - name: Clippy
+        run: cargo clippy -p model-compute --target ${{ matrix.target }} --all-targets -- -D warnings
+
+      - name: Tests (default features)
+        if: matrix.platform != 'android'
+        run: cargo test -p model-compute --target ${{ matrix.target }}
+
+      - name: Tests (default features, Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p model-compute --target ${{ matrix.target }} --lib --tests
+
+      - name: Tests (native feature)
+        if: matrix.platform != 'android'
+        run: cargo test -p model-compute --target ${{ matrix.target }} --no-default-features --features native
+
+      - name: Tests (native feature, Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p model-compute --target ${{ matrix.target }} --no-default-features --features native --lib --tests
+
+      - name: Tests (wasm feature)
+        if: matrix.platform != 'android'
+        run: cargo test -p model-compute --target ${{ matrix.target }} --no-default-features --features wasm
+
+      - name: Tests (wasm feature, Android)
+        if: matrix.platform == 'android'
+        run: cargo test -p model-compute --target ${{ matrix.target }} --no-default-features --features wasm --lib --tests
+
+      - name: Benchmark compile/tests
+        run: cargo test -p model-compute --target ${{ matrix.target }} --benches
+
+  coverage:
+    needs: [test]
+    if: success() && (github.event.pull_request.draft != true || github.event_name != 'pull_request')
+    name: coverage · ubuntu
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage summary
+        run: cargo llvm-cov --package model-compute --summary-only

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,9 +28,9 @@ name: quality
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
   workflow_dispatch:
   schedule:
     # Weekly RustSec advisory refresh against the committed lockfile, so

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,9 +17,9 @@ name: validate
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -67,13 +67,13 @@ jobs:
           - { name: larql-router-protocol, cargo_flags: ''                                       }
           - { name: larql-router,          cargo_flags: ''                                       }
           - { name: larql-server,          cargo_flags: '--no-default-features'                  }
-          # Blocked — failures identify what needs porting
+          - { name: larql-vindex,          cargo_flags: '--no-default-features'                  }
           - { name: larql-inference,       cargo_flags: '--no-default-features'                  }
           - { name: larql-kv,              cargo_flags: '--no-default-features'                  }
-          - { name: larql-lql,             cargo_flags: '--no-default-features'                  }
-          - { name: larql-vindex,          cargo_flags: '--no-default-features'                  }
-          - { name: larql-cli,             cargo_flags: '--no-default-features'                  }
           - { name: kv-cache-benchmark,    cargo_flags: '--no-default-features'                  }
+          - { name: larql-lql,             cargo_flags: '--no-default-features'                  }
+          - { name: larql-cli,             cargo_flags: '--no-default-features'                  }
+          # Blocked — failures identify what needs porting
           - { name: larql-python,          cargo_flags: '--no-default-features'                  }
 
         # ── Build modes ───────────────────────────────────────────────────

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -63,11 +63,11 @@ jobs:
           - { name: larql-core,            cargo_flags: '--no-default-features'                  }
           - { name: larql-models,          cargo_flags: '--no-default-features'                  }
           - { name: model-compute,         cargo_flags: '--no-default-features --features wasm'  }
+          - { name: larql-compute,         cargo_flags: '--no-default-features'                  }
           - { name: larql-router-protocol, cargo_flags: ''                                       }
           - { name: larql-router,          cargo_flags: ''                                       }
           - { name: larql-server,          cargo_flags: '--no-default-features'                  }
           # Blocked — failures identify what needs porting
-          - { name: larql-compute,         cargo_flags: '--no-default-features'                  }
           - { name: larql-inference,       cargo_flags: '--no-default-features'                  }
           - { name: larql-kv,              cargo_flags: '--no-default-features'                  }
           - { name: larql-lql,             cargo_flags: '--no-default-features'                  }

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -63,15 +63,15 @@ jobs:
           - { name: larql-core,            cargo_flags: '--no-default-features'                  }
           - { name: larql-models,          cargo_flags: '--no-default-features'                  }
           - { name: model-compute,         cargo_flags: '--no-default-features --features wasm'  }
+          - { name: larql-router-protocol, cargo_flags: ''                                       }
+          - { name: larql-router,          cargo_flags: ''                                       }
+          - { name: larql-server,          cargo_flags: '--no-default-features'                  }
           # Blocked — failures identify what needs porting
           - { name: larql-compute,         cargo_flags: '--no-default-features'                  }
           - { name: larql-inference,       cargo_flags: '--no-default-features'                  }
           - { name: larql-kv,              cargo_flags: '--no-default-features'                  }
           - { name: larql-lql,             cargo_flags: '--no-default-features'                  }
           - { name: larql-vindex,          cargo_flags: '--no-default-features'                  }
-          - { name: larql-server,          cargo_flags: '--no-default-features'                  }
-          - { name: larql-router,          cargo_flags: ''                                       }
-          - { name: larql-router-protocol, cargo_flags: ''                                       }
           - { name: larql-cli,             cargo_flags: '--no-default-features'                  }
           - { name: kv-cache-benchmark,    cargo_flags: '--no-default-features'                  }
           - { name: larql-python,          cargo_flags: '--no-default-features'                  }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Gate source-level tonic/tokio/axum types and native-only server modules behind `#[cfg(not(target_arch = "wasm32"))]`; larql-router-protocol, larql-router, and larql-server now pass `cargo check --target wasm32-unknown-unknown`
 - Gate source-level reqwest::blocking/hf-hub references in larql-vindex (huggingface module), larql-inference (remote/moe_remote FFN modules), and larql-lql (Remote backend variant, executor/remote module); promote larql-compute from Blocked to Passing in wasm CI matrix
 - Gate larql-core HttpProvider (reqwest::blocking) behind not(wasm32) in addition to http feature; gate vindexfile huggingface path resolver behind not(wasm32)
+- Gate rustyline REPL and HF/remote path resolution in larql-lql behind not(wasm32); gate HF/remote FFN commands in larql-cli (hf_cmd, ffn_latency_cmd, model_cmd, publish_cmd, pull_cmd, bench/walk/run remote paths) behind not(wasm32); promote larql-vindex, larql-inference, larql-kv, kv-cache-benchmark, larql-lql, larql-cli from Blocked to Passing in wasm CI matrix
 - Gate sdot on dotprod feature and add QEMU emulation for tests
 - Gate trace_final_residual_matches_raw_forward_logits
 - Move wasm-pack flags before crate path for latest wasm-pack compat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Gate metal-only code behind target_os = "macos" so the workspace builds on Linux
 - Gate orphan items in vindex test + cover second lql bench
 - Gate source-level tonic/tokio/axum types and native-only server modules behind `#[cfg(not(target_arch = "wasm32"))]`; larql-router-protocol, larql-router, and larql-server now pass `cargo check --target wasm32-unknown-unknown`
+- Gate source-level reqwest::blocking/hf-hub references in larql-vindex (huggingface module), larql-inference (remote/moe_remote FFN modules), and larql-lql (Remote backend variant, executor/remote module); promote larql-compute from Blocked to Passing in wasm CI matrix
 - Gate sdot on dotprod feature and add QEMU emulation for tests
 - Gate trace_final_residual_matches_raw_forward_logits
 - Move wasm-pack flags before crate path for latest wasm-pack compat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Gate orphan items in vindex test + cover second lql bench
 - Gate source-level tonic/tokio/axum types and native-only server modules behind `#[cfg(not(target_arch = "wasm32"))]`; larql-router-protocol, larql-router, and larql-server now pass `cargo check --target wasm32-unknown-unknown`
 - Gate source-level reqwest::blocking/hf-hub references in larql-vindex (huggingface module), larql-inference (remote/moe_remote FFN modules), and larql-lql (Remote backend variant, executor/remote module); promote larql-compute from Blocked to Passing in wasm CI matrix
+- Gate larql-core HttpProvider (reqwest::blocking) behind not(wasm32) in addition to http feature; gate vindexfile huggingface path resolver behind not(wasm32)
 - Gate sdot on dotprod feature and add QEMU emulation for tests
 - Gate trace_final_residual_matches_raw_forward_logits
 - Move wasm-pack flags before crate path for latest wasm-pack compat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - Gate metal-only code behind target_os = "macos" (#48)
 - Gate metal-only code behind target_os = "macos" so the workspace builds on Linux
 - Gate orphan items in vindex test + cover second lql bench
+- Gate source-level tonic/tokio/axum types and native-only server modules behind `#[cfg(not(target_arch = "wasm32"))]`; larql-router-protocol, larql-router, and larql-server now pass `cargo check --target wasm32-unknown-unknown`
 - Gate sdot on dotprod feature and add QEMU emulation for tests
 - Gate trace_final_residual_matches_raw_forward_logits
 - Move wasm-pack flags before crate path for latest wasm-pack compat

--- a/crates/larql-cli/Cargo.toml
+++ b/crates/larql-cli/Cargo.toml
@@ -48,3 +48,4 @@ tokenizers = "0.21"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true }
+tokenizers = { version = "0.21", default-features = false, features = ["unstable_wasm"] }

--- a/crates/larql-cli/src/commands/extraction/bfs_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/bfs_cmd.rs
@@ -117,17 +117,24 @@ pub fn run(args: BfsArgs) -> Result<(), Box<dyn std::error::Error>> {
         };
         Box::new(larql_core::engine::mock_provider::MockProvider::with_knowledge(knowledge))
     } else {
-        let endpoint = args
-            .endpoint
-            .as_deref()
-            .unwrap_or("http://localhost:11434/v1");
-        let model = args
-            .model
-            .as_deref()
-            .ok_or("--model required when not using --mock")?;
-        Box::new(larql_core::engine::http_provider::HttpProvider::new(
-            endpoint, model,
-        ))
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let endpoint = args
+                .endpoint
+                .as_deref()
+                .unwrap_or("http://localhost:11434/v1");
+            let model = args
+                .model
+                .as_deref()
+                .ok_or("--model required when not using --mock")?;
+            Box::new(larql_core::engine::http_provider::HttpProvider::new(
+                endpoint, model,
+            )) as Box<dyn ModelProvider>
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            return Err("HTTP provider is not available in WASM builds; use --mock".into());
+        }
     };
 
     let seeds: Vec<String> = args

--- a/crates/larql-cli/src/commands/extraction/mod.rs
+++ b/crates/larql-cli/src/commands/extraction/mod.rs
@@ -10,9 +10,11 @@ pub mod convert_cmd;
 pub mod embedding_jump_cmd;
 pub mod extract_index_cmd;
 pub mod ffn_bottleneck_cmd;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod ffn_latency_cmd;
 pub mod ffn_overlap_cmd;
 pub mod fingerprint_extract_cmd;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod hf_cmd;
 pub mod index_gates_cmd;
 pub mod kg_bench_cmd;

--- a/crates/larql-cli/src/commands/extraction/walk_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/walk_cmd.rs
@@ -26,8 +26,10 @@ fn rss_mb() -> f64 {
 use clap::Args;
 use larql_inference::{
     predict_with_ffn, predict_with_router, vindex::WalkFfn, InferenceModel, LayerFfnRouter,
-    LayerShardedBackend, ModelWeights, SparseFfn, WeightFfn,
+    ModelWeights, SparseFfn, WeightFfn,
 };
+#[cfg(not(target_arch = "wasm32"))]
+use larql_inference::LayerShardedBackend;
 use larql_vindex::{
     load_vindex_embeddings, load_vindex_tokenizer, ndarray, tokenizers, IndexLoadCallbacks,
     SilentLoadCallbacks, VectorIndex,
@@ -413,6 +415,7 @@ fn run_with_vindex_weights(
         // RSS now = attn weights + embeddings + norms. FFN payload (gate_vectors,
         // interleaved_q4k) is demand-paged; pages fault in during inference.
         vlog!(verbose, "  RSS after weights: {:.1} GB", rss_mb() / 1024.0);
+        #[cfg(not(target_arch = "wasm32"))]
         if args.ffn_remote.is_some() {
             return run_predict_q4k_remote(&mut weights, &tokenizer, args, vindex_path);
         }
@@ -607,6 +610,7 @@ fn run_predict_q4k(
 /// Q4K dequant. So instead of routing through `run_predict_remote` we call
 /// `predict_q4k_with_ffn` directly with a `RemoteWalkBackend` — that path
 /// dequantises only Q/K/V/O per layer and skips the FFN dequant entirely.
+#[cfg(not(target_arch = "wasm32"))]
 fn run_predict_q4k_remote(
     weights: &mut ModelWeights,
     tokenizer: &tokenizers::Tokenizer,
@@ -741,6 +745,7 @@ fn run_predict_inner(
     // Remote FFN short-circuit: attention runs locally, FFN hits the server
     // per layer. Mutually exclusive with --compare (the comparison backends
     // need local FFN weights to diff against).
+    #[cfg(not(target_arch = "wasm32"))]
     if let Some(ref url) = args.ffn_remote {
         if args.compare {
             return Err("--compare is incompatible with --ffn-remote \
@@ -888,6 +893,7 @@ fn run_predict_inner(
 /// backend and `crates/larql-server/src/routes/walk_ffn.rs` for the
 /// server endpoint.
 ///
+#[cfg(not(target_arch = "wasm32"))]
 fn run_predict_remote(
     weights: &ModelWeights,
     tokenizer: &tokenizers::Tokenizer,

--- a/crates/larql-cli/src/commands/primary/bench_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/bench_cmd.rs
@@ -363,6 +363,7 @@ pub fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     if let Some(ref ffn_url) = args.ffn {
         if let Some(ref wire_list) = args.wire {
             // Wire format comparison: run once per requested format.
@@ -385,6 +386,7 @@ pub fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     if let Some(ref shards_str) = args.moe_shards {
         if args.bench_grid {
             // Grid scaling sweep: run with 1..N shards from the shard map.
@@ -874,6 +876,7 @@ fn run_engine_q4k(
 /// Reports overall tok/s plus a breakdown:
 ///   ffn-rtt  — time spent in the remote FFN closure (all layers summed)
 ///   attn+    — remainder = local attn + norm + lm_head + embed
+#[cfg(not(target_arch = "wasm32"))]
 fn run_remote_ffn_bench(
     vindex_path: &std::path::Path,
     args: &BenchArgs,
@@ -1054,6 +1057,7 @@ fn run_remote_ffn_bench(
 /// Reports overall tok/s plus a breakdown:
 ///   expert-rtt  — time spent in remote expert dispatch per token
 ///   attn+       — remainder = local attn + router + dense FFN
+#[cfg(not(target_arch = "wasm32"))]
 fn run_remote_moe_bench(
     vindex_path: &std::path::Path,
     args: &BenchArgs,

--- a/crates/larql-cli/src/commands/primary/cache.rs
+++ b/crates/larql-cli/src/commands/primary/cache.rs
@@ -248,7 +248,10 @@ pub fn resolve_shorthand_from(
 pub fn resolve_model(model: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
     // 1. hf:// URI — defer to the vindex crate. Downloads if not cached.
     if model.starts_with("hf://") {
+        #[cfg(not(target_arch = "wasm32"))]
         return Ok(larql_vindex::resolve_hf_vindex(model)?);
+        #[cfg(target_arch = "wasm32")]
+        return Err("HuggingFace paths are not supported in WASM builds".into());
     }
 
     // 2. Already a local directory.
@@ -267,7 +270,13 @@ pub fn resolve_model(model: &str) -> Result<PathBuf, Box<dyn std::error::Error>>
         if let Some(hit) = cache.iter().find(|c| c.repo == model) {
             return Ok(hit.snapshot.clone());
         }
+        #[cfg(not(target_arch = "wasm32"))]
         return Ok(larql_vindex::resolve_hf_vindex(&format!("hf://{model}"))?);
+        #[cfg(target_arch = "wasm32")]
+        return Err(format!(
+            "HuggingFace repo '{model}' requires network access (not available in WASM)"
+        )
+        .into());
     }
 
     // 4. Plain name — look up by cache shorthand.

--- a/crates/larql-cli/src/commands/primary/mod.rs
+++ b/crates/larql-cli/src/commands/primary/mod.rs
@@ -9,8 +9,11 @@ pub mod cache;
 pub mod diag_cmd;
 pub mod link_cmd;
 pub mod list_cmd;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod model_cmd;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod publish_cmd;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod pull_cmd;
 pub mod rm_cmd;
 pub mod run_cmd;

--- a/crates/larql-cli/src/commands/primary/run_cmd.rs
+++ b/crates/larql-cli/src/commands/primary/run_cmd.rs
@@ -238,6 +238,7 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
         return experts::run(&vindex_path, &args);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     if let Some(ref ffn_url) = args.ffn {
         let prompt = args.prompt.as_deref().ok_or(
             "--ffn requires a prompt argument (chat mode not yet supported with --ffn-dispatch batch)",
@@ -261,6 +262,7 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
                 .into(),
         );
     }
+    #[cfg(not(target_arch = "wasm32"))]
     if args.moe_shards.is_some() || args.moe_units_manifest.is_some() {
         let prompt = args.prompt.as_deref().ok_or(
             "--moe-shards / --moe-units-manifest requires a prompt argument \
@@ -370,6 +372,7 @@ fn build_walk_args(
 /// Metal runs attention + dense FFN on GPU (same as normal `larql run --metal`).
 /// MoE expert blocks are dispatched to remote mini-processes via binary
 /// `POST /v1/expert/batch` instead of running locally.
+#[cfg(not(target_arch = "wasm32"))]
 fn run_with_moe_shards(
     vindex_path: &std::path::Path,
     prompt: &str,
@@ -543,6 +546,7 @@ fn run_with_moe_shards(
 /// This is analogous to `run_with_moe_shards` for hybrid-MoE models, but
 /// simpler: there is no local FFN and no router — every layer unconditionally
 /// calls the remote server.
+#[cfg(not(target_arch = "wasm32"))]
 fn run_with_remote_ffn(
     vindex_path: &std::path::Path,
     prompt: &str,

--- a/crates/larql-cli/src/main.rs
+++ b/crates/larql-cli/src/main.rs
@@ -61,11 +61,13 @@ enum Commands {
     Chat(ChatArgs),
 
     /// Download a vindex from HuggingFace and cache it locally.
+    #[cfg(not(target_arch = "wasm32"))]
     Pull(pull_cmd::PullArgs),
 
     /// Manage HuggingFace *model* repos (safetensors + tokenizer + config).
     /// Companion to `pull` (which is vindex-only). Use `model pull` to
     /// stage a raw HF model for `convert safetensors-to-vindex`.
+    #[cfg(not(target_arch = "wasm32"))]
     Model(model_cmd::ModelArgs),
 
     /// Register a local vindex directory with the cache so `run` / `list`
@@ -82,6 +84,7 @@ enum Commands {
     Slice(slice_cmd::SliceArgs),
 
     /// Publish a vindex to HuggingFace — full vindex plus slice siblings.
+    #[cfg(not(target_arch = "wasm32"))]
     Publish(publish_cmd::PublishArgs),
 
     /// Remove a cached vindex.
@@ -129,6 +132,7 @@ enum Commands {
     /// Convert between model formats (GGUF ↔ vindex, safetensors → vindex).
     Convert(convert_cmd::ConvertArgs),
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[command(next_help_heading = "Build")]
     /// HuggingFace Hub: upload a vindex.
     Hf(hf_cmd::HfArgs),
@@ -260,6 +264,7 @@ enum DevCommand {
     Bfs(bfs_cmd::BfsArgs),
 
     /// Measure round-trip latency breakdown against a remote FFN server.
+    #[cfg(not(target_arch = "wasm32"))]
     FfnLatency(ffn_latency_cmd::FfnLatencyArgs),
 }
 
@@ -536,12 +541,15 @@ fn real_main() -> i32 {
         Commands::Chat(args) => run_cmd::run(args.into()),
         Commands::Bench(args) => bench_cmd::run(args),
         Commands::Shannon(cmd) => shannon_cmd::run(cmd),
+        #[cfg(not(target_arch = "wasm32"))]
         Commands::Pull(args) => pull_cmd::run(args),
+        #[cfg(not(target_arch = "wasm32"))]
         Commands::Model(args) => model_cmd::run(args),
         Commands::Link(args) => link_cmd::run(args),
         Commands::List(args) => list_cmd::run(args),
         Commands::Show(args) => show_cmd::run(args),
         Commands::Slice(args) => slice_cmd::run(args),
+        #[cfg(not(target_arch = "wasm32"))]
         Commands::Publish(args) => publish_cmd::run(args),
         Commands::Rm(args) => rm_cmd::run(args),
 
@@ -551,6 +559,7 @@ fn real_main() -> i32 {
         Commands::Build(args) => build_cmd::run(args),
         Commands::Compile(args) => compile_cmd::run(args),
         Commands::Convert(args) => convert_cmd::run(args),
+        #[cfg(not(target_arch = "wasm32"))]
         Commands::Hf(args) => hf_cmd::run(args),
         Commands::Verify(args) => verify_cmd::run(args),
         Commands::Diag(args) => diag_cmd::run(args),
@@ -619,6 +628,7 @@ fn run_dev(cmd: DevCommand) -> Result<(), Box<dyn std::error::Error>> {
         DevCommand::BottleneckTest(a) => bottleneck_test_cmd::run(a),
         DevCommand::EmbeddingJump(a) => embedding_jump_cmd::run(a),
         DevCommand::Bfs(a) => bfs_cmd::run(a),
+        #[cfg(not(target_arch = "wasm32"))]
         DevCommand::FfnLatency(a) => ffn_latency_cmd::run(a),
     }
 }

--- a/crates/larql-core/src/engine/http_provider.rs
+++ b/crates/larql-core/src/engine/http_provider.rs
@@ -1,21 +1,21 @@
-#[cfg(feature = "http")]
+#[cfg(all(feature = "http", not(target_arch = "wasm32")))]
 use reqwest::blocking::Client;
 
 use super::provider::*;
 
-#[cfg(feature = "http")]
+#[cfg(all(feature = "http", not(target_arch = "wasm32")))]
 const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 60;
 
 /// Connects to any OpenAI-compatible completions API.
 /// Works with: ollama, vLLM, llama.cpp server, LM Studio.
-#[cfg(feature = "http")]
+#[cfg(all(feature = "http", not(target_arch = "wasm32")))]
 pub struct HttpProvider {
     client: Client,
     base_url: String,
     name: String,
 }
 
-#[cfg(feature = "http")]
+#[cfg(all(feature = "http", not(target_arch = "wasm32")))]
 impl HttpProvider {
     pub fn new(base_url: impl Into<String>, model: impl Into<String>) -> Self {
         Self {
@@ -39,7 +39,7 @@ impl HttpProvider {
     }
 }
 
-#[cfg(feature = "http")]
+#[cfg(all(feature = "http", not(target_arch = "wasm32")))]
 impl ModelProvider for HttpProvider {
     fn model_name(&self) -> &str {
         &self.name

--- a/crates/larql-inference/src/ffn/mod.rs
+++ b/crates/larql-inference/src/ffn/mod.rs
@@ -8,7 +8,9 @@
 //! production dispatch.
 
 pub mod graph_backend;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod moe_remote;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod remote;
 pub mod sparse;
 pub mod sparse_compute;
@@ -52,7 +54,9 @@ pub trait FfnBackend {
 
 // ── Re-exports ──
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use moe_remote::{MoeRouterWeights, RemoteMoeBackend, RemoteMoeError, ShardConfig};
+#[cfg(not(target_arch = "wasm32"))]
 pub use remote::{
     LayerShardedBackend, RemoteFfnConfig, RemoteFfnError, RemoteLatencyStats, RemoteWalkBackend,
     WirePreference,

--- a/crates/larql-inference/src/layer_graph/mod.rs
+++ b/crates/larql-inference/src/layer_graph/mod.rs
@@ -15,6 +15,7 @@
 mod cached;
 mod dense;
 pub mod generate;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod grid;
 pub mod hybrid;
 pub mod logits;

--- a/crates/larql-inference/src/lib.rs
+++ b/crates/larql-inference/src/lib.rs
@@ -98,10 +98,11 @@ pub use capture::{
 pub use chat::{wrap_chat_prompt, wrap_prompt_raw, wrap_with_vindex_template, ChatWrap};
 pub use error::InferenceError;
 pub use ffn::graph_backend::{GateIndex, IndexBuildCallbacks, SilentIndexCallbacks};
+pub use ffn::{BackendFfn, FfnBackend, LayerFfnRouter, SparseFfn, WeightFfn};
+#[cfg(not(target_arch = "wasm32"))]
 pub use ffn::{
-    BackendFfn, FfnBackend, LayerFfnRouter, LayerShardedBackend, MoeRouterWeights, RemoteFfnConfig,
-    RemoteFfnError, RemoteLatencyStats, RemoteMoeBackend, RemoteMoeError, RemoteWalkBackend,
-    ShardConfig, SparseFfn, WeightFfn, WirePreference,
+    LayerShardedBackend, MoeRouterWeights, RemoteFfnConfig, RemoteFfnError, RemoteLatencyStats,
+    RemoteMoeBackend, RemoteMoeError, RemoteWalkBackend, ShardConfig, WirePreference,
 };
 // Crate-root forward re-exports — kept for any name with external use OR
 // in-crate examples/tests/benches that already import from the root. The
@@ -138,11 +139,6 @@ pub use layer_graph::{
     generate,
     generate_streaming,
     generate_with_sampling,
-    // Expert grid generation
-    grid::{
-        generate_with_remote_ffn, generate_with_remote_ffn_batch, generate_with_remote_moe,
-        generate_with_remote_moe_batch,
-    },
     hybrid::predict_hybrid,
     predict_honest,
     predict_pipeline,
@@ -174,6 +170,11 @@ pub use layer_graph::{
     TemplatePattern,
     TemplateUniverse,
     WalkLayerGraph,
+};
+#[cfg(not(target_arch = "wasm32"))]
+pub use layer_graph::grid::{
+    generate_with_remote_ffn, generate_with_remote_ffn_batch, generate_with_remote_moe,
+    generate_with_remote_moe_batch,
 };
 pub use model::{load_model_dir, resolve_model_path, ModelWeights};
 pub use tokenizer::{decode_token, decode_token_raw, encode_prompt, load_tokenizer};

--- a/crates/larql-inference/src/vindex/mod.rs
+++ b/crates/larql-inference/src/vindex/mod.rs
@@ -15,8 +15,8 @@ pub use loader::{open_inference_vindex, ENV_VINDEX_PATH};
 pub(crate) use q4k_forward::generate_q4k_cpu_constrained_streaming_sampled_with_eos;
 pub use q4k_forward::{
     generate_q4k_cpu, generate_q4k_cpu_constrained, generate_q4k_cpu_constrained_streaming,
-    generate_q4k_cpu_constrained_streaming_sampled, generate_q4k_cpu_remote,
-    insert_q4k_layer_tensors, is_end_of_turn, predict_q4k, predict_q4k_hidden,
+    generate_q4k_cpu_constrained_streaming_sampled, insert_q4k_layer_tensors, is_end_of_turn,
+    predict_q4k, predict_q4k_hidden,
     predict_q4k_hidden_hooked, predict_q4k_hidden_with_ffn,
     predict_q4k_hidden_with_mapped_head_residual_delta, predict_q4k_hidden_with_mapped_pre_o_head,
     predict_q4k_hidden_with_original_head_residual_delta,
@@ -27,5 +27,7 @@ pub use q4k_forward::{
     predict_q4k_metal_with_replaced_head_residual_delta, predict_q4k_with_ffn,
     q4k_ffn_forward_layer, q4k_ffn_forward_layer_q8k, remove_layer_tensors,
 };
+#[cfg(not(target_arch = "wasm32"))]
+pub use q4k_forward::generate_q4k_cpu_remote;
 pub use walk_config::WalkFfnConfig;
 pub use walk_ffn::WalkFfn;

--- a/crates/larql-inference/src/vindex/q4k_forward/generation.rs
+++ b/crates/larql-inference/src/vindex/q4k_forward/generation.rs
@@ -65,6 +65,7 @@ pub fn generate_q4k_cpu(
 
 /// Like [`generate_q4k_cpu`] but dispatches MoE expert matmuls to remote shard
 /// servers via [`crate::ffn::RemoteMoeBackend`].
+#[cfg(not(target_arch = "wasm32"))]
 pub fn generate_q4k_cpu_remote(
     weights: &mut ModelWeights,
     tokenizer: &Tokenizer,

--- a/crates/larql-inference/src/vindex/q4k_forward/hidden.rs
+++ b/crates/larql-inference/src/vindex/q4k_forward/hidden.rs
@@ -11,6 +11,13 @@ use crate::forward::run_layer_with_ffn;
 
 use super::tensors::{insert_q4k_layer_tensors, remove_layer_tensors};
 
+// On wasm32 the remote-MoE types are not available; use a zero-sized
+// placeholder so callers that always pass `None` keep the same call signature.
+#[cfg(not(target_arch = "wasm32"))]
+type MoeRemoteArg<'a> = Option<&'a crate::ffn::RemoteMoeBackend>;
+#[cfg(target_arch = "wasm32")]
+type MoeRemoteArg<'a> = Option<&'a ()>;
+
 /// Compute the final hidden state for `token_ids` against a Q4_K/Q6_K
 /// vindex, dequantising attn + FFN one layer at a time. Returns the
 /// `[seq_len, hidden]` array; caller owns the lm_head step.
@@ -18,7 +25,7 @@ pub fn predict_q4k_hidden(
     weights: &mut ModelWeights,
     token_ids: &[u32],
     index: &VectorIndex,
-    moe_remote: Option<&crate::ffn::RemoteMoeBackend>,
+    moe_remote: MoeRemoteArg<'_>,
 ) -> Array2<f32> {
     let num_layers = weights.num_layers;
     let mut h = embed_tokens_pub(weights, token_ids);
@@ -43,6 +50,7 @@ pub fn predict_q4k_hidden(
         let is_moe_layer = weights.arch.is_hybrid_moe();
         let ffn_backend = crate::ffn::WeightFfn { weights };
         if is_moe_layer {
+            #[cfg(not(target_arch = "wasm32"))]
             if let Some((h_new, kv_out)) = run_moe_layer_cpu(
                 weights,
                 &h,
@@ -87,7 +95,7 @@ pub fn predict_q4k_hidden(
     h
 }
 
-/// Build `MoeRouterWeights` for a single layer from the model's vector store.
+#[cfg(not(target_arch = "wasm32"))]
 fn build_moe_router_weights<'a>(
     weights: &'a larql_models::ModelWeights,
     arch: &dyn larql_models::ModelArchitecture,
@@ -114,7 +122,7 @@ fn build_moe_router_weights<'a>(
     })
 }
 
-/// CPU forward for one hybrid-MoE layer (Gemma 4 26B A4B).
+#[cfg(not(target_arch = "wasm32"))]
 fn run_moe_layer_cpu(
     weights: &ModelWeights,
     h: &Array2<f32>,

--- a/crates/larql-inference/src/vindex/q4k_forward/mod.rs
+++ b/crates/larql-inference/src/vindex/q4k_forward/mod.rs
@@ -20,9 +20,10 @@ mod walk_ffn;
 pub(crate) use generation::generate_q4k_cpu_constrained_streaming_sampled_with_eos;
 pub use generation::{
     generate_q4k_cpu, generate_q4k_cpu_constrained, generate_q4k_cpu_constrained_streaming,
-    generate_q4k_cpu_constrained_streaming_sampled, generate_q4k_cpu_remote, is_end_of_turn,
-    predict_q4k,
+    generate_q4k_cpu_constrained_streaming_sampled, is_end_of_turn, predict_q4k,
 };
+#[cfg(not(target_arch = "wasm32"))]
+pub use generation::generate_q4k_cpu_remote;
 pub use hidden::predict_q4k_hidden;
 pub use hooks::predict_q4k_hidden_hooked;
 pub use interventions::{

--- a/crates/larql-lql/src/executor/backend.rs
+++ b/crates/larql-lql/src/executor/backend.rs
@@ -48,6 +48,7 @@ pub(crate) enum Backend {
     },
     /// Remote server backend — queries forwarded via HTTP.
     /// Local patches can be applied for client-side overlay.
+    #[cfg(not(target_arch = "wasm32"))]
     Remote {
         url: String,
         client: reqwest::blocking::Client,

--- a/crates/larql-lql/src/executor/lifecycle/stats.rs
+++ b/crates/larql-lql/src/executor/lifecycle/stats.rs
@@ -190,6 +190,7 @@ impl Session {
                 out.push("For WALK/DESCRIBE/SELECT/INSERT: EXTRACT into a vindex first.".into());
                 Ok(out)
             }
+            #[cfg(not(target_arch = "wasm32"))]
             Backend::Remote { .. } => self.remote_stats(),
             Backend::None => Err(LqlError::NoBackend),
         }

--- a/crates/larql-lql/src/executor/lifecycle/use_cmd.rs
+++ b/crates/larql-lql/src/executor/lifecycle/use_cmd.rs
@@ -15,10 +15,22 @@ impl Session {
         match target {
             UseTarget::Vindex(path_str) => {
                 // Resolve hf:// paths to local cache
+                #[cfg(not(target_arch = "wasm32"))]
                 let path = if larql_vindex::is_hf_path(path_str) {
                     larql_vindex::resolve_hf_vindex(path_str)
                         .map_err(|e| LqlError::exec("HuggingFace download failed", e))?
                 } else {
+                    let p = PathBuf::from(path_str);
+                    if !p.exists() {
+                        return Err(LqlError::Execution(format!(
+                            "vindex not found: {}",
+                            p.display()
+                        )));
+                    }
+                    p
+                };
+                #[cfg(target_arch = "wasm32")]
+                let path = {
                     let p = PathBuf::from(path_str);
                     if !p.exists() {
                         return Err(LqlError::Execution(format!(
@@ -133,7 +145,12 @@ impl Session {
                 self.auto_patch = false;
                 Ok(out)
             }
+            #[cfg(not(target_arch = "wasm32"))]
             UseTarget::Remote(url) => self.exec_use_remote(url),
+            #[cfg(target_arch = "wasm32")]
+            UseTarget::Remote(_) => Err(LqlError::Execution(
+                "remote backends are not supported in WASM builds".into(),
+            )),
         }
     }
 }

--- a/crates/larql-lql/src/executor/mod.rs
+++ b/crates/larql-lql/src/executor/mod.rs
@@ -11,6 +11,7 @@ mod lifecycle;
 mod memit_persist;
 mod mutation;
 mod query;
+#[cfg(not(target_arch = "wasm32"))]
 mod remote;
 mod trace;
 mod tuning;
@@ -106,6 +107,7 @@ impl Session {
 
     pub fn execute(&mut self, stmt: &Statement) -> Result<Vec<String>, LqlError> {
         // Remote backend: forward supported queries via HTTP.
+        #[cfg(not(target_arch = "wasm32"))]
         if self.is_remote() {
             return self.execute_remote(stmt);
         }
@@ -288,6 +290,7 @@ impl Session {
     }
 
     /// Execute a statement against a remote backend.
+    #[cfg(not(target_arch = "wasm32"))]
     fn execute_remote(&mut self, stmt: &Statement) -> Result<Vec<String>, LqlError> {
         match stmt {
             Statement::Use { target } => self.exec_use(target),
@@ -501,6 +504,11 @@ impl Session {
             }
             None => Err(LqlError::Execution(format!("patch not found: {path}"))),
         }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn is_remote(&self) -> bool {
+        false
     }
 
     /// Bump the LSM epoch + minor/major mutation counters. Called after

--- a/crates/larql-lql/src/repl.rs
+++ b/crates/larql-lql/src/repl.rs
@@ -3,7 +3,9 @@
 use crate::executor::Session;
 use crate::parser;
 
+#[cfg(not(target_arch = "wasm32"))]
 use rustyline::error::ReadlineError;
+#[cfg(not(target_arch = "wasm32"))]
 use rustyline::DefaultEditor;
 
 const BANNER: &str = r#"
@@ -26,6 +28,7 @@ fn dirs_or_home() -> Option<std::path::PathBuf> {
 }
 
 /// Run the interactive REPL.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn run_repl() {
     println!("{BANNER}");
 
@@ -140,6 +143,9 @@ pub fn run_repl() {
 
     println!("Goodbye.");
 }
+
+#[cfg(target_arch = "wasm32")]
+pub fn run_repl() {}
 
 /// Basic fallback REPL without line editing (used if rustyline fails).
 fn run_repl_basic() {

--- a/crates/larql-router-protocol/build.rs
+++ b/crates/larql-router-protocol/build.rs
@@ -14,6 +14,9 @@ fn set_protoc() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+        return Ok(());
+    }
     set_protoc();
     tonic_build::compile_protos("proto/grid.proto")?;
     tonic_build::compile_protos("proto/expert.proto")?;

--- a/crates/larql-router-protocol/src/lib.rs
+++ b/crates/larql-router-protocol/src/lib.rs
@@ -1,19 +1,29 @@
+#[cfg(not(target_arch = "wasm32"))]
 pub mod proto {
     tonic::include_proto!("larql.grid.v1");
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod expert_proto {
     tonic::include_proto!("larql.expert.v1");
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use expert_proto::expert_service_client::ExpertServiceClient;
+#[cfg(not(target_arch = "wasm32"))]
 pub use expert_proto::expert_service_server::{ExpertService, ExpertServiceServer};
+#[cfg(not(target_arch = "wasm32"))]
 pub use expert_proto::{
     ExpertBatchItem, ExpertBatchRequest, ExpertBatchResponse, ExpertBatchResult, ExpertLayerInput,
     ExpertLayerOutput,
 };
+#[cfg(not(target_arch = "wasm32"))]
 pub use proto::grid_service_client::GridServiceClient;
+#[cfg(not(target_arch = "wasm32"))]
 pub use proto::grid_service_server::{GridService, GridServiceServer};
+#[cfg(not(target_arch = "wasm32"))]
 pub use proto::router_message::Payload as RouterPayload;
+#[cfg(not(target_arch = "wasm32"))]
 pub use proto::server_message::Payload as ServerPayload;
+#[cfg(not(target_arch = "wasm32"))]
 pub use proto::*;

--- a/crates/larql-router/src/lib.rs
+++ b/crates/larql-router/src/lib.rs
@@ -1,4 +1,6 @@
 //! larql-router library — exposes grid state for tests and benchmarks.
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod grid;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod rebalancer;

--- a/crates/larql-router/src/main.rs
+++ b/crates/larql-router/src/main.rs
@@ -17,26 +17,44 @@
 //! is supported for JSON only; binary multi-shard requests are rejected with
 //! HTTP 400 (use the batched JSON format or route per-shard manually).
 
+#[cfg(not(target_arch = "wasm32"))]
 use larql_router::grid;
+#[cfg(not(target_arch = "wasm32"))]
 use larql_router::rebalancer;
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
 use std::net::SocketAddr;
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 
+#[cfg(not(target_arch = "wasm32"))]
 use axum::body::Bytes;
+#[cfg(not(target_arch = "wasm32"))]
 use axum::extract::State;
+#[cfg(not(target_arch = "wasm32"))]
 use axum::http::{header, StatusCode};
+#[cfg(not(target_arch = "wasm32"))]
 use axum::response::Response;
+#[cfg(not(target_arch = "wasm32"))]
 use axum::routing::post;
+#[cfg(not(target_arch = "wasm32"))]
 use axum::{Json, Router};
+#[cfg(not(target_arch = "wasm32"))]
 use clap::Parser;
+#[cfg(not(target_arch = "wasm32"))]
 use serde_json::Value;
+#[cfg(not(target_arch = "wasm32"))]
 use tokio::sync::RwLock;
+#[cfg(not(target_arch = "wasm32"))]
 use tonic::transport::Server as GrpcServer;
+#[cfg(not(target_arch = "wasm32"))]
 use tracing::{info, warn};
 
+#[cfg(not(target_arch = "wasm32"))]
 use grid::{GridServiceImpl, GridState};
+#[cfg(not(target_arch = "wasm32"))]
 use larql_router_protocol::GridServiceServer;
 
 // ── Binary wire format constants ───────────────────────────────────────────────
@@ -46,6 +64,7 @@ const BATCH_MARKER: u32 = 0xFFFF_FFFF;
 
 // ── CLI ────────────────────────────────────────────────────────────────────────
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Parser)]
 #[command(
     name = "larql-router",
@@ -179,6 +198,7 @@ pub(crate) fn peek_binary(body: &[u8]) -> Option<Vec<usize>> {
 
 // ── App state ──────────────────────────────────────────────────────────────────
 
+#[cfg(not(target_arch = "wasm32"))]
 struct AppState {
     /// Static shards from --shards (may be empty).
     static_shards: Vec<Shard>,
@@ -187,6 +207,7 @@ struct AppState {
     client: reqwest::Client,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl AppState {
     /// Resolve all layers in one lock acquisition.
     /// Returns Ok(layer → url) or Err(first missing layer).
@@ -233,6 +254,7 @@ impl AppState {
 
 // ── Route handler ──────────────────────────────────────────────────────────────
 
+#[cfg(not(target_arch = "wasm32"))]
 async fn handle_walk_ffn(
     State(state): State<Arc<AppState>>,
     request: axum::extract::Request,
@@ -251,6 +273,7 @@ async fn handle_walk_ffn(
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 async fn handle_walk_ffn_inner(
     state: Arc<AppState>,
     request: axum::extract::Request,
@@ -404,6 +427,7 @@ async fn handle_walk_ffn_inner(
 
 /// Forward raw bytes to a shard, passing the Content-Type header through.
 /// The shard's response status and Content-Type are preserved unchanged.
+#[cfg(not(target_arch = "wasm32"))]
 async fn proxy_raw(
     client: &reqwest::Client,
     base_url: &str,
@@ -438,6 +462,7 @@ async fn proxy_raw(
         .unwrap())
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 async fn handle_health() -> Json<Value> {
     Json(serde_json::json!({"status": "ok"}))
 }
@@ -445,6 +470,7 @@ async fn handle_health() -> Json<Value> {
 /// Proxy /v1/stats to the first reachable shard so that clients connecting
 /// via RemoteWalkBackend (which reads hidden_size from /v1/stats) work
 /// transparently through the router.
+#[cfg(not(target_arch = "wasm32"))]
 async fn handle_stats(State(state): State<Arc<AppState>>) -> Response {
     // Collect candidate shard URLs: grid shards first, then static.
     let mut candidates: Vec<String> = Vec::new();
@@ -483,6 +509,7 @@ async fn handle_stats(State(state): State<Arc<AppState>>) -> Response {
 
 // ── Main ───────────────────────────────────────────────────────────────────────
 
+#[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Accept both `larql-router <args>` and `larql-router route <args>`.
@@ -602,6 +629,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     Ok(())
 }
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}
 
 // ══════════════════════════════════════════════════════════════════════════════
 // Tests

--- a/crates/larql-server/Cargo.toml
+++ b/crates/larql-server/Cargo.toml
@@ -15,15 +15,7 @@ name = "larql-server"
 path = "src/main.rs"
 
 [dependencies]
-larql-vindex = { path = "../larql-vindex" }
-larql-inference = { path = "../larql-inference" }
-larql-models = { path = "../larql-models" }
 larql-router-protocol = { path = "../larql-router-protocol" }
-# Optional Metal backend for shard-side GPU experts (macOS).  When the
-# `metal-experts` feature is enabled, the server uses
-# `MetalBackend::run_experts_preselected_metal` to dispatch each layer's
-# selected experts on the GPU instead of running them per-expert on CPU.
-larql-compute = { path = "../larql-compute" }
 
 half = "2"
 sha2 = "0.10"
@@ -34,13 +26,10 @@ subtle = "2.6"
 prost = "0.13"
 async-stream = "0.3"
 futures = "0.3"
-rayon = "1.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 clap = { version = "4", features = ["derive", "env"] }
-libc = "0.2"
-memmap2 = "0.9"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -63,6 +52,17 @@ tonic-build = "0.13"
 protobuf-src = "2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+larql-vindex = { path = "../larql-vindex" }
+larql-inference = { path = "../larql-inference" }
+larql-models = { path = "../larql-models" }
+# Optional Metal backend for shard-side GPU experts (macOS).  When the
+# `metal-experts` feature is enabled, the server uses
+# `MetalBackend::run_experts_preselected_metal` to dispatch each layer's
+# selected experts on the GPU instead of running them per-expert on CPU.
+larql-compute = { path = "../larql-compute" }
+rayon = "1.10"
+libc = "0.2"
+memmap2 = "0.9"
 axum = { version = "0.8", features = ["ws"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/larql-server/build.rs
+++ b/crates/larql-server/build.rs
@@ -13,6 +13,9 @@ fn set_protoc() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+        return Ok(());
+    }
     set_protoc();
     tonic_build::compile_protos("proto/vindex.proto")?;
     Ok(())

--- a/crates/larql-server/src/lib.rs
+++ b/crates/larql-server/src/lib.rs
@@ -4,24 +4,40 @@
 // for all gRPC handlers, so flipping to Box<Status> is not worth the churn.
 #![allow(clippy::result_large_err)]
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod announce;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod auth;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod band_utils;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod bootstrap;
 pub mod cache;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod embed_store;
 pub mod env_flags;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod error;
 pub mod etag;
 pub mod ffn_l2_cache;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod grpc;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod grpc_expert;
 pub mod http;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod metrics;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod openapi;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod ratelimit;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod routes;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod session;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod shard_loader;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod state;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod wire;

--- a/crates/larql-server/src/main.rs
+++ b/crates/larql-server/src/main.rs
@@ -6,10 +6,13 @@
 //! integration tests can drive the same code path without going through
 //! `clap::Parser::parse_from`.
 
+#[cfg(not(target_arch = "wasm32"))]
 use clap::Parser;
 
+#[cfg(not(target_arch = "wasm32"))]
 use larql_server::bootstrap::{self, normalize_serve_alias, BoxError, Cli};
 
+#[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> Result<(), BoxError> {
     // Accept both `larql-server <path>` and `larql-server serve <path>`.
@@ -24,3 +27,6 @@ async fn main() -> Result<(), BoxError> {
 
     bootstrap::serve(cli).await
 }
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/crates/larql-vindex/src/format/mod.rs
+++ b/crates/larql-vindex/src/format/mod.rs
@@ -5,6 +5,7 @@ pub mod checksums;
 pub mod down_meta;
 pub mod filenames;
 pub mod fp4_codec;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod huggingface;
 pub mod load;
 pub mod quant;

--- a/crates/larql-vindex/src/lib.rs
+++ b/crates/larql-vindex/src/lib.rs
@@ -87,6 +87,7 @@ pub use format::load::{
     load_feature_labels, load_vindex_config, load_vindex_embeddings, load_vindex_tokenizer,
 };
 // Model loading: use larql_models::{load_model_dir, resolve_model_path, load_gguf} directly
+#[cfg(not(target_arch = "wasm32"))]
 pub use format::huggingface::{
     dataset_repo_exists, download_hf_weights, ensure_collection, fetch_collection_items,
     is_hf_path, publish_vindex, publish_vindex_with_opts, repo_exists,

--- a/crates/larql-vindex/src/vindexfile/mod.rs
+++ b/crates/larql-vindex/src/vindexfile/mod.rs
@@ -185,12 +185,22 @@ fn resolve_vindexfile_path(
     path: &str,
     working_dir: &Path,
 ) -> Result<std::path::PathBuf, VindexError> {
+    #[cfg(not(target_arch = "wasm32"))]
     if crate::format::huggingface::is_hf_path(path) {
         // Use the same resolver `larql run` and `larql extract` use
         // — caches under HF's standard cache dir, conditional fetch
         // by ETag. Returns the local snapshot path.
-        crate::format::huggingface::resolve_hf_vindex(path)
-    } else if path.starts_with("https://") || path.starts_with("http://") {
+        return crate::format::huggingface::resolve_hf_vindex(path);
+    }
+    #[cfg(target_arch = "wasm32")]
+    if path.starts_with("hf://") {
+        return Err(VindexError::Parse(
+            "HuggingFace paths are not supported in WASM builds; \
+             download the vindex locally first"
+                .into(),
+        ));
+    }
+    if path.starts_with("https://") || path.starts_with("http://") {
         Err(VindexError::Parse(format!(
             "remote URLs not yet implemented in Vindexfile: {path} \
              — download manually and use a local path"


### PR DESCRIPTION
## Summary

Completes **Blocker 4** of the LARQL WASM portability work. PR 59 already gated the *dependencies* (tokio, tonic, axum, mio) in each crate's `Cargo.toml`, but the *source files* still unconditionally referenced those types — causing `cargo check --target wasm32-unknown-unknown` to fail.

- **larql-router-protocol**: gate `tonic::include_proto!` mod blocks and all gRPC service re-exports behind `#[cfg(not(target_arch = "wasm32"))]`; add wasm32 early-return to `build.rs` to skip protoc invocation
- **larql-router**: gate `pub mod grid; pub mod rebalancer;` in `lib.rs`; gate all axum/tonic/tokio handler functions and the `Cli` struct in `main.rs`; add `#[cfg(target_arch = "wasm32")] fn main() {}` stub; keep pure-Rust items (`parse_shards`, `peek_binary`, `struct Shard`, tests) unconditional
- **larql-server**: move `larql-vindex`, `larql-inference`, `larql-models`, `larql-compute`, `rayon`, `libc`, `memmap2` to `cfg(not(wasm32))` target deps in `Cargo.toml`; add wasm32 early-return to `build.rs`; gate all native-only modules in `lib.rs` (keeping pure-std `cache`, `env_flags`, `etag`, `ffn_l2_cache`, `http` unconditional); gate the `#[tokio::main]` entry point

CI matrix updated: three crates move from **Blocked → Passing** (7 crates now pass, 8 remain blocked).

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p larql-router-protocol` — passes
- [x] `cargo check --target wasm32-unknown-unknown -p larql-router` — passes
- [x] `cargo check --target wasm32-unknown-unknown -p larql-server --no-default-features` — passes
- [x] `cargo build -p larql-router-protocol` (native) — passes
- [x] `cargo build -p larql-router` (native) — passes
- [x] `cargo build -p larql-server` (native) — passes
- [x] `cargo test -p larql-router` — 28 tests pass (15 lib + 13 main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)