### PR TITLE
fix(ci): remove stale ci/workflows-complete branch from all workflow triggers

### DIFF
--- a/.github/workflows/bench-regress.yml
+++ b/.github/workflows/bench-regress.yml
@@ -17,7 +17,7 @@ name: bench-regress
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -26,7 +26,7 @@ on:
       - 'LICENSE*'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/kv-cache-benchmark.yml
+++ b/.github/workflows/kv-cache-benchmark.yml
@@ -8,7 +8,7 @@ name: kv-cache-benchmark
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/kv-cache-benchmark/**'
       - 'crates/larql-inference/**'
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/kv-cache-benchmark.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/kv-cache-benchmark/**'
       - 'crates/larql-inference/**'

--- a/.github/workflows/larql-boundary.yml
+++ b/.github/workflows/larql-boundary.yml
@@ -13,7 +13,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-boundary/**'
       - 'Cargo.toml'
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/larql-boundary.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-boundary/**'
       - 'Cargo.toml'

--- a/.github/workflows/larql-cli.yml
+++ b/.github/workflows/larql-cli.yml
@@ -16,7 +16,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-cli/**'
       - 'crates/larql-lql/**'
@@ -30,7 +30,7 @@ on:
       - '.github/workflows/larql-cli.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-cli/**'
       - 'crates/larql-lql/**'

--- a/.github/workflows/larql-compute.yml
+++ b/.github/workflows/larql-compute.yml
@@ -11,7 +11,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-compute/**'
       - 'crates/larql-models/**'
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/larql-compute.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-compute/**'
       - 'crates/larql-models/**'

--- a/.github/workflows/larql-core.yml
+++ b/.github/workflows/larql-core.yml
@@ -8,7 +8,7 @@ name: larql-core
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-core/**'
       - 'Cargo.toml'
@@ -17,7 +17,7 @@ on:
       - '.github/workflows/larql-core.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-core/**'
       - 'Cargo.toml'

--- a/.github/workflows/larql-experts.yml
+++ b/.github/workflows/larql-experts.yml
@@ -9,7 +9,7 @@ name: larql-experts
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-experts/**'
       - 'Cargo.toml'
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/larql-experts.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-experts/**'
       - 'Cargo.toml'

--- a/.github/workflows/larql-inference.yml
+++ b/.github/workflows/larql-inference.yml
@@ -14,7 +14,7 @@ name: larql-inference
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-inference/**'
       - 'crates/larql-compute/**'
@@ -27,7 +27,7 @@ on:
       - '.github/workflows/larql-inference.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-inference/**'
       - 'crates/larql-compute/**'

--- a/.github/workflows/larql-kv.yml
+++ b/.github/workflows/larql-kv.yml
@@ -10,7 +10,7 @@ name: larql-kv
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-kv/**'
       - 'crates/larql-inference/src/test_utils.rs'
@@ -27,7 +27,7 @@ on:
       - '.github/workflows/larql-kv.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-kv/**'
       - 'crates/larql-inference/src/test_utils.rs'

--- a/.github/workflows/larql-lql.yml
+++ b/.github/workflows/larql-lql.yml
@@ -9,7 +9,7 @@ name: larql-lql
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-lql/**'
       - 'crates/larql-core/**'
@@ -22,7 +22,7 @@ on:
       - '.github/workflows/larql-lql.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-lql/**'
       - 'crates/larql-core/**'

--- a/.github/workflows/larql-models.yml
+++ b/.github/workflows/larql-models.yml
@@ -13,7 +13,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-models/**'
       - 'Cargo.toml'
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/larql-models.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-models/**'
       - 'Cargo.toml'

--- a/.github/workflows/larql-python.yml
+++ b/.github/workflows/larql-python.yml
@@ -10,7 +10,7 @@ name: larql-python
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-python/**'
       - 'crates/larql-core/**'
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/larql-python.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-python/**'
       - 'crates/larql-core/**'

--- a/.github/workflows/larql-router.yml
+++ b/.github/workflows/larql-router.yml
@@ -8,7 +8,7 @@ name: larql-router
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-router/**'
       - 'crates/larql-router-protocol/**'
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/larql-router.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-router/**'
       - 'crates/larql-router-protocol/**'

--- a/.github/workflows/larql-server.yml
+++ b/.github/workflows/larql-server.yml
@@ -13,7 +13,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-server/**'
       - 'crates/larql-router-protocol/**'
@@ -26,7 +26,7 @@ on:
       - '.github/workflows/larql-server.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-server/**'
       - 'crates/larql-router-protocol/**'

--- a/.github/workflows/larql-vindex.yml
+++ b/.github/workflows/larql-vindex.yml
@@ -12,7 +12,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-vindex/**'
       - 'crates/larql-lql/src/executor/lifecycle/compile/into_vindex.rs'
@@ -23,7 +23,7 @@ on:
       - '.github/workflows/larql-vindex.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/larql-vindex/**'
       - 'crates/larql-lql/src/executor/lifecycle/compile/into_vindex.rs'

--- a/.github/workflows/model-compute.yml
+++ b/.github/workflows/model-compute.yml
@@ -9,7 +9,7 @@ name: model-compute
 
 on:
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/model-compute/**'
       - 'Cargo.toml'
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/model-compute.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
     paths:
       - 'crates/model-compute/**'
       - 'Cargo.toml'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,9 +28,9 @@ name: quality
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
   workflow_dispatch:
   schedule:
     # Weekly RustSec advisory refresh against the committed lockfile, so

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,9 +17,9 @@ name: validate
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, ci/workflows-complete]
+    branches: [main]
   push:
-    branches: [main, ci/workflows-complete]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Strips `, ci/workflows-complete` from the `push.branches` and `pull_request` (where present) triggers in all 18 workflow files
- That branch no longer exists; `main` is the only valid push target
- Workflow files only — no source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)