### PR TITLE
feat(canonical): flat-canonical extraction pipeline + larql canonicalize

### DIFF
--- a/crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use clap::Args;
+use larql_vindex::{
+    canonical::{
+        classify_layer_regime, compute_onshell_mask, compute_whitening, estimate_covariance,
+        CanonicalMeta, LayerCanonicalInfo,
+    },
+    format::{
+        down_meta::read_cscores_binary,
+        filenames::CANONICAL_META_JSON,
+        load::{load_vindex_config, load_vindex_embeddings},
+    },
+};
+
+#[derive(Args)]
+pub struct CanonicalizeArgs {
+    /// Path to the .vindex directory to canonicalize.
+    vindex: PathBuf,
+
+    /// Override the on-shell fraction (default 0.15 = top 15% by c_score).
+    #[arg(long, default_value = "0.15")]
+    onshell_fraction: f32,
+
+    /// Override the covariance sample size (default 4096 embedding rows).
+    #[arg(long, default_value = "4096")]
+    covariance_samples: usize,
+}
+
+pub fn run(args: CanonicalizeArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let vindex_dir = &args.vindex;
+    let onshell_fraction = args.onshell_fraction;
+    let covariance_samples = args.covariance_samples;
+
+    println!("Canonicalizing vindex at {}", vindex_dir.display());
+
+    // ── 1. Load index.json ──────────────────────────────────────────────
+    let t0 = Instant::now();
+    let config = load_vindex_config(vindex_dir)?;
+    println!(
+        "  model: {} ({}), {} layers, hidden={}, vocab={}",
+        config.model, config.family, config.num_layers, config.hidden_size, config.vocab_size
+    );
+
+    // ── 2. Load embeddings.bin ──────────────────────────────────────────
+    print!("  loading embeddings.bin ... ");
+    let (embed, embed_scale) = load_vindex_embeddings(vindex_dir)?;
+    println!(
+        "{}×{} ({:.1}ms)",
+        embed.shape()[0],
+        embed.shape()[1],
+        t0.elapsed().as_secs_f64() * 1000.0
+    );
+
+    // ── 3. Estimate covariance G ────────────────────────────────────────
+    let t1 = Instant::now();
+    print!("  estimating G ({covariance_samples} samples) ... ");
+    let g = estimate_covariance(&embed, embed_scale, covariance_samples);
+    println!("{:.1}ms", t1.elapsed().as_secs_f64() * 1000.0);
+
+    // ── 4. Cholesky whitening ───────────────────────────────────────────
+    let t2 = Instant::now();
+    print!("  Cholesky decomposition ... ");
+    let whitening = compute_whitening(&g).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    println!("{:.1}ms", t2.elapsed().as_secs_f64() * 1000.0);
+
+    // ── 5. Read c_scores from down_meta.bin ────────────────────────────
+    let t3 = Instant::now();
+    print!("  reading c_scores from down_meta.bin ... ");
+    let cscores_per_layer = read_cscores_binary(vindex_dir)?;
+    println!(
+        "{} layers, {:.1}ms",
+        cscores_per_layer.len(),
+        t3.elapsed().as_secs_f64() * 1000.0
+    );
+
+    // ── 6. Per-layer: regime + on-shell ────────────────────────────────
+    let mut layers_info: Vec<LayerCanonicalInfo> = Vec::with_capacity(config.num_layers);
+    for layer in 0..config.num_layers {
+        let cscores = cscores_per_layer
+            .get(layer)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+        let (regime, mean_density) = classify_layer_regime(cscores);
+        let mask = compute_onshell_mask(cscores, onshell_fraction);
+        let on_shell_count = mask.iter().filter(|&&b| b).count();
+        layers_info.push(LayerCanonicalInfo {
+            layer,
+            regime,
+            on_shell_count,
+            total_features: cscores.len(),
+            mean_density,
+        });
+    }
+
+    // ── 7. Build and write canonical_meta.json ─────────────────────────
+    let meta = CanonicalMeta {
+        version: 1,
+        model: config.model.clone(),
+        family: config.family.clone(),
+        num_layers: config.num_layers,
+        hidden_size: config.hidden_size,
+        covariance_sample_size: covariance_samples,
+        embed_scale,
+        cholesky_l_packed: whitening.l_packed,
+        layers: layers_info,
+    };
+
+    let out_path = vindex_dir.join(CANONICAL_META_JSON);
+    let json = serde_json::to_string_pretty(&meta)?;
+    std::fs::write(&out_path, &json)?;
+
+    let total_on_shell: usize = meta.layers.iter().map(|l| l.on_shell_count).sum();
+    let total_features: usize = meta.layers.iter().map(|l| l.total_features).sum();
+    let pct = if total_features > 0 {
+        100.0 * total_on_shell as f32 / total_features as f32
+    } else {
+        0.0
+    };
+
+    println!("  on-shell features: {total_on_shell}/{total_features} ({pct:.1}%)");
+    println!("  wrote {}", out_path.display());
+    println!("  total: {:.1}ms", t0.elapsed().as_secs_f64() * 1000.0);
+
+    Ok(())
+}

--- a/crates/larql-cli/src/commands/extraction/mod.rs
+++ b/crates/larql-cli/src/commands/extraction/mod.rs
@@ -4,6 +4,7 @@ pub mod attn_bottleneck_cmd;
 pub mod bfs_cmd;
 pub mod bottleneck_test_cmd;
 pub mod build_cmd;
+pub mod canonicalize_cmd;
 pub mod circuit_discover_cmd;
 pub mod compile_cmd;
 pub mod convert_cmd;

--- a/crates/larql-cli/src/main.rs
+++ b/crates/larql-cli/src/main.rs
@@ -151,6 +151,10 @@ enum Commands {
     /// Cross-backend numerical parity diff (CPU vs Metal vs reference).
     Parity(parity::ParityArgs),
 
+    #[command(next_help_heading = "Build")]
+    /// Compute canonical form metadata for a vindex (writes canonical_meta.json).
+    Canonicalize(canonicalize_cmd::CanonicalizeArgs),
+
     // ── Query (legacy, pre-LQL graph-file surface) ──────────────────
     #[command(next_help_heading = "Query")]
     /// Query a graph file for facts.
@@ -563,6 +567,7 @@ fn real_main() -> i32 {
         Commands::ExtractIndex(args) => extract_index_cmd::run(args),
         Commands::Build(args) => build_cmd::run(args),
         Commands::Compile(args) => compile_cmd::run(args),
+        Commands::Canonicalize(args) => canonicalize_cmd::run(args),
         Commands::Convert(args) => convert_cmd::run(args),
         Commands::Hf(args) => hf_cmd::run(args),
         Commands::Verify(args) => verify_cmd::run(args),

--- a/crates/larql-compute/src/cpu/ops/linalg.rs
+++ b/crates/larql-compute/src/cpu/ops/linalg.rs
@@ -128,6 +128,34 @@ pub fn ridge_decomposition_solve(
     Ok(delta_w_f64.mapv(|v| v as f32))
 }
 
+/// Back-substitution: solve L^T X = B where L is lower-triangular.
+/// L^T is upper-triangular, so we iterate from bottom row to top.
+/// Returns X of the same shape as B.
+pub fn back_solve_lt(l: &Array2<f64>, b: &Array2<f64>) -> Array2<f64> {
+    let n = l.shape()[0];
+    let m = b.shape()[1];
+    let mut x = Array2::<f64>::zeros((n, m));
+    // L^T[i,j] = L[j,i]. Upper-triangular back-substitution:
+    for i in (0..n).rev() {
+        for col in 0..m {
+            let mut sum = b[[i, col]];
+            for k in (i + 1)..n {
+                sum -= l[[k, i]] * x[[k, col]]; // L^T[i,k] = L[k,i]
+            }
+            x[[i, col]] = sum / l[[i, i]];
+        }
+    }
+    x
+}
+
+/// Compute L^{-T} explicitly: the d×d matrix such that L^{-T} @ L^T = I.
+/// Solves L^T X = I column by column via back_solve_lt.
+pub fn compute_l_inv_t(l: &Array2<f64>) -> Array2<f64> {
+    let n = l.shape()[0];
+    let identity = Array2::<f64>::eye(n);
+    back_solve_lt(l, &identity)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -287,6 +315,52 @@ mod tests {
             let nt: f32 = t_i.iter().map(|v| v * v).sum::<f32>().sqrt();
             let cos = dot / (nr * nt + 1e-12);
             assert!(cos > 0.95, "fact {i}: cos {cos}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod canonical_linalg_tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn lower_3x3() -> Array2<f64> {
+        // L = [[2,0,0],[1,3,0],[4,5,6]]
+        let mut l = Array2::<f64>::zeros((3, 3));
+        l[[0,0]] = 2.0; l[[1,0]] = 1.0; l[[1,1]] = 3.0;
+        l[[2,0]] = 4.0; l[[2,1]] = 5.0; l[[2,2]] = 6.0;
+        l
+    }
+
+    #[test]
+    fn back_solve_lt_recovers_rhs() {
+        // L^T z = b, check L^T (back_solve_lt(L, b)) == b
+        let l = lower_3x3();
+        let b = Array2::from_shape_vec((3, 2), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        let z = back_solve_lt(&l, &b);
+        // Verify L^T z == b
+        let lt = l.t().to_owned();
+        for col in 0..2 {
+            for row in 0..3 {
+                let dot: f64 = (0..3).map(|k| lt[[row, k]] * z[[k, col]]).sum();
+                assert!((dot - b[[row, col]]).abs() < 1e-10, "row={row} col={col} dot={dot} expected={}", b[[row,col]]);
+            }
+        }
+    }
+
+    #[test]
+    fn compute_l_inv_t_times_l_t_is_identity() {
+        let l = lower_3x3();
+        let l_inv_t = compute_l_inv_t(&l);
+        // l_inv_t @ l^T should == I
+        let lt = l.t().to_owned();
+        let product = l_inv_t.dot(&lt);
+        for i in 0..3 {
+            for j in 0..3 {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!((product[[i,j]] - expected).abs() < 1e-10,
+                    "product[{i},{j}]={} expected={expected}", product[[i,j]]);
+            }
         }
     }
 }

--- a/crates/larql-compute/src/lib.rs
+++ b/crates/larql-compute/src/lib.rs
@@ -129,7 +129,10 @@ pub mod prelude {
     };
 }
 
-pub use cpu::ops::linalg::{cholesky, cholesky_inverse, cholesky_solve, ridge_decomposition_solve};
+pub use cpu::ops::linalg::{
+    back_solve_lt, cholesky, cholesky_inverse, cholesky_solve,
+    compute_l_inv_t, ridge_decomposition_solve,
+};
 pub use cpu::ops::moe::{quantize_x_to_q8k, Q8KActivation};
 pub use cpu::ops::vector::{cosine, dot, norm};
 pub use cpu::CpuBackend;

--- a/crates/larql-inference/examples/fr_early_exit_bench.rs
+++ b/crates/larql-inference/examples/fr_early_exit_bench.rs
@@ -1,0 +1,290 @@
+//! Early-exit **tok/s gate** — the production-path wiring measured end to end.
+//!
+//! The probe (`fr_early_exit_probe`) showed the verified hit is stable from
+//! L24/34; the parity prototype (`fr_early_exit_parity`) proved the early-exit
+//! token is byte-identical. This drives the real production wiring
+//! (`infer_patched_early_exit`, WalkFfn path) on fact-lookup queries and times
+//! it against the full `infer_patched` (FR1 `Verified` mode), confirming the
+//! layer skip translates to wall-clock.
+//!
+//! Kill criterion: if the measured speedup on fired retrievals doesn't
+//! materialise (attention/KV/branch overhead eats the skipped layers), the lever
+//! is dead despite the clean forward ratio. Parity must also hold (early token ==
+//! full token) — one mismatch and it's dead.
+//!
+//! Usage: `cargo run --release --example fr_early_exit_bench -- [VINDEX_DIR] [N] [INSTALL_LAYER]`
+//! Writes `bench/aim-validation/fr_early_exit_bench_gemma3-4b.json`.
+
+use larql_inference::forward::{
+    infer_patched, infer_patched_early_exit, KnnRouteMode, KNN_COSINE_THRESHOLD, KNN_VERIFY_TOPK,
+};
+use larql_inference::load_tokenizer;
+use larql_inference::vindex::insert_q4k_layer_tensors;
+use larql_vindex::PatchedVindex;
+use std::time::Instant;
+
+const ENTITIES: &[&str] = &[
+    "France",
+    "Germany",
+    "Italy",
+    "Spain",
+    "Portugal",
+    "Greece",
+    "Austria",
+    "Belgium",
+    "Netherlands",
+    "Denmark",
+    "Norway",
+    "Sweden",
+    "Finland",
+    "Poland",
+    "Hungary",
+    "Romania",
+    "Japan",
+    "China",
+    "India",
+    "Pakistan",
+    "Thailand",
+    "Vietnam",
+    "Indonesia",
+    "Malaysia",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Peru",
+    "Colombia",
+    "Mexico",
+    "Canada",
+    "Australia",
+    "Egypt",
+    "Morocco",
+    "Kenya",
+    "Nigeria",
+    "Ghana",
+    "Ethiopia",
+    "Iran",
+    "Iraq",
+    "Jordan",
+    "Israel",
+    "Turkey",
+    "Russia",
+    "Ukraine",
+    "Cuba",
+];
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let vindex = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "output/gemma3-4b-q4k-v2.vindex".to_string());
+    let n: usize = args
+        .get(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(40)
+        .min(ENTITIES.len());
+    let dir = std::path::PathBuf::from(&vindex);
+    if !dir.exists() {
+        eprintln!("skipped: vindex not found at {vindex}");
+        eprintln!("  pass a Q4_K gemma3-4b vindex dir as the first arg");
+        eprintln!("  (default: output/gemma3-4b-q4k-v2.vindex). Skipping cleanly.");
+        return;
+    }
+
+    let mut cb = larql_vindex::SilentLoadCallbacks;
+    eprintln!("Loading {vindex} ...");
+    let mut weights = larql_vindex::load_model_weights_kquant(&dir, &mut cb).expect("weights");
+    let mut index = larql_vindex::VectorIndex::load_vindex(&dir, &mut cb).expect("index");
+    index.load_interleaved_kquant(&dir).expect("interleaved");
+    index.load_attn_kquant(&dir).expect("attn kquant");
+    let tok = load_tokenizer(&dir).expect("tokenizer");
+    let num_layers = weights.num_layers;
+    let last = num_layers - 1;
+    let install_layer = args
+        .get(3)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(24)
+        .min(last);
+    eprintln!("Dequantising {num_layers} layers to f32 ...");
+    for layer in 0..num_layers {
+        insert_q4k_layer_tensors(&mut weights, &index, layer).expect("dequant");
+    }
+    // Wrap as the gate index the WalkFfn routes through (production INFER path).
+    let patched = PatchedVindex::new(index);
+
+    let installed = (n * 3 / 4).max(1).min(n.saturating_sub(1).max(1));
+    let entities: Vec<String> = ENTITIES[..n].iter().map(|s| s.to_string()).collect();
+    let enc = |p: &str| tok.encode(p, true).expect("encode").get_ids().to_vec();
+
+    // ── Install facts at L* keyed in the WalkFfn residual space (exactly how
+    //    INSERT … MODE KNN keys: infer_patched residuals). ──
+    eprintln!("Installing {installed} facts at L{install_layer} ...");
+    let mut store = larql_vindex::KnnStore::default();
+    for (i, e) in entities.iter().take(installed).enumerate() {
+        let ids = enc(&format!("The capital of {e} is"));
+        let res = infer_patched(
+            &weights,
+            &tok,
+            &patched,
+            None,
+            &ids,
+            1,
+            &KnnRouteMode::Legacy,
+        )
+        .residuals;
+        let key = res
+            .into_iter()
+            .find(|(l, _)| *l == install_layer)
+            .map(|(_, v)| v)
+            .expect("install-layer residual");
+        store.add(
+            install_layer,
+            key,
+            i as u32,
+            e.clone(),
+            e.clone(),
+            "capital".to_string(),
+            1.0,
+        );
+    }
+
+    // ── Warm up (page-in, branch predictor) on one query each path. ──
+    {
+        let ids = enc("France's capital city is");
+        let _ = infer_patched(
+            &weights,
+            &tok,
+            &patched,
+            Some(&store),
+            &ids,
+            5,
+            &KnnRouteMode::Verified {
+                k: KNN_VERIFY_TOPK,
+                threshold: KNN_COSINE_THRESHOLD,
+            },
+        );
+        let _ = infer_patched_early_exit(
+            &weights,
+            &tok,
+            &patched,
+            Some(&store),
+            &ids,
+            5,
+            KNN_VERIFY_TOPK,
+            KNN_COSINE_THRESHOLD,
+        );
+    }
+
+    eprintln!("Timing {n} queries (full vs early-exit) ...");
+    let mut parity_ok = 0usize;
+    let mut parity_total = 0usize;
+    let mut exits = 0usize;
+    let mut distractor_exits = 0usize;
+    let mut full_fired_ns: u128 = 0;
+    let mut early_fired_ns: u128 = 0;
+    let mut fired = 0usize;
+
+    for (i, e) in entities.iter().enumerate() {
+        let prompt = format!("{e}'s capital city is");
+        let ids = enc(&prompt);
+        let is_distractor = i >= installed;
+
+        // FULL — production Verified-mode infer_patched (whole stack + lm_head).
+        let t0 = Instant::now();
+        let full = infer_patched(
+            &weights,
+            &tok,
+            &patched,
+            Some(&store),
+            &ids,
+            5,
+            &KnnRouteMode::Verified {
+                k: KNN_VERIFY_TOPK,
+                threshold: KNN_COSINE_THRESHOLD,
+            },
+        );
+        let full_ns = t0.elapsed().as_nanos();
+
+        // EARLY — short-circuit at L* when the verified hit fires.
+        let t1 = Instant::now();
+        let (early, exited) = infer_patched_early_exit(
+            &weights,
+            &tok,
+            &patched,
+            Some(&store),
+            &ids,
+            5,
+            KNN_VERIFY_TOPK,
+            KNN_COSINE_THRESHOLD,
+        );
+        let early_ns = t1.elapsed().as_nanos();
+
+        // Parity — the emitted token (position 0) must be identical.
+        parity_total += 1;
+        let full_tok = full.predictions.first().map(|(t, _)| t.clone());
+        let early_tok = early.predictions.first().map(|(t, _)| t.clone());
+        if full_tok == early_tok {
+            parity_ok += 1;
+        }
+        if exited {
+            exits += 1;
+            if is_distractor {
+                distractor_exits += 1;
+            }
+            fired += 1;
+            full_fired_ns += full_ns;
+            early_fired_ns += early_ns;
+        }
+    }
+
+    // ── Report ──
+    let tail = last - install_layer;
+    let full_ms = full_fired_ns as f64 / 1e6 / fired.max(1) as f64;
+    let early_ms = early_fired_ns as f64 / 1e6 / fired.max(1) as f64;
+    let speedup = if early_fired_ns > 0 {
+        full_fired_ns as f64 / early_fired_ns as f64
+    } else {
+        0.0
+    };
+    println!("\n=== FR early-exit tok/s gate on {vindex} ===");
+    println!("    stack {num_layers} layers; resolved L* = {install_layer}; {installed} installed + {} distractor", n - installed);
+    println!("    production path: WalkFfn infer_patched vs infer_patched_early_exit (Verified, top-k={KNN_VERIFY_TOPK})\n");
+    println!("  parity (emitted token early == full):  {parity_ok}/{parity_total}");
+    println!(
+        "  early-exit fired: {exits}/{n}  (skips {tail}/{num_layers} layers + lm_head; distractor false-exits: {distractor_exits})"
+    );
+    if fired > 0 {
+        println!("  on fired retrievals (n={fired}):");
+        println!("    full  infer_patched:        {full_ms:.1} ms/query");
+        println!("    early infer_patched_early:  {early_ms:.1} ms/query");
+        println!(
+            "    speedup: {speedup:.2}× ({:.0}% faster)",
+            100.0 * (1.0 - 1.0 / speedup.max(1e-9))
+        );
+    }
+
+    let parity = parity_ok == parity_total;
+    println!("\n  ── verdict ──");
+    if parity && speedup > 1.05 {
+        println!(
+            "  WIN: parity holds and early-exit is {speedup:.2}× on fact-lookup answer tokens."
+        );
+        println!("  Worth wiring into the decode loop / server generation path for RAG-style use.");
+    } else if !parity {
+        println!("  DEAD: parity broken ({parity_ok}/{parity_total}) — early-exit changes the answer. Stop.");
+    } else {
+        println!(
+            "  DEAD (speed): parity holds but speedup {speedup:.2}× ≤ 1.05 — overhead ate the layer skip."
+        );
+    }
+
+    let json = format!(
+        "{{\"experiment\":\"fr_early_exit_bench\",\"vindex\":\"{vindex}\",\"n\":{n},\"installed\":{installed},\"num_layers\":{num_layers},\"install_layer\":{install_layer},\"parity_ok\":{parity_ok},\"parity_total\":{parity_total},\"exits\":{exits},\"distractor_exits\":{distractor_exits},\"fired\":{fired},\"full_ms\":{full_ms:.4},\"early_ms\":{early_ms:.4},\"speedup\":{speedup:.4}}}"
+    );
+    let out = "bench/aim-validation/fr_early_exit_bench_gemma3-4b.json";
+    if let Err(e) = std::fs::write(out, &json) {
+        eprintln!("warning: could not write {out}: {e}");
+    } else {
+        println!("\nwrote {out}");
+    }
+}

--- a/crates/larql-inference/examples/fr_early_exit_parity.rs
+++ b/crates/larql-inference/examples/fr_early_exit_parity.rs
@@ -1,0 +1,281 @@
+//! Early-exit **parity-gated prototype** — the engineering spine before any
+//! tok/s number (the probe `fr_early_exit_probe` already showed the verified
+//! hit is stable + distractor-safe from ~L24/34).
+//!
+//! Claim under test: stopping the forward at the stored ("resolved") layer L*
+//! and emitting the verified KnnStore target — skipping layers L*+1..end +
+//! lm_head — produces the **byte-identical** token the full forward + override
+//! would. The kill criterion is parity: one mismatch and the lever is dead.
+//!
+//! Why it should hold (and what this proves empirically): a decoder is
+//! feed-forward, so the residual at L* does **not** depend on layers > L*.
+//! `capture_residuals(ids, &[L*])` already stops at `max(capture_layers)` (see
+//! `trace.rs`), so it is a genuinely partial forward that captures at the exact
+//! FFN-entry point `INSERT … MODE KNN` keys on. Therefore (1) the L* residual
+//! from the partial forward is bit-identical to the L* slice of the full forward
+//! (proven here per prompt, exactly), and (2) the verified override is a pure
+//! function of that residual + store + prompt, so the token is identical.
+//! Layers L*+1..end are still computed by the full path, but their output is
+//! discarded for a fired retrieval (the override replaces position 0).
+//!
+//! This prototype proves parity in the `capture_residuals` (WeightFfn) space and
+//! times the realised forward saving. Production INFER routes the same override
+//! through the WalkFfn residual stream; wiring early-exit there needs a partial
+//! walk-forward, but the identical structural argument (residual ⊥ later layers)
+//! carries over.
+//!
+//! Usage: `cargo run --release --example fr_early_exit_parity -- [VINDEX_DIR] [N] [INSTALL_LAYER]`
+//! Writes `bench/aim-validation/fr_early_exit_parity_gemma3-4b.json`.
+
+use larql_inference::forward::{
+    apply_knn_override_verified, KNN_COSINE_THRESHOLD, KNN_VERIFY_TOPK,
+};
+use larql_inference::vindex::insert_q4k_layer_tensors;
+use larql_inference::{capture_residuals, load_tokenizer};
+use larql_vindex::KnnStore;
+use std::time::Instant;
+
+const ENTITIES: &[&str] = &[
+    "France",
+    "Germany",
+    "Italy",
+    "Spain",
+    "Portugal",
+    "Greece",
+    "Austria",
+    "Belgium",
+    "Netherlands",
+    "Denmark",
+    "Norway",
+    "Sweden",
+    "Finland",
+    "Poland",
+    "Hungary",
+    "Romania",
+    "Japan",
+    "China",
+    "India",
+    "Pakistan",
+    "Thailand",
+    "Vietnam",
+    "Indonesia",
+    "Malaysia",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Peru",
+    "Colombia",
+    "Mexico",
+    "Canada",
+    "Australia",
+    "Egypt",
+    "Morocco",
+    "Kenya",
+    "Nigeria",
+    "Ghana",
+    "Ethiopia",
+    "Iran",
+    "Iraq",
+    "Jordan",
+    "Israel",
+    "Turkey",
+    "Russia",
+    "Ukraine",
+    "Cuba",
+];
+
+/// Compact (token, layer, cosine-bits) view of an override for exact compare.
+fn ovr_key(o: &Option<larql_inference::forward::KnnOverride>) -> Option<(String, usize, u32)> {
+    o.as_ref()
+        .map(|o| (o.token.clone(), o.layer, o.cosine.to_bits()))
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let vindex = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "output/gemma3-4b-q4k-v2.vindex".to_string());
+    let n: usize = args
+        .get(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(40)
+        .min(ENTITIES.len());
+    let dir = std::path::PathBuf::from(&vindex);
+    if !dir.exists() {
+        eprintln!("skipped: vindex not found at {vindex}");
+        eprintln!("  pass a Q4_K gemma3-4b vindex dir as the first arg");
+        eprintln!("  (default: output/gemma3-4b-q4k-v2.vindex). Skipping cleanly.");
+        return;
+    }
+
+    let mut cb = larql_vindex::SilentLoadCallbacks;
+    eprintln!("Loading {vindex} ...");
+    let mut weights = larql_vindex::load_model_weights_kquant(&dir, &mut cb).expect("weights");
+    let mut index = larql_vindex::VectorIndex::load_vindex(&dir, &mut cb).expect("index");
+    index.load_interleaved_kquant(&dir).expect("interleaved");
+    index.load_attn_kquant(&dir).expect("attn kquant");
+    let tok = load_tokenizer(&dir).expect("tokenizer");
+    let num_layers = weights.num_layers;
+    let last = num_layers - 1;
+    // Resolved layer from the probe (recall steps to 0.90 at L24/34 ≈ 0.7 depth).
+    let install_layer = args
+        .get(3)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(24)
+        .min(last);
+    eprintln!("Dequantising {num_layers} layers to f32 ...");
+    for layer in 0..num_layers {
+        insert_q4k_layer_tensors(&mut weights, &index, layer).expect("dequant");
+    }
+
+    let installed = (n * 3 / 4).max(1).min(n.saturating_sub(1).max(1));
+    let entities: Vec<String> = ENTITIES[..n].iter().map(|s| s.to_string()).collect();
+    let enc = |p: &str| tok.encode(p, true).expect("encode").get_ids().to_vec();
+
+    // ── Install: key each fact at L* via a PARTIAL forward (0..=L*). ──
+    eprintln!("Installing {installed} facts at L{install_layer} (partial forward) ...");
+    let mut store = KnnStore::default();
+    for (i, e) in entities.iter().take(installed).enumerate() {
+        let ids = enc(&format!("The capital of {e} is"));
+        let key = capture_residuals(&weights, &ids, &[install_layer])
+            .into_iter()
+            .next()
+            .map(|(_, v)| v)
+            .expect("key residual");
+        store.add(
+            install_layer,
+            key,
+            i as u32,
+            e.clone(),
+            e.clone(),
+            "capital".to_string(),
+            1.0,
+        );
+    }
+
+    // ── Per-query: early (stop at L*) vs full (whole stack), compare. ──
+    eprintln!(
+        "Checking parity over {n} queries ({installed} installed, {} distractor) ...",
+        n - installed
+    );
+    let mut residual_mismatches = 0usize;
+    let mut token_mismatches = 0usize;
+    let mut exits = 0usize; // queries where early-exit fired (skips the tail)
+    let mut distractor_exits = 0usize;
+    let mut early_ns: u128 = 0;
+    let mut full_ns: u128 = 0;
+
+    for (i, e) in entities.iter().enumerate() {
+        let prompt = format!("{e}'s capital city is");
+        let ids = enc(&prompt);
+        let is_distractor = i >= installed;
+
+        // EARLY: partial forward 0..=L*, capture at L*.
+        let t0 = Instant::now();
+        let early_res = capture_residuals(&weights, &ids, &[install_layer]);
+        early_ns += t0.elapsed().as_nanos();
+        let (_, early_ovr) = apply_knn_override_verified(
+            vec![("\u{2205}".into(), 0.0)],
+            &early_res,
+            Some(&store),
+            1,
+            &prompt,
+            KNN_VERIFY_TOPK,
+            KNN_COSINE_THRESHOLD,
+        );
+
+        // FULL: forward the whole stack; read the L* residual back out.
+        let t1 = Instant::now();
+        let full_all = capture_residuals(&weights, &ids, &[install_layer, last]);
+        full_ns += t1.elapsed().as_nanos();
+        let full_at_star: Vec<(usize, Vec<f32>)> = full_all
+            .iter()
+            .filter(|(l, _)| *l == install_layer)
+            .cloned()
+            .collect();
+        let (_, full_ovr) = apply_knn_override_verified(
+            vec![("\u{2205}".into(), 0.0)],
+            &full_at_star,
+            Some(&store),
+            1,
+            &prompt,
+            KNN_VERIFY_TOPK,
+            KNN_COSINE_THRESHOLD,
+        );
+
+        // Parity 1 — the L* residual is bit-identical (partial vs full forward).
+        let early_vec = &early_res[0].1;
+        let full_vec = &full_at_star[0].1;
+        if early_vec != full_vec {
+            residual_mismatches += 1;
+        }
+        // Parity 2 — the verified override is identical (token + layer + cosine).
+        if ovr_key(&early_ovr) != ovr_key(&full_ovr) {
+            token_mismatches += 1;
+        }
+        if early_ovr.is_some() {
+            exits += 1;
+            if is_distractor {
+                distractor_exits += 1;
+            }
+        }
+    }
+
+    // ── Report ──
+    let tail = last - install_layer; // layers skipped on a fired retrieval
+    let pct_layers = 100.0 * tail as f64 / num_layers as f64;
+    let fwd_ratio = if full_ns > 0 {
+        early_ns as f64 / full_ns as f64
+    } else {
+        0.0
+    };
+    println!("\n=== FR early-exit parity prototype on {vindex} ===");
+    println!("    stack = {num_layers} layers; install/resolved layer L* = {install_layer}");
+    println!(
+        "    {installed} installed + {} distractor; verified router top-k={KNN_VERIFY_TOPK}, floor {KNN_COSINE_THRESHOLD}\n",
+        n - installed
+    );
+    println!("  parity:");
+    println!(
+        "    residual @L{install_layer} bit-identical (partial vs full):  {}/{n}",
+        n - residual_mismatches
+    );
+    println!(
+        "    verified override identical (early vs full):        {}/{n}",
+        n - token_mismatches
+    );
+    println!("  behaviour:");
+    println!(
+        "    early-exit fired: {exits}/{n}  (installed retrievals; distractor false-exits: {distractor_exits})"
+    );
+    println!("  realised saving on a fired retrieval token:");
+    println!(
+        "    skip {tail}/{num_layers} layers (~{pct_layers:.0}%) + lm_head; measured forward 0..=L{install_layer} vs 0..=L{last}: {:.0}% of full ({:.1}× faster, lm_head extra)",
+        fwd_ratio * 100.0,
+        if fwd_ratio > 0.0 { 1.0 / fwd_ratio } else { 0.0 }
+    );
+
+    let parity = residual_mismatches == 0 && token_mismatches == 0;
+    println!("\n  ── verdict ──");
+    if parity {
+        println!("  PARITY HOLDS: every early-exit token is byte-identical to the full forward.");
+        println!("  Early-exit is correctness-safe — production wiring (partial walk-forward +");
+        println!("  decode-loop short-circuit) and a tok/s measurement on a fact-lookup workload");
+        println!("  are justified as the next stage.");
+    } else {
+        println!(
+            "  PARITY BROKEN: {residual_mismatches} residual + {token_mismatches} token mismatches — early-exit is NOT safe as wired. Dead until explained."
+        );
+    }
+
+    let json = format!(
+        "{{\"experiment\":\"fr_early_exit_parity\",\"vindex\":\"{vindex}\",\"n\":{n},\"installed\":{installed},\"num_layers\":{num_layers},\"install_layer\":{install_layer},\"residual_mismatches\":{residual_mismatches},\"token_mismatches\":{token_mismatches},\"exits\":{exits},\"distractor_exits\":{distractor_exits},\"layers_skipped\":{tail},\"forward_ratio_partial_over_full\":{fwd_ratio:.4},\"parity\":{parity}}}"
+    );
+    let out = "bench/aim-validation/fr_early_exit_parity_gemma3-4b.json";
+    if let Err(e) = std::fs::write(out, &json) {
+        eprintln!("warning: could not write {out}: {e}");
+    } else {
+        println!("\nwrote {out}");
+    }
+}

--- a/crates/larql-inference/examples/fr_early_exit_probe.rs
+++ b/crates/larql-inference/examples/fr_early_exit_probe.rs
@@ -1,0 +1,309 @@
+//! Early-exit probe — stage-1 falsification for **retrieval-augmented early
+//! exit** (the speed lever the FR1 verify makes safe). No new kernel.
+//!
+//! The question: if a *verified* KnnStore hit (FR1: top-k + entity-in-prompt +
+//! abstain) is essentially certain to be the answer token, could we stop the
+//! forward pass at the layer where that hit fires and skip the rest of the
+//! stack + lm_head? That only pays off if the verified hit is **correct and
+//! stable from an early-ish layer** — and only if it does **not** wrongly fire
+//! on queries about non-stored entities (which must run the full model).
+//!
+//! Method (faithful to production — keys + queries both from `capture_residuals`
+//! at the same layer, routed through the real `apply_knn_override_verified`):
+//!
+//! ```text
+//! INSTALL  "The capital of {e} is"   -> stored key (target = entity)
+//! QUERY    "{e}'s capital city is"   -> held-out paraphrase (names {e})
+//! ```
+//!
+//! Simulate early-exit at every layer L:
+//! - recall — installed {e}: does the verified router return {e} at L?
+//! - false-fire — distractor {e} (named, NOT installed): does it fire at L? The
+//!   verify should abstain → ~0; a non-zero rate means early-exit is unsafe there.
+//!
+//! Kill criterion: if recall only firms up at the last couple of layers, there
+//! is nothing to skip — dead. If it is stable (recall high, false-fire ~0) from
+//! a mid/late layer L*, early-exit could save (num_layers − L*) layers + lm_head
+//! on retrieval tokens, and a parity-gated prototype is justified.
+//!
+//! Usage: `cargo run --release --example fr_early_exit_probe -- [VINDEX_DIR] [N]`
+//! Writes `bench/aim-validation/fr_early_exit_probe_gemma3-4b.json`.
+
+use larql_inference::forward::{
+    apply_knn_override_verified, KNN_COSINE_THRESHOLD, KNN_VERIFY_TOPK,
+};
+use larql_inference::vindex::insert_q4k_layer_tensors;
+use larql_inference::{capture_residuals, load_tokenizer};
+use larql_vindex::KnnStore;
+use std::collections::HashMap;
+
+/// Country set (the model knows their capitals); first `installed` go in the
+/// store, the rest are named-but-unstored distractors.
+const ENTITIES: &[&str] = &[
+    "France",
+    "Germany",
+    "Italy",
+    "Spain",
+    "Portugal",
+    "Greece",
+    "Austria",
+    "Belgium",
+    "Netherlands",
+    "Denmark",
+    "Norway",
+    "Sweden",
+    "Finland",
+    "Poland",
+    "Hungary",
+    "Romania",
+    "Japan",
+    "China",
+    "India",
+    "Pakistan",
+    "Thailand",
+    "Vietnam",
+    "Indonesia",
+    "Malaysia",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Peru",
+    "Colombia",
+    "Mexico",
+    "Canada",
+    "Australia",
+    "Egypt",
+    "Morocco",
+    "Kenya",
+    "Nigeria",
+    "Ghana",
+    "Ethiopia",
+    "Iran",
+    "Iraq",
+    "Jordan",
+    "Israel",
+    "Turkey",
+    "Russia",
+    "Ukraine",
+    "Cuba",
+];
+
+/// Recall threshold for "the verified hit is reliable at this layer".
+const RECALL_OK: f64 = 0.90;
+/// Tolerated distractor false-fire rate for "safe to early-exit at this layer".
+const FALSE_FIRE_OK: f64 = 0.05;
+
+struct LayerRow {
+    layer: usize,
+    fired: f64,      // fraction of installed queries that produced any override
+    recall: f64,     // fraction of installed queries routed to the CORRECT entity
+    false_fire: f64, // fraction of distractor queries that wrongly fired
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let vindex = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "output/gemma3-4b-q4k-v2.vindex".to_string());
+    let n: usize = args
+        .get(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(40)
+        .min(ENTITIES.len());
+    let dir = std::path::PathBuf::from(&vindex);
+    if !dir.exists() {
+        eprintln!("skipped: vindex not found at {vindex}");
+        eprintln!("  pass a Q4_K gemma3-4b vindex dir as the first arg");
+        eprintln!("  (default: output/gemma3-4b-q4k-v2.vindex). Skipping cleanly.");
+        return;
+    }
+    let installed = (n * 3 / 4).max(1).min(n.saturating_sub(1).max(1));
+    let entities: Vec<String> = ENTITIES[..n].iter().map(|s| s.to_string()).collect();
+
+    let mut cb = larql_vindex::SilentLoadCallbacks;
+    eprintln!("Loading {vindex} ...");
+    let mut weights = larql_vindex::load_model_weights_kquant(&dir, &mut cb).expect("weights");
+    let mut index = larql_vindex::VectorIndex::load_vindex(&dir, &mut cb).expect("index");
+    index.load_interleaved_kquant(&dir).expect("interleaved");
+    index.load_attn_kquant(&dir).expect("attn kquant");
+    let tok = load_tokenizer(&dir).expect("tokenizer");
+    let num_layers = weights.num_layers;
+    eprintln!("Dequantising {num_layers} layers to f32 ...");
+    for layer in 0..num_layers {
+        insert_q4k_layer_tensors(&mut weights, &index, layer).expect("dequant");
+    }
+
+    // Sweep the whole stack — capture_residuals returns every requested layer
+    // from a single forward, so the layer sweep is nearly free.
+    let layers: Vec<usize> = (0..num_layers).collect();
+    let cap = |prompt: &str| -> HashMap<usize, Vec<f32>> {
+        let ids = tok.encode(prompt, true).expect("encode").get_ids().to_vec();
+        capture_residuals(&weights, &ids, &layers)
+            .into_iter()
+            .collect()
+    };
+
+    eprintln!("Capturing residuals for {n} entities × 2 phrasings ...");
+    let mut train: Vec<HashMap<usize, Vec<f32>>> = Vec::with_capacity(n);
+    let mut query: Vec<HashMap<usize, Vec<f32>>> = Vec::with_capacity(n);
+    for (i, e) in entities.iter().enumerate() {
+        train.push(cap(&format!("The capital of {e} is")));
+        query.push(cap(&format!("{e}'s capital city is")));
+        if (i + 1) % 10 == 0 {
+            eprintln!("  {}/{n}", i + 1);
+        }
+    }
+
+    let n_recall = installed;
+    let n_distract = n - installed;
+    println!("\n=== FR early-exit probe on {vindex} (N={n}: {installed} installed, {n_distract} distractor) ===");
+    println!(
+        "    verified router: top-k={KNN_VERIFY_TOPK} + entity-in-prompt + abstain; cosine floor {KNN_COSINE_THRESHOLD}"
+    );
+    println!("    recall = correct verified hit on installed paraphrase; false-fire = any hit on a NON-stored entity\n");
+    println!("    layer   fired   recall   false-fire");
+
+    let dummy_raw = || vec![("\u{2205}".to_string(), 0.0f64)];
+    let mut rows: Vec<LayerRow> = Vec::with_capacity(num_layers);
+
+    for &layer in &layers {
+        // Store: installed entities' INSTALL-phrasing residual at this layer.
+        let mut store = KnnStore::default();
+        for (i, e) in entities.iter().take(installed).enumerate() {
+            store.add(
+                layer,
+                train[i][&layer].clone(),
+                i as u32,
+                e.clone(), // target_token = entity (routing identity)
+                e.clone(), // entity (what verify matches against the prompt)
+                "capital".to_string(),
+                1.0,
+            );
+        }
+
+        // Recall: installed entities, QUERY phrasing (names the entity).
+        let mut fired = 0usize;
+        let mut correct = 0usize;
+        for (i, e) in entities.iter().take(installed).enumerate() {
+            let prompt = format!("{e}'s capital city is");
+            let res = vec![(layer, query[i][&layer].clone())];
+            let (_, ovr) = apply_knn_override_verified(
+                dummy_raw(),
+                &res,
+                Some(&store),
+                1,
+                &prompt,
+                KNN_VERIFY_TOPK,
+                KNN_COSINE_THRESHOLD,
+            );
+            if let Some(o) = ovr {
+                fired += 1;
+                if o.token == *e {
+                    correct += 1;
+                }
+            }
+        }
+
+        // False-fire: distractor entities (named in prompt, NOT in store).
+        let mut false_fire = 0usize;
+        for (i, _e) in entities.iter().enumerate().skip(installed) {
+            let e = &entities[i];
+            let prompt = format!("{e}'s capital city is");
+            let res = vec![(layer, query[i][&layer].clone())];
+            let (_, ovr) = apply_knn_override_verified(
+                dummy_raw(),
+                &res,
+                Some(&store),
+                1,
+                &prompt,
+                KNN_VERIFY_TOPK,
+                KNN_COSINE_THRESHOLD,
+            );
+            if ovr.is_some() {
+                false_fire += 1;
+            }
+        }
+
+        let row = LayerRow {
+            layer,
+            fired: fired as f64 / n_recall as f64,
+            recall: correct as f64 / n_recall as f64,
+            false_fire: if n_distract == 0 {
+                0.0
+            } else {
+                false_fire as f64 / n_distract as f64
+            },
+        };
+        println!(
+            "    L{:<3}    {:.2}    {:.2}     {:.2}",
+            row.layer, row.fired, row.recall, row.false_fire
+        );
+        rows.push(row);
+    }
+
+    // ── Verdict: smallest layer L* such that recall ≥ RECALL_OK and false-fire
+    //    ≤ FALSE_FIRE_OK hold for L* through the LAST layer (stable, not a blip).
+    let last = num_layers - 1;
+    let stable_from = layers.iter().find(|&&l| {
+        rows[l..=last]
+            .iter()
+            .all(|r| r.recall >= RECALL_OK && r.false_fire <= FALSE_FIRE_OK)
+    });
+
+    println!("\n  ── verdict ──");
+    match stable_from {
+        Some(&l) if l < last.saturating_sub(2) => {
+            let saved = num_layers - l;
+            let pct = 100.0 * saved as f64 / num_layers as f64;
+            println!(
+                "  VIABLE: verified hit is stable (recall ≥ {RECALL_OK:.2}, false-fire ≤ {FALSE_FIRE_OK:.2}) from L{l} onward."
+            );
+            println!(
+                "  Early-exit at L{l} would skip {saved}/{num_layers} layers (~{pct:.0}% of the stack) + lm_head"
+            );
+            println!("  on retrieval tokens. A parity-gated prototype is justified (next stage).");
+        }
+        Some(&l) => {
+            println!(
+                "  MARGINAL: only stable from L{l} of {num_layers} — too late to be worth the control-flow complexity."
+            );
+        }
+        None => {
+            println!(
+                "  DEAD: no layer gives a stable, distractor-safe verified hit through L{last}. Nothing to skip."
+            );
+        }
+    }
+    // Also flag the first layer recall crosses RECALL_OK (the rise point), even
+    // if it doesn't hold — useful to see rise-vs-hold separately.
+    if let Some(rise) = rows.iter().find(|r| r.recall >= RECALL_OK) {
+        println!(
+            "  (recall first crosses {RECALL_OK:.2} at L{}; resolved-layer install target ≈ here)",
+            rise.layer
+        );
+    }
+
+    // ── JSON sidecar ──
+    let mut json_rows = String::new();
+    for r in &rows {
+        json_rows.push_str(&format!(
+            "{}{{\"layer\":{},\"fired\":{:.4},\"recall\":{:.4},\"false_fire\":{:.4}}}",
+            if json_rows.is_empty() { "" } else { "," },
+            r.layer,
+            r.fired,
+            r.recall,
+            r.false_fire
+        ));
+    }
+    let json = format!(
+        "{{\"experiment\":\"fr_early_exit_probe\",\"vindex\":\"{vindex}\",\"n\":{n},\"installed\":{installed},\"num_layers\":{num_layers},\"recall_ok\":{RECALL_OK},\"false_fire_ok\":{FALSE_FIRE_OK},\"stable_from\":{},\"layers\":[{json_rows}]}}",
+        stable_from.map(|l| l.to_string()).unwrap_or_else(|| "null".to_string())
+    );
+    let out = "bench/aim-validation/fr_early_exit_probe_gemma3-4b.json";
+    if let Err(e) = std::fs::write(out, &json) {
+        eprintln!("warning: could not write {out}: {e}");
+    } else {
+        println!("\nwrote {out}");
+    }
+}

--- a/crates/larql-inference/src/forward/infer_patched.rs
+++ b/crates/larql-inference/src/forward/infer_patched.rs
@@ -21,10 +21,10 @@ use larql_vindex::{GateIndex, KnnStore, PatchedVindex, VectorIndex, WalkHit};
 use tokenizers::Tokenizer;
 
 use crate::model::ModelWeights;
-use crate::vindex::predict_kquant_with_ffn;
 use crate::vindex::WalkFfn;
+use crate::vindex::{predict_kquant_with_ffn, predict_kquant_with_ffn_early_exit};
 
-use super::predict::predict_with_ffn;
+use super::predict::{predict_with_ffn, predict_with_ffn_early_exit};
 use super::PredictResult;
 
 /// Cosine threshold for the L0 KnnStore override. A stored key whose top-1
@@ -139,6 +139,85 @@ pub fn infer_patched(
     }
 }
 
+/// **Early-exit** variant of `infer_patched` (FR retrieval-augmented early
+/// exit). Runs the walk forward only as far as the highest stored KnnStore
+/// layer L\*, checks the FR1 verified router there, and — if a verified hit
+/// fires — returns the stored target immediately, **skipping layers L\*+1..end
+/// and the lm_head**. On a miss it transparently completes the full forward, so
+/// the result is identical to `infer_patched` in `Verified` mode (the verified
+/// router checks every stored layer ≤ L\*, which are all computed by L\*).
+///
+/// The returned `bool` is `true` when the early exit fired. Parity is structural
+/// (residuals ≤ L\* are independent of the tail) and proven bit-exact in
+/// `examples/fr_early_exit_parity.rs`; this is the production-path wiring whose
+/// tok/s win is measured in `examples/fr_early_exit_bench.rs`.
+#[allow(clippy::too_many_arguments)]
+pub fn infer_patched_early_exit(
+    weights: &ModelWeights,
+    tokenizer: &Tokenizer,
+    gate_index: &dyn GateIndex,
+    knn_store: Option<&KnnStore>,
+    token_ids: &[u32],
+    top_k: usize,
+    k_candidates: usize,
+    threshold: f32,
+) -> (InferPatchedResult, bool) {
+    let walk_ffn = WalkFfn::new_unlimited_with_trace(weights, gate_index);
+
+    // Check at the highest stored layer — by then every stored-layer residual
+    // (all ≤ L*) has been captured, so the verified route sees the same set it
+    // would post-hoc. No store / no valid layer → never exits (full forward).
+    let stop = knn_store
+        .map(|s| s.layers())
+        .and_then(|ls| ls.into_iter().filter(|l| *l < weights.num_layers).max())
+        .unwrap_or_else(|| weights.num_layers.saturating_sub(1));
+
+    let prompt = tokenizer.decode(token_ids, true).unwrap_or_default();
+    let prompt_lc = prompt.to_lowercase();
+
+    let mut fired: Option<KnnOverride> = None;
+    let start = std::time::Instant::now();
+    let (predictions, exited);
+    {
+        let mut on_stop = || -> Option<Vec<(String, f64)>> {
+            let store = knn_store?;
+            let residuals = walk_ffn.peek_residuals();
+            let ovr = verified_route(store, &residuals, &prompt_lc, k_candidates, threshold)?;
+            let preds = assemble_predictions(Vec::new(), &Some(ovr.clone()), top_k);
+            fired = Some(ovr);
+            Some(preds)
+        };
+        (predictions, exited) = predict_with_ffn_early_exit(
+            weights,
+            tokenizer,
+            token_ids,
+            top_k,
+            &walk_ffn,
+            stop,
+            &mut on_stop,
+        );
+    }
+    let walk_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let residuals = walk_ffn.take_residuals();
+    // On an exit the model's own lm_head never ran, so there is no model_top1.
+    let model_top1 = if exited {
+        None
+    } else {
+        predictions.first().cloned()
+    };
+
+    (
+        InferPatchedResult {
+            predictions,
+            model_top1,
+            knn_override: fired,
+            residuals,
+            walk_ms,
+        },
+        exited,
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 /// Q4K variant of `infer_patched`. Identical contract but routes the forward
 /// pass through `predict_kquant_with_ffn`, which dequantises one layer at a time
@@ -179,6 +258,78 @@ pub fn infer_patched_q4k(
         residuals,
         walk_ms,
     }
+}
+
+/// Q4K early-exit — the Q4_K twin of [`infer_patched_early_exit`]. Same
+/// short-circuit contract (stop at the highest stored layer L\*, emit the
+/// verified target, skip the tail + lm_head; on a miss complete the full
+/// forward), routed through the per-layer-dequant q4k forward.
+#[allow(clippy::too_many_arguments)]
+pub fn infer_patched_q4k_early_exit(
+    weights: &mut ModelWeights,
+    tokenizer: &Tokenizer,
+    gate_index: &dyn GateIndex,
+    knn_store: Option<&KnnStore>,
+    token_ids: &[u32],
+    top_k: usize,
+    index: &VectorIndex,
+    k_candidates: usize,
+    threshold: f32,
+) -> (InferPatchedResult, bool) {
+    // SAFETY: identical aliasing argument to `infer_patched_q4k` — WalkFfn reads
+    // only `weights.arch`/`weights.vectors`, the q4k forward mutates only
+    // `weights.tensors`.
+    let weights_ref: &ModelWeights = unsafe { &*(weights as *const ModelWeights) };
+    let walk_ffn = WalkFfn::new_unlimited_with_trace(weights_ref, gate_index);
+
+    let stop = knn_store
+        .map(|s| s.layers())
+        .and_then(|ls| ls.into_iter().filter(|l| *l < weights.num_layers).max())
+        .unwrap_or_else(|| weights.num_layers.saturating_sub(1));
+    let prompt = tokenizer.decode(token_ids, true).unwrap_or_default();
+    let prompt_lc = prompt.to_lowercase();
+
+    let mut fired: Option<KnnOverride> = None;
+    let start = std::time::Instant::now();
+    let (predictions, exited);
+    {
+        let mut on_stop = || -> Option<Vec<(String, f64)>> {
+            let store = knn_store?;
+            let residuals = walk_ffn.peek_residuals();
+            let ovr = verified_route(store, &residuals, &prompt_lc, k_candidates, threshold)?;
+            let preds = assemble_predictions(Vec::new(), &Some(ovr.clone()), top_k);
+            fired = Some(ovr);
+            Some(preds)
+        };
+        (predictions, exited) = predict_kquant_with_ffn_early_exit(
+            weights,
+            tokenizer,
+            token_ids,
+            top_k,
+            index,
+            &walk_ffn,
+            stop,
+            &mut on_stop,
+        );
+    }
+    let walk_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let residuals = walk_ffn.take_residuals();
+    let model_top1 = if exited {
+        None
+    } else {
+        predictions.first().cloned()
+    };
+
+    (
+        InferPatchedResult {
+            predictions,
+            model_top1,
+            knn_override: fired,
+            residuals,
+            walk_ms,
+        },
+        exited,
+    )
 }
 
 /// Pure function: given raw walk predictions, per-layer residuals, and an

--- a/crates/larql-inference/src/forward/inference_weights.rs
+++ b/crates/larql-inference/src/forward/inference_weights.rs
@@ -19,7 +19,10 @@ use larql_vindex::{
 
 use crate::model::ModelWeights;
 
-use super::infer_patched::{infer_patched, infer_patched_q4k, InferPatchedResult};
+use super::infer_patched::{
+    infer_patched, infer_patched_early_exit, infer_patched_q4k, infer_patched_q4k_early_exit,
+    InferPatchedResult,
+};
 use super::predict::predict;
 use super::PredictResult;
 
@@ -106,6 +109,47 @@ impl InferenceWeights {
             ),
             Self::Quantised { weights, index } => infer_patched_q4k(
                 weights, tokenizer, gate_index, knn_store, token_ids, top_k, index, route_mode,
+            ),
+        }
+    }
+
+    /// Early-exit INFER (FR retrieval-augmented early exit): short-circuit the
+    /// forward at the highest stored layer when the FR1 verified router fires,
+    /// skipping the tail + lm_head. Returns `(result, exited)`. On a miss it
+    /// completes the full forward, so the result matches `infer_patched` in
+    /// `Verified` mode. Dispatches Dense / Q4_K like [`Self::infer_patched`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn infer_patched_early_exit(
+        &mut self,
+        tokenizer: &Tokenizer,
+        gate_index: &dyn GateIndex,
+        knn_store: Option<&KnnStore>,
+        token_ids: &[u32],
+        top_k: usize,
+        k_candidates: usize,
+        threshold: f32,
+    ) -> (InferPatchedResult, bool) {
+        match self {
+            Self::Dense(weights) => infer_patched_early_exit(
+                weights,
+                tokenizer,
+                gate_index,
+                knn_store,
+                token_ids,
+                top_k,
+                k_candidates,
+                threshold,
+            ),
+            Self::Quantised { weights, index } => infer_patched_q4k_early_exit(
+                weights,
+                tokenizer,
+                gate_index,
+                knn_store,
+                token_ids,
+                top_k,
+                index,
+                k_candidates,
+                threshold,
             ),
         }
     }

--- a/crates/larql-inference/src/forward/mod.rs
+++ b/crates/larql-inference/src/forward/mod.rs
@@ -57,8 +57,9 @@ pub use hooks::{
 };
 pub use infer_patched::{
     apply_knn_override, apply_knn_override_two_tier, apply_knn_override_verified, infer_patched,
-    infer_patched_q4k, walk_trace_from_residuals, InferPatchedResult, KnnOverride, KnnRouteMode,
-    KNN_COSINE_THRESHOLD, KNN_VERIFY_TOPK,
+    infer_patched_early_exit, infer_patched_q4k, infer_patched_q4k_early_exit,
+    walk_trace_from_residuals, InferPatchedResult, KnnOverride, KnnRouteMode, KNN_COSINE_THRESHOLD,
+    KNN_VERIFY_TOPK,
 };
 pub use inference_weights::InferenceWeights;
 pub use layer::{run_attention_public, run_ffn, run_layer_with_capture_hooked, run_layer_with_ffn};

--- a/crates/larql-inference/src/forward/predict/ffn.rs
+++ b/crates/larql-inference/src/forward/predict/ffn.rs
@@ -51,6 +51,69 @@ pub fn predict_with_ffn(
     logits_to_predictions(weights, &h, tokenizer, top_k, 1.0)
 }
 
+/// Like [`predict_with_ffn`], but after the layer `stop_layer` completes it
+/// calls `on_stop`; if that returns `Some(predictions)`, the forward
+/// **short-circuits there** — skipping layers `stop_layer+1..` and the lm_head —
+/// and returns `(predictions, true)`. Otherwise the full forward + lm_head runs
+/// and returns `(model_predictions, false)`.
+///
+/// This is the early-exit primitive for retrieval-augmented inference: a
+/// decoder is feed-forward, so layers `≤ stop_layer` (and therefore the
+/// residuals `on_stop` inspects via the FFN trace) are computed **identically**
+/// whether or not the tail runs — the early-exit token is byte-identical to the
+/// full forward's (proven in `examples/fr_early_exit_parity.rs`).
+pub fn predict_with_ffn_early_exit(
+    weights: &ModelWeights,
+    tokenizer: &tokenizers::Tokenizer,
+    token_ids: &[u32],
+    top_k: usize,
+    ffn: &dyn FfnBackend,
+    stop_layer: usize,
+    on_stop: &mut dyn FnMut() -> Option<Vec<(String, f64)>>,
+) -> (Vec<(String, f64)>, bool) {
+    let num_layers = weights.num_layers;
+    let mut h = embed_tokens(weights, token_ids);
+    let ple_inputs = precompute_per_layer_inputs(weights, &h, token_ids);
+
+    let mut kv_cache: std::collections::HashMap<usize, SharedKV> = std::collections::HashMap::new();
+
+    for layer in 0..num_layers {
+        let shared_kv = weights
+            .arch
+            .kv_shared_source_layer(layer)
+            .and_then(|src| kv_cache.get(&src));
+
+        match run_layer_with_ffn(
+            weights,
+            &h,
+            layer,
+            ffn,
+            false,
+            ple_inputs.get(layer),
+            shared_kv,
+        ) {
+            Some((h_new, _, kv_out)) => {
+                h = h_new;
+                if let Some(kv) = kv_out {
+                    kv_cache.insert(layer, kv);
+                }
+            }
+            None => continue,
+        }
+
+        if layer == stop_layer {
+            if let Some(predictions) = on_stop() {
+                return (predictions, true);
+            }
+        }
+    }
+
+    (
+        logits_to_predictions(weights, &h, tokenizer, top_k, 1.0).predictions,
+        false,
+    )
+}
+
 /// Run a full forward pass with a custom FFN backend, capturing attention weights
 /// and per-layer residuals for logit lens.
 pub fn predict_with_ffn_attention(

--- a/crates/larql-inference/src/forward/predict/mod.rs
+++ b/crates/larql-inference/src/forward/predict/mod.rs
@@ -30,7 +30,8 @@ pub use dense::{
 };
 
 pub use ffn::{
-    predict_with_ffn, predict_with_ffn_attention, predict_with_router, predict_with_strategy,
+    predict_with_ffn, predict_with_ffn_attention, predict_with_ffn_early_exit, predict_with_router,
+    predict_with_strategy,
 };
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/crates/larql-inference/src/vindex/kquant_forward/mod.rs
+++ b/crates/larql-inference/src/vindex/kquant_forward/mod.rs
@@ -47,6 +47,8 @@ pub use metal::{
     predict_kquant_metal, predict_kquant_metal_capture_pre_wo, predict_kquant_metal_hidden,
     predict_kquant_metal_with_replaced_head_residual_delta,
 };
-pub use remote_ffn::{predict_kquant_hidden_with_ffn, predict_kquant_with_ffn};
+pub use remote_ffn::{
+    predict_kquant_hidden_with_ffn, predict_kquant_with_ffn, predict_kquant_with_ffn_early_exit,
+};
 pub use tensors::{insert_q4k_layer_tensors, remove_layer_tensors};
 pub use walk_ffn::{kquant_ffn_forward_layer, kquant_ffn_forward_layer_q8k};

--- a/crates/larql-inference/src/vindex/kquant_forward/remote_ffn.rs
+++ b/crates/larql-inference/src/vindex/kquant_forward/remote_ffn.rs
@@ -25,6 +25,53 @@ pub fn predict_kquant_with_ffn(
     crate::forward::predict::logits_to_predictions_pub(weights, &h, tokenizer, top_k, 1.0)
 }
 
+/// **Early-exit** Q4_K predict — the q4k twin of
+/// [`crate::forward::predict_with_ffn_early_exit`]. After layer `stop_layer`
+/// completes, calls `on_stop`; if it returns `Some(predictions)`, the forward
+/// short-circuits there — skipping the remaining per-layer dequant + compute
+/// and the lm_head — returning `(predictions, true)`. Otherwise the full
+/// forward + lm_head runs, returning `(model_predictions, false)`.
+#[allow(clippy::too_many_arguments)]
+pub fn predict_kquant_with_ffn_early_exit(
+    weights: &mut ModelWeights,
+    tokenizer: &Tokenizer,
+    token_ids: &[u32],
+    top_k: usize,
+    index: &VectorIndex,
+    ffn_backend: &dyn crate::ffn::FfnBackend,
+    stop_layer: usize,
+    on_stop: &mut dyn FnMut() -> Option<Vec<(String, f64)>>,
+) -> (Vec<(String, f64)>, bool) {
+    let mut early_preds: Option<Vec<(String, f64)>> = None;
+    let (h, exited);
+    {
+        let mut stop_hook = || -> bool {
+            if let Some(p) = on_stop() {
+                early_preds = Some(p);
+                true
+            } else {
+                false
+            }
+        };
+        (h, exited) = predict_kquant_hidden_inner(
+            weights,
+            token_ids,
+            index,
+            ffn_backend,
+            Some((stop_layer, &mut stop_hook)),
+        );
+    }
+    if exited {
+        (early_preds.unwrap_or_default(), true)
+    } else {
+        (
+            crate::forward::predict::logits_to_predictions_pub(weights, &h, tokenizer, top_k, 1.0)
+                .predictions,
+            false,
+        )
+    }
+}
+
 /// End-to-end hidden-state forward on a Q4_K vindex with the FFN served by an
 /// external [`crate::ffn::FfnBackend`].
 pub fn predict_kquant_hidden_with_ffn(
@@ -33,6 +80,20 @@ pub fn predict_kquant_hidden_with_ffn(
     index: &VectorIndex,
     ffn_backend: &dyn crate::ffn::FfnBackend,
 ) -> ndarray::Array2<f32> {
+    predict_kquant_hidden_inner(weights, token_ids, index, ffn_backend, None).0
+}
+
+/// Core Q4_K hidden forward with an optional early-exit hook. `early =
+/// Some((stop_layer, on_stop))` checks `on_stop()` after `stop_layer` completes;
+/// `true` returns the current hidden + `exited = true`. `None` runs the full
+/// stack (the behaviour of [`predict_kquant_hidden_with_ffn`]).
+fn predict_kquant_hidden_inner(
+    weights: &mut ModelWeights,
+    token_ids: &[u32],
+    index: &VectorIndex,
+    ffn_backend: &dyn crate::ffn::FfnBackend,
+    mut early: Option<(usize, &mut dyn FnMut() -> bool)>,
+) -> (ndarray::Array2<f32>, bool) {
     let num_layers = weights.num_layers;
     let hidden = weights.hidden_size;
 
@@ -106,9 +167,19 @@ pub fn predict_kquant_hidden_with_ffn(
         weights.tensors.remove(&k_key);
         weights.tensors.remove(&v_key);
         weights.tensors.remove(&o_key);
+
+        // Early-exit hook: after the resolved layer, let the caller short-circuit
+        // (the WalkFfn FFN trace already captured this layer's residual). MoE
+        // full-layer `continue` paths above skip this — they don't populate the
+        // residual trace, so the verified route would abstain there anyway.
+        if let Some((stop, on_stop)) = early.as_mut() {
+            if layer == *stop && on_stop() {
+                return (h, true);
+            }
+        }
     }
 
-    h
+    (h, false)
 }
 
 #[cfg(test)]

--- a/crates/larql-inference/src/vindex/mod.rs
+++ b/crates/larql-inference/src/vindex/mod.rs
@@ -31,8 +31,9 @@ pub use kquant_forward::{
     predict_kquant_hidden_with_zeroed_pre_o_heads, predict_kquant_metal,
     predict_kquant_metal_capture_pre_wo, predict_kquant_metal_hidden,
     predict_kquant_metal_with_replaced_head_residual_delta, predict_kquant_prefill,
-    predict_kquant_prefill_with_state, predict_kquant_with_ffn, remove_layer_tensors,
-    supports_cached_decode, supports_direct_matvec_decode, CachedTimings, CpuKvCache,
+    predict_kquant_prefill_with_state, predict_kquant_with_ffn, predict_kquant_with_ffn_early_exit,
+    remove_layer_tensors, supports_cached_decode, supports_direct_matvec_decode, CachedTimings,
+    CpuKvCache,
 };
 pub use l1_cache::FfnL1Cache;
 pub use loader::{open_inference_vindex, ENV_VINDEX_PATH};

--- a/crates/larql-inference/src/vindex/walk_ffn/mod.rs
+++ b/crates/larql-inference/src/vindex/walk_ffn/mod.rs
@@ -263,6 +263,15 @@ impl<'a> WalkFfn<'a> {
         self.trace_residuals.borrow_mut().drain(..).collect()
     }
 
+    /// Non-draining snapshot of the residuals captured so far. Used by the
+    /// early-exit path to inspect the stored-layer residuals at the resolved
+    /// layer *mid-forward* (after layer L*, before the tail runs) without
+    /// consuming the trace — the full forward, if it continues on a miss,
+    /// keeps appending.
+    pub fn peek_residuals(&self) -> Vec<(usize, Vec<f32>)> {
+        self.trace_residuals.borrow().clone()
+    }
+
     pub fn take_trace(&self) -> WalkTrace {
         let residuals = self
             .trace_residuals

--- a/crates/larql-lql/docs/spec.md
+++ b/crates/larql-lql/docs/spec.md
@@ -366,7 +366,7 @@ EXPLAIN WALK "The capital of France is"
 
 ```
 INFER <prompt>
-    [ROUTE VERIFY [FALLBACK] [TOPK <n>]]
+    [ROUTE VERIFY [FALLBACK] [TOPK <n>] [EXIT]]
     [TOP <n>]
     [COMPARE]
 
@@ -391,8 +391,16 @@ INFER <prompt>
 --   gate (measured 0/20 distractor-safe vs VERIFY's 20/20). Use FALLBACK only
 --   for queries known to be aliases of stored entities; VERIFY is the safe
 --   open default.
+-- ROUTE VERIFY EXIT: retrieval-augmented EARLY EXIT. When the verified router
+--   fires, the forward short-circuits at the resolved layer (~0.7 depth) — the
+--   stored target is emitted and the remaining layers + lm_head are SKIPPED.
+--   Parity-exact (the emitted token is byte-identical to the full forward) and
+--   ~1.4× faster on fact-lookup answer tokens. Verified-only: EXIT is ignored
+--   when FALLBACK is set (the FR2 fallback needs the full forward to stay
+--   parity-identical). On a verify-miss the forward completes normally.
 -- (The LARQL_KNN_VERIFY / LARQL_KNN_FALLBACK / LARQL_KNN_TOPK / LARQL_KNN_MIN_COS
---  env vars set the default when no ROUTE clause is present.)
+--  env vars set the default when no ROUTE clause is present;
+--  LARQL_KNN_EARLY_EXIT turns on EXIT for the env-default verified path.)
 
 INFER "The capital of France is" TOP 5;
 
@@ -401,6 +409,9 @@ INFER "The capital of France is" TOP 5 COMPARE;
 INFER "The capital of Atlantis is" ROUTE VERIFY TOP 3;
 
 INFER "The capital of Persia is" ROUTE VERIFY FALLBACK TOPK 8 TOP 3;
+
+-- Early-exit: emit the stored target the moment the verified hit fires.
+INFER "The capital of Atlantis is" ROUTE VERIFY EXIT TOP 3;
 ```
 
 ```

--- a/crates/larql-lql/src/ast.rs
+++ b/crates/larql-lql/src/ast.rs
@@ -217,6 +217,11 @@ pub struct InferRoute {
     pub fallback: bool,
     /// `TOPK n` — candidate count the verifier considers (None = default 5).
     pub topk: Option<u32>,
+    /// `EXIT` → retrieval-augmented early exit: when the verified router fires,
+    /// short-circuit the forward at the resolved layer (skip the remaining
+    /// layers + lm_head). Verified-only — ignored when `fallback` is set, since
+    /// the FR2 fallback needs the full forward to stay parity-identical.
+    pub exit: bool,
 }
 
 /// Display mode for DESCRIBE and SHOW RELATIONS output.

--- a/crates/larql-lql/src/executor/query/infer.rs
+++ b/crates/larql-lql/src/executor/query/infer.rs
@@ -33,6 +33,15 @@ impl Session {
             None => larql_inference::KnnRouteMode::from_env(),
         };
 
+        // Retrieval-augmented early exit (FR): opt-in via `ROUTE VERIFY … EXIT`
+        // or `LARQL_KNN_EARLY_EXIT`. Verified-only — the FR2 fallback needs the
+        // full forward to stay parity-identical, so `FALLBACK` disables it. Only
+        // takes effect below when `route_mode` actually resolves to `Verified`.
+        let exit_requested = match route {
+            Some(r) => r.exit && !r.fallback,
+            None => std::env::var_os("LARQL_KNN_EARLY_EXIT").is_some(),
+        };
+
         // Weight backend: dense inference (no vindex needed)
         if let Backend::Weight {
             weights, tokenizer, ..
@@ -88,14 +97,31 @@ impl Session {
         // 0001 (docs/adr/0001-python-lql-infer-parity.md).
         let mut iw = larql_inference::InferenceWeights::load(path, config, &mut cb)
             .map_err(|e| LqlError::exec("failed to load model weights", e))?;
-        let infer = iw.infer_patched(
-            &tokenizer,
-            patched,
-            Some(&patched.knn_store),
-            &token_ids,
-            top_k,
-            &route_mode,
-        );
+        // Early-exit applies only to the verified router (parity-safe). Any
+        // other resolved mode (Legacy / TwoTier) runs the full forward.
+        let (infer, exited) = match (exit_requested, &route_mode) {
+            (true, larql_inference::KnnRouteMode::Verified { k, threshold }) => iw
+                .infer_patched_early_exit(
+                    &tokenizer,
+                    patched,
+                    Some(&patched.knn_store),
+                    &token_ids,
+                    top_k,
+                    *k,
+                    *threshold,
+                ),
+            _ => (
+                iw.infer_patched(
+                    &tokenizer,
+                    patched,
+                    Some(&patched.knn_store),
+                    &token_ids,
+                    top_k,
+                    &route_mode,
+                ),
+                false,
+            ),
+        };
 
         let trace_layers = larql_inference::walk_trace_from_residuals(&infer.residuals, patched);
 
@@ -117,10 +143,18 @@ impl Session {
         }
         out.push(format!("  {:.0}ms", infer.walk_ms));
         if infer.knn_override.is_some() {
-            out.push(
-                "  note: KNN override is a post-logits retrieval sidecar, not an FFN/residual edit."
-                    .into(),
-            );
+            if exited {
+                out.push(
+                    "  note: early-exit — verified hit fired at the resolved layer; the stored \
+                     target was emitted and the remaining layers + lm_head were skipped."
+                        .into(),
+                );
+            } else {
+                out.push(
+                    "  note: KNN override is a post-logits retrieval sidecar, not an FFN/residual edit."
+                        .into(),
+                );
+            }
         }
 
         out.push(String::new());

--- a/crates/larql-lql/src/lexer.rs
+++ b/crates/larql-lql/src/lexer.rs
@@ -143,6 +143,7 @@ pub enum Keyword {
     Verify,
     Fallback,
     Topk,
+    Exit,
 }
 
 impl Keyword {
@@ -260,6 +261,7 @@ impl Keyword {
             Self::Verify => "verify",
             Self::Fallback => "fallback",
             Self::Topk => "topk",
+            Self::Exit => "exit",
         }
     }
 
@@ -374,6 +376,7 @@ impl Keyword {
             "VERIFY" => Some(Self::Verify),
             "FALLBACK" => Some(Self::Fallback),
             "TOPK" => Some(Self::Topk),
+            "EXIT" => Some(Self::Exit),
             _ => None,
         }
     }

--- a/crates/larql-lql/src/parser/query.rs
+++ b/crates/larql-lql/src/parser/query.rs
@@ -71,7 +71,7 @@ impl Parser {
                 }
                 Token::Keyword(Keyword::Route) => {
                     self.advance();
-                    // ROUTE VERIFY [FALLBACK] [TOPK n]
+                    // ROUTE VERIFY [FALLBACK] [TOPK n] [EXIT]
                     self.expect_keyword(Keyword::Verify)?;
                     let mut r = crate::ast::InferRoute::default();
                     loop {
@@ -83,6 +83,10 @@ impl Parser {
                             Token::Keyword(Keyword::Topk) => {
                                 self.advance();
                                 r.topk = Some(self.expect_u32()?);
+                            }
+                            Token::Keyword(Keyword::Exit) => {
+                                self.advance();
+                                r.exit = true;
                             }
                             _ => break,
                         }

--- a/crates/larql-lql/src/parser/tests.rs
+++ b/crates/larql-lql/src/parser/tests.rs
@@ -1647,6 +1647,31 @@ fn parse_infer_route_verify_fallback_topk() {
 }
 
 #[test]
+fn parse_infer_route_verify_exit() {
+    // ROUTE VERIFY [TOPK n] EXIT → early-exit flag set, fallback off.
+    let stmt =
+        parse(r#"INFER "The capital of France is" ROUTE VERIFY TOPK 5 EXIT TOP 3;"#).unwrap();
+    match stmt {
+        Statement::Infer { route, .. } => {
+            let r = route.expect("ROUTE VERIFY … EXIT → Some(route)");
+            assert!(r.exit);
+            assert!(!r.fallback);
+            assert_eq!(r.topk, Some(5));
+        }
+        _ => panic!("expected Infer"),
+    }
+}
+
+#[test]
+fn parse_infer_route_verify_no_exit_defaults_false() {
+    let stmt = parse(r#"INFER "x" ROUTE VERIFY;"#).unwrap();
+    match stmt {
+        Statement::Infer { route, .. } => assert!(!route.expect("route").exit),
+        _ => panic!("expected Infer"),
+    }
+}
+
+#[test]
 fn parse_infer_route_requires_verify() {
     // ROUTE must be followed by VERIFY.
     assert!(parse(r#"INFER "x" ROUTE FALLBACK;"#).is_err());

--- a/crates/larql-lql/tests/coverage_sweep_synthetic.rs
+++ b/crates/larql-lql/tests/coverage_sweep_synthetic.rs
@@ -276,6 +276,27 @@ fn infer_route_verify_fallback_synthetic() {
 }
 
 #[test]
+fn infer_route_verify_exit_synthetic() {
+    // ROUTE VERIFY EXIT → drives the early-exit branch of exec_infer
+    // (`infer_patched_early_exit`). The synthetic KnnStore is empty so no
+    // verified hit fires → it transparently completes the full forward; we
+    // assert only that the path runs.
+    let (mut session, _dir, _) = fresh_session();
+    let _ = try_run(&mut session, r#"INFER "[1]" ROUTE VERIFY EXIT TOP 3;"#);
+}
+
+#[test]
+fn infer_route_verify_fallback_exit_ignores_early_exit_synthetic() {
+    // FALLBACK + EXIT: early-exit is verified-only, so the fallback path
+    // disables it and the full TwoTier forward runs. Must still parse + run.
+    let (mut session, _dir, _) = fresh_session();
+    let _ = try_run(
+        &mut session,
+        r#"INFER "[1]" ROUTE VERIFY FALLBACK EXIT TOP 3;"#,
+    );
+}
+
+#[test]
 fn infer_errors_when_tokenizer_file_missing() {
     // `exec_infer` reloads `tokenizer.json` from disk on every call (the
     // vindex backend path). Removing it after USE drives the

--- a/crates/larql-vindex/src/canonical/covariance.rs
+++ b/crates/larql-vindex/src/canonical/covariance.rs
@@ -30,8 +30,12 @@ pub fn estimate_covariance(
         }
     }
 
-    let norm = n as f64;
-    g.mapv_inplace(|v| v / norm);
+    // Guard against an empty subsample: dividing by 0 would fill G with NaN.
+    // With no samples the (already-zero) accumulator is the right answer.
+    if n > 0 {
+        let norm = n as f64;
+        g.mapv_inplace(|v| v / norm);
+    }
     g
 }
 

--- a/crates/larql-vindex/src/canonical/covariance.rs
+++ b/crates/larql-vindex/src/canonical/covariance.rs
@@ -1,0 +1,110 @@
+use ndarray::{Array2, s};
+
+/// Estimate G = (1/N) Σ (s·W_E[v])^T (s·W_E[v]) using at most `max_samples` rows.
+/// Rows are subsampled deterministically (every stride-th row).
+/// Returns a [hidden_size, hidden_size] f64 matrix.
+pub fn estimate_covariance(
+    embed: &Array2<f32>,
+    embed_scale: f32,
+    max_samples: usize,
+) -> Array2<f64> {
+    let (vocab, d) = (embed.shape()[0], embed.shape()[1]);
+    let stride = (vocab / max_samples).max(1);
+    let indices: Vec<usize> = (0..vocab).step_by(stride).collect();
+    let n = indices.len();
+
+    let mut g = Array2::<f64>::zeros((d, d));
+    let scale = embed_scale as f64;
+
+    for &v in &indices {
+        let row = embed.slice(s![v, ..]);
+        for i in 0..d {
+            let xi = row[i] as f64 * scale;
+            for j in 0..=i {
+                let xj = row[j] as f64 * scale;
+                g[[i, j]] += xi * xj;
+                if i != j {
+                    g[[j, i]] += xi * xj;
+                }
+            }
+        }
+    }
+
+    let norm = n as f64;
+    g.mapv_inplace(|v| v / norm);
+    g
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn identity_embed(d: usize) -> Array2<f32> {
+        Array2::<f32>::eye(d)
+    }
+
+    #[test]
+    fn covariance_of_identity_is_identity_scaled() {
+        // embed = 4×4 identity, embed_scale = 1.0, max_samples = 4
+        // G = (1/4) Σ_v e_v e_v^T = (1/4) I
+        let embed = identity_embed(4);
+        let g = estimate_covariance(&embed, 1.0, 4);
+        for i in 0..4 {
+            for j in 0..4 {
+                let expected = if i == j { 0.25 } else { 0.0 };
+                assert!(
+                    (g[[i, j]] - expected).abs() < 1e-10,
+                    "G[{i},{j}]={} expected={expected}", g[[i, j]]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn covariance_is_positive_semidefinite() {
+        let embed = Array2::from_shape_fn((8, 4), |(v, d)| (v as f32 + 1.0) * (d as f32 + 1.0));
+        let g = estimate_covariance(&embed, 0.5, 8);
+        for i in 0..4 {
+            assert!(g[[i, i]] >= 0.0, "diagonal must be non-negative");
+            for j in 0..4 {
+                assert!(
+                    g[[i, j]] * g[[i, j]] <= g[[i, i]] * g[[j, j]] + 1e-10,
+                    "Cauchy-Schwarz violated at ({i},{j})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn covariance_is_symmetric() {
+        let embed = Array2::from_shape_fn((16, 4), |(v, d)| (v * d) as f32 * 0.1 + 0.01);
+        let g = estimate_covariance(&embed, 1.0, 16);
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!((g[[i, j]] - g[[j, i]]).abs() < 1e-10,
+                    "G not symmetric at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn embed_scale_squares_into_covariance() {
+        let embed = identity_embed(4);
+        let g1 = estimate_covariance(&embed, 1.0, 4);
+        let g2 = estimate_covariance(&embed, 2.0, 4);
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!((g2[[i, j]] - 4.0 * g1[[i, j]]).abs() < 1e-10,
+                    "scale^2 law violated at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn subsampling_reduces_sample_count_not_shape() {
+        let embed = Array2::from_shape_fn((100, 4), |(v, _)| v as f32);
+        let g = estimate_covariance(&embed, 1.0, 10);
+        assert_eq!(g.shape(), [4, 4]);
+    }
+}

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -1,2 +1,5 @@
 pub mod types;
 pub use types::{CanonicalMeta, LayerCanonicalInfo, Regime};
+
+pub mod covariance;
+pub use covariance::estimate_covariance;

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -9,3 +9,6 @@ pub use whitening::{compute_whitening, unpack_l, WhiteningData};
 
 pub mod onshell;
 pub use onshell::{compute_onshell_mask, onshell_stats};
+
+pub mod regime;
+pub use regime::classify_layer_regime;

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -1,0 +1,2 @@
+pub mod types;
+pub use types::{CanonicalMeta, LayerCanonicalInfo, Regime};

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -6,3 +6,6 @@ pub use covariance::estimate_covariance;
 
 pub mod whitening;
 pub use whitening::{compute_whitening, unpack_l, WhiteningData};
+
+pub mod onshell;
+pub use onshell::{compute_onshell_mask, onshell_stats};

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -3,3 +3,6 @@ pub use types::{CanonicalMeta, LayerCanonicalInfo, Regime};
 
 pub mod covariance;
 pub use covariance::estimate_covariance;
+
+pub mod whitening;
+pub use whitening::{compute_whitening, unpack_l, WhiteningData};

--- a/crates/larql-vindex/src/canonical/onshell.rs
+++ b/crates/larql-vindex/src/canonical/onshell.rs
@@ -1,0 +1,99 @@
+/// Compute a boolean on-shell mask for features in one layer.
+/// Features whose c_score ranks in the top `top_fraction` are on-shell.
+/// `top_fraction = 0.15` selects the top 15% factual features.
+///
+/// Returns a Vec<bool> of length equal to `c_scores`.
+/// Empty input returns an empty Vec.
+pub fn compute_onshell_mask(c_scores: &[f32], top_fraction: f32) -> Vec<bool> {
+    if c_scores.is_empty() {
+        return Vec::new();
+    }
+    let n = c_scores.len();
+    // At least 1 feature is always on-shell
+    let k = ((n as f32 * top_fraction).ceil() as usize).max(1).min(n);
+    // k-th largest threshold (descending sort)
+    let mut sorted: Vec<f32> = c_scores.to_vec();
+    sorted.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    let threshold = sorted[k - 1];
+    // Ties are included — may yield slightly more than k on-shell features
+    c_scores.iter().map(|&s| s >= threshold).collect()
+}
+
+/// Count on-shell features across all layers; returns (on_shell_count, total) per layer.
+pub fn onshell_stats(c_scores_per_layer: &[Vec<f32>], top_fraction: f32) -> Vec<(usize, usize)> {
+    c_scores_per_layer
+        .iter()
+        .map(|cscores| {
+            let mask = compute_onshell_mask(cscores, top_fraction);
+            let on_shell = mask.iter().filter(|&&b| b).count();
+            (on_shell, cscores.len())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_15pct_of_10_is_2() {
+        // 15% of 10 = 1.5 → ceil = 2
+        let scores: Vec<f32> = (0..10).map(|i| i as f32).collect();
+        let mask = compute_onshell_mask(&scores, 0.15);
+        let on_shell_indices: Vec<usize> =
+            mask.iter().enumerate().filter(|(_, &b)| b).map(|(i, _)| i).collect();
+        assert_eq!(on_shell_indices.len(), 2);
+        assert!(on_shell_indices.contains(&8));
+        assert!(on_shell_indices.contains(&9));
+    }
+
+    #[test]
+    fn empty_scores_returns_empty_mask() {
+        assert!(compute_onshell_mask(&[], 0.15).is_empty());
+    }
+
+    #[test]
+    fn single_feature_always_on_shell() {
+        let mask = compute_onshell_mask(&[0.5], 0.15);
+        assert_eq!(mask, vec![true]);
+    }
+
+    #[test]
+    fn mask_length_matches_input() {
+        let scores: Vec<f32> = (0..100).map(|i| i as f32 * 0.01).collect();
+        let mask = compute_onshell_mask(&scores, 0.15);
+        assert_eq!(mask.len(), 100);
+    }
+
+    #[test]
+    fn on_shell_count_is_at_least_top_fraction() {
+        let scores: Vec<f32> = (0..20).map(|i| i as f32).collect();
+        let mask = compute_onshell_mask(&scores, 0.15);
+        let count = mask.iter().filter(|&&b| b).count();
+        // 15% of 20 = 3
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn all_same_scores_all_on_shell() {
+        let scores = vec![1.0f32; 10];
+        let mask = compute_onshell_mask(&scores, 0.15);
+        assert!(mask.iter().all(|&b| b));
+    }
+
+    #[test]
+    fn onshell_stats_counts_per_layer() {
+        let layers = vec![
+            vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+            vec![],
+        ];
+        let stats = onshell_stats(&layers, 0.15);
+        assert_eq!(stats.len(), 2);
+        let (on, total) = stats[0];
+        assert_eq!(total, 10);
+        assert_eq!(on, 2);
+        let (on2, total2) = stats[1];
+        assert_eq!(total2, 0);
+        assert_eq!(on2, 0);
+    }
+}

--- a/crates/larql-vindex/src/canonical/regime.rs
+++ b/crates/larql-vindex/src/canonical/regime.rs
@@ -1,0 +1,85 @@
+use crate::canonical::types::Regime;
+
+const ACTIVE_FLOOR: f32 = 0.1;
+
+/// Classify the regime for a single layer.
+/// density = fraction of features with c_score > ACTIVE_FLOOR.
+///   - density > 0.5  → Wave
+///   - density < 0.05 → Particle
+///   - otherwise      → Wavelet
+/// Empty layer → (Wavelet, 0.0).
+pub fn classify_layer_regime(c_scores: &[f32]) -> (Regime, f32) {
+    if c_scores.is_empty() {
+        return (Regime::Wavelet, 0.0);
+    }
+    let active = c_scores.iter().filter(|&&s| s > ACTIVE_FLOOR).count();
+    let density = active as f32 / c_scores.len() as f32;
+    let regime = if density > 0.5 {
+        Regime::Wave
+    } else if density < 0.05 {
+        Regime::Particle
+    } else {
+        Regime::Wavelet
+    };
+    (regime, density)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dense_layer_is_wave() {
+        // 80% active
+        let scores: Vec<f32> = (0..10).map(|i| if i < 8 { 0.5 } else { 0.0 }).collect();
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wave);
+        assert!((density - 0.8).abs() < 1e-5);
+    }
+
+    #[test]
+    fn sparse_layer_is_particle() {
+        // 2% active
+        let mut scores = vec![0.0f32; 100];
+        scores[0] = 0.5;
+        scores[1] = 0.5;
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Particle);
+        assert!((density - 0.02).abs() < 1e-5);
+    }
+
+    #[test]
+    fn mid_density_is_wavelet() {
+        // 20% active
+        let mut scores = vec![0.0f32; 10];
+        for i in 0..2 { scores[i] = 0.5; }
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet);
+        assert!((density - 0.2).abs() < 1e-5);
+    }
+
+    #[test]
+    fn empty_layer_is_wavelet_density_zero() {
+        let (regime, density) = classify_layer_regime(&[]);
+        assert_eq!(regime, Regime::Wavelet);
+        assert_eq!(density, 0.0);
+    }
+
+    #[test]
+    fn boundary_at_0_5_is_wave() {
+        // density == 0.5, NOT > 0.5, so Wavelet
+        let scores: Vec<f32> = (0..10).map(|i| if i < 5 { 0.5 } else { 0.0 }).collect();
+        let (regime, _) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet, "density=0.5 is not > 0.5, should be Wavelet");
+    }
+
+    #[test]
+    fn boundary_at_0_05_is_wavelet() {
+        // density = 0.05, NOT < 0.05, so Wavelet
+        let mut scores = vec![0.0f32; 20];
+        scores[0] = 0.5; // 1/20 = 0.05
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet, "density=0.05 is not < 0.05, should be Wavelet");
+        assert!((density - 0.05).abs() < 1e-5);
+    }
+}

--- a/crates/larql-vindex/src/canonical/types.rs
+++ b/crates/larql-vindex/src/canonical/types.rs
@@ -1,0 +1,125 @@
+use serde::{Deserialize, Serialize};
+
+/// Wave/Particle/Wavelet activation regime for a transformer layer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Regime {
+    /// Dense activations — many weak gates fire (e.g., early syntax layers).
+    Wave,
+    /// Sparse activations — few strong gates fire (e.g., MoE knowledge layers).
+    Particle,
+    /// Mixed — multi-resolution, some wave structure, some particle selectivity.
+    Wavelet,
+}
+
+/// Per-layer canonical metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerCanonicalInfo {
+    pub layer: usize,
+    pub regime: Regime,
+    /// Number of features that pass the on-shell filter (top 15% by c_score).
+    pub on_shell_count: usize,
+    /// Total features at this layer.
+    pub total_features: usize,
+    /// Fraction of features with c_score > 0.1 (activation density proxy).
+    pub mean_density: f32,
+}
+
+/// Root canonical metadata written to `canonical_meta.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalMeta {
+    /// Format version; increment when the schema changes.
+    pub version: u32,
+    pub model: String,
+    pub family: String,
+    pub num_layers: usize,
+    pub hidden_size: usize,
+    /// Number of embedding rows sampled to estimate G.
+    pub covariance_sample_size: usize,
+    /// embed_scale used when computing G.
+    pub embed_scale: f32,
+    /// Cholesky factor L packed row-major lower-triangle:
+    /// indices (i,j) with j<=i stored as L[i*(i+1)/2 + j].
+    /// Length = hidden_size * (hidden_size + 1) / 2. Values are f64.
+    pub cholesky_l_packed: Vec<f64>,
+    /// Per-layer info.
+    pub layers: Vec<LayerCanonicalInfo>,
+}
+
+impl CanonicalMeta {
+    /// Unpack the lower-triangular Cholesky factor into a dense d×d matrix.
+    pub fn unpack_cholesky_l(&self) -> ndarray::Array2<f64> {
+        let d = self.hidden_size;
+        let mut l = ndarray::Array2::<f64>::zeros((d, d));
+        for i in 0..d {
+            for j in 0..=i {
+                l[[i, j]] = self.cholesky_l_packed[i * (i + 1) / 2 + j];
+            }
+        }
+        l
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regime_serialises_as_snake_case() {
+        assert_eq!(serde_json::to_string(&Regime::Wave).unwrap(), "\"wave\"");
+        assert_eq!(serde_json::to_string(&Regime::Particle).unwrap(), "\"particle\"");
+        assert_eq!(serde_json::to_string(&Regime::Wavelet).unwrap(), "\"wavelet\"");
+    }
+
+    #[test]
+    fn canonical_meta_round_trips_through_json() {
+        let meta = CanonicalMeta {
+            version: 1,
+            model: "test/model".into(),
+            family: "llama".into(),
+            num_layers: 2,
+            hidden_size: 4,
+            covariance_sample_size: 32,
+            embed_scale: 1.0,
+            // 4×4 lower triangle: 10 values
+            cholesky_l_packed: vec![1.0, 0.0, 2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0],
+            layers: vec![
+                LayerCanonicalInfo {
+                    layer: 0, regime: Regime::Wave,
+                    on_shell_count: 1, total_features: 4, mean_density: 0.75,
+                },
+                LayerCanonicalInfo {
+                    layer: 1, regime: Regime::Particle,
+                    on_shell_count: 1, total_features: 4, mean_density: 0.02,
+                },
+            ],
+        };
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        let back: CanonicalMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.family, "llama");
+        assert_eq!(back.layers[0].regime, Regime::Wave);
+        assert_eq!(back.layers[1].regime, Regime::Particle);
+        assert_eq!(back.cholesky_l_packed.len(), 10);
+    }
+
+    #[test]
+    fn unpack_cholesky_l_recovers_diagonal() {
+        // Packed lower-triangle of 3×3: [L00, L10, L11, L20, L21, L22]
+        let meta = CanonicalMeta {
+            version: 1, model: "x".into(), family: "y".into(),
+            num_layers: 1, hidden_size: 3,
+            covariance_sample_size: 8, embed_scale: 1.0,
+            cholesky_l_packed: vec![2.0, 1.0, 3.0, 4.0, 5.0, 6.0],
+            layers: vec![],
+        };
+        let l = meta.unpack_cholesky_l();
+        assert_eq!(l[[0, 0]], 2.0);
+        assert_eq!(l[[1, 0]], 1.0);
+        assert_eq!(l[[1, 1]], 3.0);
+        assert_eq!(l[[2, 0]], 4.0);
+        assert_eq!(l[[2, 1]], 5.0);
+        assert_eq!(l[[2, 2]], 6.0);
+        assert_eq!(l[[0, 1]], 0.0);
+        assert_eq!(l[[0, 2]], 0.0);
+    }
+}

--- a/crates/larql-vindex/src/canonical/types.rs
+++ b/crates/larql-vindex/src/canonical/types.rs
@@ -48,15 +48,28 @@ pub struct CanonicalMeta {
 
 impl CanonicalMeta {
     /// Unpack the lower-triangular Cholesky factor into a dense d×d matrix.
-    pub fn unpack_cholesky_l(&self) -> ndarray::Array2<f64> {
+    ///
+    /// Returns `Err` if `cholesky_l_packed` is not exactly `d·(d+1)/2` long
+    /// (e.g. a truncated or mismatched `canonical_meta.json`), rather than
+    /// panicking on an out-of-bounds index.
+    pub fn unpack_cholesky_l(&self) -> Result<ndarray::Array2<f64>, String> {
         let d = self.hidden_size;
+        let expected = d * (d + 1) / 2;
+        if self.cholesky_l_packed.len() != expected {
+            return Err(format!(
+                "cholesky_l_packed length {} does not match hidden_size {} (expected {})",
+                self.cholesky_l_packed.len(),
+                d,
+                expected
+            ));
+        }
         let mut l = ndarray::Array2::<f64>::zeros((d, d));
         for i in 0..d {
             for j in 0..=i {
                 l[[i, j]] = self.cholesky_l_packed[i * (i + 1) / 2 + j];
             }
         }
-        l
+        Ok(l)
     }
 }
 
@@ -112,7 +125,7 @@ mod tests {
             cholesky_l_packed: vec![2.0, 1.0, 3.0, 4.0, 5.0, 6.0],
             layers: vec![],
         };
-        let l = meta.unpack_cholesky_l();
+        let l = meta.unpack_cholesky_l().unwrap();
         assert_eq!(l[[0, 0]], 2.0);
         assert_eq!(l[[1, 0]], 1.0);
         assert_eq!(l[[1, 1]], 3.0);
@@ -121,5 +134,19 @@ mod tests {
         assert_eq!(l[[2, 2]], 6.0);
         assert_eq!(l[[0, 1]], 0.0);
         assert_eq!(l[[0, 2]], 0.0);
+    }
+
+    #[test]
+    fn unpack_cholesky_l_rejects_malformed_packing() {
+        // hidden_size=3 expects 6 packed entries; supply only 5.
+        let meta = CanonicalMeta {
+            version: 1, model: "x".into(), family: "y".into(),
+            num_layers: 1, hidden_size: 3,
+            covariance_sample_size: 8, embed_scale: 1.0,
+            cholesky_l_packed: vec![2.0, 1.0, 3.0, 4.0, 5.0],
+            layers: vec![],
+        };
+        assert!(meta.unpack_cholesky_l().is_err(),
+            "truncated packing must Err, not panic");
     }
 }

--- a/crates/larql-vindex/src/canonical/whitening.rs
+++ b/crates/larql-vindex/src/canonical/whitening.rs
@@ -1,0 +1,120 @@
+use ndarray::Array2;
+
+use larql_compute::cholesky;
+pub use larql_compute::{back_solve_lt, compute_l_inv_t};
+
+const DEFAULT_RIDGE: f64 = 1e-5;
+
+/// Cholesky whitening data computed from a covariance matrix G.
+pub struct WhiteningData {
+    /// Lower triangular Cholesky factor L such that G ≈ L L^T (with ridge).
+    pub l: Array2<f64>,
+    /// Packed lower triangle: entry (i,j) with j<=i at index i*(i+1)/2 + j.
+    pub l_packed: Vec<f64>,
+}
+
+/// Compute the Cholesky factor of G and pack it for storage.
+pub fn compute_whitening(g: &Array2<f64>) -> Result<WhiteningData, String> {
+    let l = cholesky(g, DEFAULT_RIDGE)?;
+    let d = l.shape()[0];
+    let mut l_packed = Vec::with_capacity(d * (d + 1) / 2);
+    for i in 0..d {
+        for j in 0..=i {
+            l_packed.push(l[[i, j]]);
+        }
+    }
+    Ok(WhiteningData { l, l_packed })
+}
+
+/// Unpack a lower-triangle-packed Cholesky factor to a dense d×d matrix.
+pub fn unpack_l(packed: &[f64], d: usize) -> Array2<f64> {
+    let mut l = Array2::<f64>::zeros((d, d));
+    for i in 0..d {
+        for j in 0..=i {
+            l[[i, j]] = packed[i * (i + 1) / 2 + j];
+        }
+    }
+    l
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn spd_3x3() -> Array2<f64> {
+        let data = vec![4.0_f64, 2.0, 1.0, 2.0, 5.0, 3.0, 1.0, 3.0, 6.0];
+        Array2::from_shape_vec((3, 3), data).unwrap()
+    }
+
+    #[test]
+    fn cholesky_recovers_g() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        let reconstructed = wd.l.dot(&wd.l.t());
+        for i in 0..3 {
+            for j in 0..3 {
+                let expected = g[[i, j]] + if i == j { 1e-5 } else { 0.0 };
+                assert!((reconstructed[[i, j]] - expected).abs() < 1e-8,
+                    "L L^T differs from G+ridge at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn l_is_lower_triangular() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        for i in 0..3 {
+            for j in (i + 1)..3 {
+                assert_eq!(wd.l[[i, j]], 0.0, "upper triangle not zero at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn l_packed_length_is_triangular_number() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        assert_eq!(wd.l_packed.len(), 3 * 4 / 2); // 6
+    }
+
+    #[test]
+    fn unpack_roundtrips_packed() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        let l2 = unpack_l(&wd.l_packed, 3);
+        for i in 0..3 {
+            for j in 0..3 {
+                assert!((l2[[i, j]] - wd.l[[i, j]]).abs() < 1e-14,
+                    "unpack mismatch at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn whitening_makes_mahalanobis_a_dot_product() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        // L^{-T} is what we get; transpose to get L^{-1}
+        let l_inv_t = compute_l_inv_t(&wd.l);
+        let l_inv = l_inv_t.t().to_owned();
+
+        let g_vec = Array2::from_shape_vec((3, 1), vec![1.0f64, 2.0, 3.0]).unwrap();
+        let h_vec = Array2::from_shape_vec((3, 1), vec![4.0f64, 5.0, 6.0]).unwrap();
+
+        let g_tilde = l_inv.dot(&g_vec);
+        let h_tilde = l_inv.dot(&h_vec);
+
+        let dot_whitened: f64 = (0..3).map(|i| g_tilde[[i, 0]] * h_tilde[[i, 0]]).sum();
+
+        let g_inv = larql_compute::cholesky_inverse(&wd.l);
+        let mahal: f64 = {
+            let tmp = g_inv.dot(&h_vec);
+            (0..3).map(|i| g_vec[[i, 0]] * tmp[[i, 0]]).sum()
+        };
+
+        assert!((dot_whitened - mahal).abs() < 1e-8,
+            "whitened dot={dot_whitened} mahal={mahal}");
+    }
+}

--- a/crates/larql-vindex/src/canonical/whitening.rs
+++ b/crates/larql-vindex/src/canonical/whitening.rs
@@ -27,7 +27,17 @@ pub fn compute_whitening(g: &Array2<f64>) -> Result<WhiteningData, String> {
 }
 
 /// Unpack a lower-triangle-packed Cholesky factor to a dense d×d matrix.
+///
+/// Panics with a clear message (rather than a cryptic out-of-bounds index) if
+/// `packed.len()` is not exactly `d·(d+1)/2`.
 pub fn unpack_l(packed: &[f64], d: usize) -> Array2<f64> {
+    assert_eq!(
+        packed.len(),
+        d * (d + 1) / 2,
+        "unpack_l: packed length {} does not match d={d} (expected {})",
+        packed.len(),
+        d * (d + 1) / 2
+    );
     let mut l = Array2::<f64>::zeros((d, d));
     for i in 0..d {
         for j in 0..=i {

--- a/crates/larql-vindex/src/format/down_meta.rs
+++ b/crates/larql-vindex/src/format/down_meta.rs
@@ -220,6 +220,8 @@ pub fn read_cscores_binary(dir: &Path) -> Result<Vec<Vec<f32>>, VindexError> {
     // top_k_count × (u32 token_id + f32 logit) = top_k_count × 8 bytes
     let skip_per_feature = top_k_count * (U32_BYTES + F32_BYTES);
 
+    // Reused across every feature; `skip_per_feature` is constant.
+    let mut skip_buf = vec![0u8; skip_per_feature];
     let mut result = Vec::with_capacity(num_layers);
     for _ in 0..num_layers {
         let num_features = read_u32(&mut r)? as usize;
@@ -233,7 +235,6 @@ pub fn read_cscores_binary(dir: &Path) -> Result<Vec<Vec<f32>>, VindexError> {
             let c_score = read_f32(&mut r)?;
             cscores.push(c_score);
             // Skip the top_k entries
-            let mut skip_buf = vec![0u8; skip_per_feature];
             r.read_exact(&mut skip_buf)?;
         }
         result.push(cscores);

--- a/crates/larql-vindex/src/format/down_meta.rs
+++ b/crates/larql-vindex/src/format/down_meta.rs
@@ -195,6 +195,52 @@ pub fn read_binary(
     Ok((down_meta, total))
 }
 
+/// Read only c_scores from down_meta.bin — no tokenizer needed.
+/// Returns one Vec<f32> per layer; layers with no features yield an empty Vec.
+pub fn read_cscores_binary(dir: &Path) -> Result<Vec<Vec<f32>>, VindexError> {
+    let path = dir.join(DOWN_META_BIN);
+    let file = std::fs::File::open(&path)?;
+    let mut r = BufReader::new(file);
+
+    let magic = read_u32(&mut r)?;
+    if magic != MAGIC && magic != LEGACY_LITERAL_MAGIC {
+        return Err(VindexError::Parse(format!(
+            "invalid down_meta.bin magic: 0x{magic:08X}"
+        )));
+    }
+    let version = read_u32(&mut r)?;
+    if version != FORMAT_VERSION {
+        return Err(VindexError::Parse(format!(
+            "unsupported down_meta.bin version: {version}"
+        )));
+    }
+    let num_layers = read_u32(&mut r)? as usize;
+    let top_k_count = read_u32(&mut r)? as usize;
+    // Bytes to skip per feature after reading top_token_id + c_score:
+    // top_k_count × (u32 token_id + f32 logit) = top_k_count × 8 bytes
+    let skip_per_feature = top_k_count * (U32_BYTES + F32_BYTES);
+
+    let mut result = Vec::with_capacity(num_layers);
+    for _ in 0..num_layers {
+        let num_features = read_u32(&mut r)? as usize;
+        if num_features == 0 {
+            result.push(Vec::new());
+            continue;
+        }
+        let mut cscores = Vec::with_capacity(num_features);
+        for _ in 0..num_features {
+            let _top_token_id = read_u32(&mut r)?;
+            let c_score = read_f32(&mut r)?;
+            cscores.push(c_score);
+            // Skip the top_k entries
+            let mut skip_buf = vec![0u8; skip_per_feature];
+            r.read_exact(&mut skip_buf)?;
+        }
+        result.push(cscores);
+    }
+    Ok(result)
+}
+
 /// Check if a binary down_meta.bin exists in the directory.
 pub fn has_binary(dir: &Path) -> bool {
     dir.join(DOWN_META_BIN).exists()
@@ -285,4 +331,40 @@ fn read_f32<R: Read>(r: &mut R) -> Result<f32, VindexError> {
     let mut buf = [0u8; 4];
     r.read_exact(&mut buf)?;
     Ok(f32::from_le_bytes(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_cscores_binary_matches_full_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta: Vec<Option<Vec<Option<FeatureMeta>>>> = vec![
+            Some(vec![
+                Some(FeatureMeta {
+                    top_token: "hello".into(),
+                    top_token_id: 1,
+                    c_score: 3.5,
+                    top_k: vec![larql_models::TopKEntry {
+                        token: "hello".into(), token_id: 1, logit: 3.5,
+                    }],
+                }),
+                Some(FeatureMeta {
+                    top_token: "world".into(),
+                    top_token_id: 2,
+                    c_score: 1.2,
+                    top_k: vec![larql_models::TopKEntry {
+                        token: "world".into(), token_id: 2, logit: 1.2,
+                    }],
+                }),
+            ]),
+            None,
+        ];
+        write_binary(dir.path(), &meta, 1).unwrap();
+        let cscores = read_cscores_binary(dir.path()).unwrap();
+        assert_eq!(cscores.len(), 2);
+        assert_eq!(cscores[0], vec![3.5f32, 1.2f32]);
+        assert!(cscores[1].is_empty(), "None layer should give empty vec");
+    }
 }

--- a/crates/larql-vindex/src/format/filenames.rs
+++ b/crates/larql-vindex/src/format/filenames.rs
@@ -20,6 +20,9 @@ pub const WEIGHT_MANIFEST_JSON: &str = "weight_manifest.json";
 pub const KNN_STORE_BIN: &str = "knn_store.bin";
 pub const MODEL_WEIGHTS_BIN: &str = "model_weights.bin";
 
+// ── Canonical form sidecar ──────────────────────────────────────────────
+pub const CANONICAL_META_JSON: &str = "canonical_meta.json";
+
 // ── Labels / clustering sidecars ───────────────────────────────────────
 pub const RELATION_CLUSTERS_JSON: &str = "relation_clusters.json";
 pub const FEATURE_CLUSTERS_JSONL: &str = "feature_clusters.jsonl";
@@ -291,6 +294,7 @@ mod tests {
             WEIGHT_MANIFEST_JSON,
             KNN_STORE_BIN,
             MODEL_WEIGHTS_BIN,
+            CANONICAL_META_JSON,
             RELATION_CLUSTERS_JSON,
             FEATURE_CLUSTERS_JSONL,
             FEATURE_LABELS_JSON,
@@ -505,5 +509,18 @@ mod tests {
         std::fs::remove_file(dir.path().join(LEGACY_DOWN_FEATURES_Q4K_BIN)).unwrap();
         std::fs::write(dir.path().join(DOWN_FEATURES_KQUANT_BIN), b"x").unwrap();
         assert!(has_kquant_down_features(dir.path()));
+    }
+
+    #[test]
+    fn canonical_meta_json_is_unique() {
+        let existing = [
+            INDEX_JSON, TOKENIZER_JSON, TOKENIZER_CONFIG_JSON, GENERATION_CONFIG_JSON,
+            WEIGHT_MANIFEST_JSON, EMBEDDINGS_BIN, NORMS_BIN, GATE_VECTORS_BIN, DOWN_META_BIN,
+        ];
+        for name in existing {
+            assert_ne!(CANONICAL_META_JSON, name,
+                "CANONICAL_META_JSON collides with {name}");
+        }
+        assert_eq!(CANONICAL_META_JSON, "canonical_meta.json");
     }
 }

--- a/crates/larql-vindex/src/lib.rs
+++ b/crates/larql-vindex/src/lib.rs
@@ -25,6 +25,7 @@
 // BLAS provided by larql-compute dependency (no direct blas_src needed)
 
 // ── Module structure ──
+pub mod canonical;
 pub mod clustering;
 pub mod config;
 pub mod describe;
@@ -51,6 +52,9 @@ pub use ndarray;
 pub use tokenizers;
 
 // ── Re-export essentials at crate root ──
+
+// Canonical
+pub use canonical::{CanonicalMeta, LayerCanonicalInfo, Regime};
 
 // Config
 pub use config::dtype::StorageDtype;

--- a/docs/lql-guide.md
+++ b/docs/lql-guide.md
@@ -114,6 +114,12 @@ INFER "The capital of Atlantis is" ROUTE VERIFY TOP 3;
 -- non-stored entity it can confident-wrong like the legacy gate — use FALLBACK
 -- only for queries known to be aliases of stored entities.
 INFER "The capital of Persia is" ROUTE VERIFY FALLBACK TOPK 8 TOP 3;
+
+-- EXIT: retrieval-augmented early exit. When the verified hit fires, the forward
+-- short-circuits at the resolved layer — the stored target is emitted and the
+-- remaining layers + lm_head are skipped (parity-exact, ~1.4× faster on
+-- fact-lookup answer tokens). Verified-only; ignored with FALLBACK.
+INFER "The capital of Atlantis is" ROUTE VERIFY EXIT TOP 3;
 ```
 
 With no `ROUTE` clause, INFER inherits the global default from the `LARQL_KNN_*`

--- a/docs/superpowers/plans/2026-06-10-canonical-extraction-pipeline.md
+++ b/docs/superpowers/plans/2026-06-10-canonical-extraction-pipeline.md
@@ -1,0 +1,1435 @@
+# Canonical Extraction Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `larql canonicalize <vindex-path>` — a command that computes the flat-canonical (single G constant across all layers, semi-intrinsic W_E calibration) form of a vindex and writes `canonical_meta.json` into the vindex directory.
+
+**Architecture:** A new `canonical` module in `larql-vindex` implements four pure algorithms: covariance estimation from the token embedding matrix, Cholesky whitening factor computation, on-shell feature scoring via c_score percentile, and regime classification per layer from the existing layer bands and activation density. The `larql-cli` gets a `Canonicalize` subcommand that opens a vindex directory, runs the pipeline, and writes `canonical_meta.json`. The existing vindex files are left untouched — canonicalize is purely additive.
+
+**Tech Stack:** Rust 2021, ndarray 0.16, existing `larql_compute::cpu::ops::linalg` (Cholesky, cholesky_inverse), `larql-vindex` format loaders (embeddings.bin, down_meta.bin, gate_vectors.bin, index.json), serde_json, clap.
+
+---
+
+## Scope note: three separate plans
+
+This synthesis document covers three independent subsystems. This plan covers **Plan 1 only**:
+
+- **Plan 1 (this):** Canonical extraction pipeline — `larql canonicalize`. The load-bearing missing piece. No prerequisites.
+- **Plan 2 (separate):** Knowledge graph integration — INSERT ops importer + entity→QID alignment. Depends on Plan 1 canonical_meta.json for Class A label addressing.
+- **Plan 3 (separate):** Cross-model Procrustes alignment CLI — `larql align`. Depends on Plan 1 whitening factor.
+
+---
+
+## Key domain concepts
+
+- **G (activation covariance):** `G = (1/N) Σ_v (embed_scale · W_E[v])^T (embed_scale · W_E[v])` where W_E is the token embedding matrix. Shape [hidden_size, hidden_size]. The flat-canonical choice uses a single G for all layers (semi-intrinsic, computed from model weights alone, no external corpus needed).
+- **Cholesky whitening:** `G = L L^T`. The whitened gate vector is `g̃_f = L^{-T} g_f` (back-solve `L^T g̃_f = g_f`). Two whitened vectors have Mahalanobis inner product = ordinary dot product.
+- **c_score:** the logit of the feature's top down-projected token (already in `down_meta.bin`). High c_score = feature strongly predicts a specific token = factual/on-shell.
+- **On-shell filter:** the top 15% features by c_score within each layer. These are the "detail wavelets" (factual subspace). Features below the 85th percentile are structural ("dark space").
+- **Regime per layer:** Wave (mean_density > 0.5), Particle (mean_density < 0.05), Wavelet (otherwise). `mean_density` = fraction of layer features with c_score above a low floor (c_score > 0.1 indicates the feature fires for at least some inputs).
+
+## File structure
+
+**New files:**
+- `crates/larql-compute/src/cpu/ops/linalg.rs` — add `back_solve_lt`, `compute_l_inv_t` functions
+- `crates/larql-vindex/src/canonical/mod.rs`
+- `crates/larql-vindex/src/canonical/types.rs` — `Regime`, `LayerCanonicalInfo`, `CanonicalMeta`
+- `crates/larql-vindex/src/canonical/covariance.rs` — `estimate_covariance`
+- `crates/larql-vindex/src/canonical/whitening.rs` — `WhiteningData`, `compute_whitening`
+- `crates/larql-vindex/src/canonical/onshell.rs` — `compute_onshell_mask`
+- `crates/larql-vindex/src/canonical/regime.rs` — `classify_layer_regime`
+- `crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs`
+
+**Modified files:**
+- `crates/larql-compute/src/cpu/ops/linalg.rs` — add two functions
+- `crates/larql-vindex/src/format/down_meta.rs` — add `read_cscores_binary` (no tokenizer needed)
+- `crates/larql-vindex/src/format/filenames.rs` — add `CANONICAL_META_JSON` constant
+- `crates/larql-vindex/src/lib.rs` — add `pub mod canonical;` and re-export types
+- `crates/larql-cli/src/commands/extraction/mod.rs` — add `pub mod canonicalize_cmd;`
+- `crates/larql-cli/src/main.rs` — add `Canonicalize` variant to `Commands`
+
+---
+
+## Task 1: `back_solve_lt` and `compute_l_inv_t` in linalg.rs
+
+These are the only new numerical primitives needed. Everything else uses existing Cholesky.
+
+**Files:**
+- Modify: `crates/larql-compute/src/cpu/ops/linalg.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the bottom of `crates/larql-compute/src/cpu/ops/linalg.rs`:
+
+```rust
+#[cfg(test)]
+mod canonical_linalg_tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn lower_3x3() -> Array2<f64> {
+        // L = [[2,0,0],[1,3,0],[4,5,6]]
+        let mut l = Array2::<f64>::zeros((3, 3));
+        l[[0,0]] = 2.0; l[[1,0]] = 1.0; l[[1,1]] = 3.0;
+        l[[2,0]] = 4.0; l[[2,1]] = 5.0; l[[2,2]] = 6.0;
+        l
+    }
+
+    #[test]
+    fn back_solve_lt_recovers_rhs() {
+        // L^T z = b, check L^T (back_solve_lt(L, b)) == b
+        let l = lower_3x3();
+        let b = Array2::from_shape_vec((3, 2), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        let z = back_solve_lt(&l, &b);
+        // Verify L^T z == b
+        let lt = l.t().to_owned();
+        for col in 0..2 {
+            for row in 0..3 {
+                let dot: f64 = (0..3).map(|k| lt[[row, k]] * z[[k, col]]).sum();
+                assert!((dot - b[[row, col]]).abs() < 1e-10, "row={row} col={col} dot={dot} expected={}", b[[row,col]]);
+            }
+        }
+    }
+
+    #[test]
+    fn compute_l_inv_t_times_l_t_is_identity() {
+        let l = lower_3x3();
+        let l_inv_t = compute_l_inv_t(&l);
+        // l_inv_t @ l^T should == I
+        let lt = l.t().to_owned();
+        let product = l_inv_t.dot(&lt);
+        for i in 0..3 {
+            for j in 0..3 {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!((product[[i,j]] - expected).abs() < 1e-10,
+                    "product[{i},{j}]={} expected={expected}", product[[i,j]]);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+cargo test -p larql-compute canonical_linalg_tests 2>&1 | tail -5
+```
+Expected: FAIL — `back_solve_lt` and `compute_l_inv_t` not defined.
+
+- [ ] **Step 3: Implement `back_solve_lt` and `compute_l_inv_t`**
+
+Add to `crates/larql-compute/src/cpu/ops/linalg.rs` before the `#[cfg(test)]` block:
+
+```rust
+/// Back-substitution: solve L^T X = B where L is lower-triangular.
+/// L^T is upper-triangular, so we iterate from bottom row to top.
+/// Returns X of the same shape as B.
+pub fn back_solve_lt(l: &Array2<f64>, b: &Array2<f64>) -> Array2<f64> {
+    let n = l.shape()[0];
+    let m = b.shape()[1];
+    let mut x = Array2::<f64>::zeros((n, m));
+    // L^T[i,j] = L[j,i]. Upper-triangular back-substitution:
+    for i in (0..n).rev() {
+        for col in 0..m {
+            let mut sum = b[[i, col]];
+            for k in (i + 1)..n {
+                sum -= l[[k, i]] * x[[k, col]]; // L^T[i,k] = L[k,i]
+            }
+            x[[i, col]] = sum / l[[i, i]];
+        }
+    }
+    x
+}
+
+/// Compute L^{-T} explicitly: the d×d matrix such that L^{-T} @ L^T = I.
+/// Equivalent to: for each unit column e_j, solve L^T x = e_j via back_solve_lt.
+/// Returns a d×d array — the whitening matrix for gate vectors.
+pub fn compute_l_inv_t(l: &Array2<f64>) -> Array2<f64> {
+    let n = l.shape()[0];
+    let identity = Array2::<f64>::eye(n);
+    back_solve_lt(l, &identity)
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```
+cargo test -p larql-compute canonical_linalg_tests 2>&1 | tail -5
+```
+Expected: `test result: ok. 2 passed`
+
+- [ ] **Step 5: Run full larql-compute tests to verify no regression**
+
+```
+cargo test -p larql-compute 2>&1 | tail -5
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/larql-compute/src/cpu/ops/linalg.rs
+git commit -m "feat(linalg): add back_solve_lt and compute_l_inv_t for canonical whitening"
+```
+
+---
+
+## Task 2: `CANONICAL_META_JSON` filename constant
+
+**Files:**
+- Modify: `crates/larql-vindex/src/format/filenames.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/larql-vindex/src/format/filenames.rs`, inside `mod tests`, add:
+
+```rust
+#[test]
+fn canonical_meta_json_is_unique() {
+    // CANONICAL_META_JSON must not collide with any existing constant.
+    let existing = [
+        INDEX_JSON, TOKENIZER_JSON, TOKENIZER_CONFIG_JSON, GENERATION_CONFIG_JSON,
+        WEIGHT_MANIFEST_JSON, EMBEDDINGS_BIN, NORMS_BIN, GATE_VECTORS_BIN, DOWN_META_BIN,
+    ];
+    for name in existing {
+        assert_ne!(CANONICAL_META_JSON, name,
+            "CANONICAL_META_JSON collides with {name}");
+    }
+    assert_eq!(CANONICAL_META_JSON, "canonical_meta.json");
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```
+cargo test -p larql-vindex canonical_meta_json_is_unique 2>&1 | tail -5
+```
+Expected: FAIL — constant not defined.
+
+- [ ] **Step 3: Add the constant**
+
+In `crates/larql-vindex/src/format/filenames.rs`, after the `INDEX_JSON` group (around line 22), add:
+
+```rust
+// ── Canonical form sidecar ──────────────────────────────────────────────
+pub const CANONICAL_META_JSON: &str = "canonical_meta.json";
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+```
+cargo test -p larql-vindex canonical_meta_json_is_unique 2>&1 | tail -5
+```
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/larql-vindex/src/format/filenames.rs
+git commit -m "feat(filenames): add CANONICAL_META_JSON constant"
+```
+
+---
+
+## Task 3: Canonical types
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/types.rs`
+- Create: `crates/larql-vindex/src/canonical/mod.rs`
+- Modify: `crates/larql-vindex/src/lib.rs`
+
+- [ ] **Step 1: Write failing tests (in types.rs, will fail until the file exists)**
+
+Create `crates/larql-vindex/src/canonical/types.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+/// Wave/Particle/Wavelet activation regime for a transformer layer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Regime {
+    /// Dense activations — many weak gates fire (e.g., early syntax layers).
+    Wave,
+    /// Sparse activations — few strong gates fire (e.g., MoE knowledge layers).
+    Particle,
+    /// Mixed — multi-resolution, some wave structure, some particle selectivity.
+    Wavelet,
+}
+
+/// Per-layer canonical metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerCanonicalInfo {
+    pub layer: usize,
+    pub regime: Regime,
+    /// Number of features that pass the on-shell filter (top 15% by c_score).
+    pub on_shell_count: usize,
+    /// Total features at this layer.
+    pub total_features: usize,
+    /// Fraction of features with c_score > 0.1 (activation density proxy).
+    pub mean_density: f32,
+}
+
+/// Root canonical metadata written to `canonical_meta.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalMeta {
+    /// Format version; increment when the schema changes.
+    pub version: u32,
+    pub model: String,
+    pub family: String,
+    pub num_layers: usize,
+    pub hidden_size: usize,
+    /// Number of embedding rows sampled to estimate G.
+    pub covariance_sample_size: usize,
+    /// embed_scale used when computing G.
+    pub embed_scale: f32,
+    /// Cholesky factor L packed row-major lower-triangle:
+    /// indices (i,j) with j<=i stored as L[i*(i+1)/2 + j].
+    /// Length = hidden_size * (hidden_size + 1) / 2. Values are f64.
+    pub cholesky_l_packed: Vec<f64>,
+    /// Per-layer info.
+    pub layers: Vec<LayerCanonicalInfo>,
+}
+
+impl CanonicalMeta {
+    /// Unpack the lower-triangular Cholesky factor into a dense d×d matrix.
+    pub fn unpack_cholesky_l(&self) -> ndarray::Array2<f64> {
+        let d = self.hidden_size;
+        let mut l = ndarray::Array2::<f64>::zeros((d, d));
+        for i in 0..d {
+            for j in 0..=i {
+                l[[i, j]] = self.cholesky_l_packed[i * (i + 1) / 2 + j];
+            }
+        }
+        l
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regime_serialises_as_snake_case() {
+        assert_eq!(serde_json::to_string(&Regime::Wave).unwrap(), "\"wave\"");
+        assert_eq!(serde_json::to_string(&Regime::Particle).unwrap(), "\"particle\"");
+        assert_eq!(serde_json::to_string(&Regime::Wavelet).unwrap(), "\"wavelet\"");
+    }
+
+    #[test]
+    fn canonical_meta_round_trips_through_json() {
+        let meta = CanonicalMeta {
+            version: 1,
+            model: "test/model".into(),
+            family: "llama".into(),
+            num_layers: 2,
+            hidden_size: 4,
+            covariance_sample_size: 32,
+            embed_scale: 1.0,
+            // 4×4 lower triangle: 10 values (indices 0..9)
+            cholesky_l_packed: vec![1.0, 0.0, 2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0],
+            layers: vec![
+                LayerCanonicalInfo {
+                    layer: 0, regime: Regime::Wave,
+                    on_shell_count: 1, total_features: 4, mean_density: 0.75,
+                },
+                LayerCanonicalInfo {
+                    layer: 1, regime: Regime::Particle,
+                    on_shell_count: 1, total_features: 4, mean_density: 0.02,
+                },
+            ],
+        };
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        let back: CanonicalMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.family, "llama");
+        assert_eq!(back.layers[0].regime, Regime::Wave);
+        assert_eq!(back.layers[1].regime, Regime::Particle);
+        assert_eq!(back.cholesky_l_packed.len(), 10);
+    }
+
+    #[test]
+    fn unpack_cholesky_l_recovers_diagonal() {
+        // Packed lower-triangle of 3×3: [L00, L10, L11, L20, L21, L22]
+        let meta = CanonicalMeta {
+            version: 1, model: "x".into(), family: "y".into(),
+            num_layers: 1, hidden_size: 3,
+            covariance_sample_size: 8, embed_scale: 1.0,
+            cholesky_l_packed: vec![2.0, 1.0, 3.0, 4.0, 5.0, 6.0],
+            layers: vec![],
+        };
+        let l = meta.unpack_cholesky_l();
+        assert_eq!(l[[0, 0]], 2.0);
+        assert_eq!(l[[1, 0]], 1.0);
+        assert_eq!(l[[1, 1]], 3.0);
+        assert_eq!(l[[2, 0]], 4.0);
+        assert_eq!(l[[2, 1]], 5.0);
+        assert_eq!(l[[2, 2]], 6.0);
+        // Upper triangle must be zero
+        assert_eq!(l[[0, 1]], 0.0);
+        assert_eq!(l[[0, 2]], 0.0);
+    }
+}
+```
+
+- [ ] **Step 2: Create `crates/larql-vindex/src/canonical/mod.rs`**
+
+```rust
+pub mod types;
+pub use types::{CanonicalMeta, LayerCanonicalInfo, Regime};
+```
+
+- [ ] **Step 3: Add `pub mod canonical;` to `crates/larql-vindex/src/lib.rs`**
+
+In `crates/larql-vindex/src/lib.rs`, after `pub mod config;`, add:
+
+```rust
+pub mod canonical;
+```
+
+Also add re-exports after the existing `// Re-export essentials at crate root` section:
+
+```rust
+// Canonical
+pub use canonical::{CanonicalMeta, LayerCanonicalInfo, Regime};
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+cargo test -p larql-vindex canonical::types 2>&1 | tail -5
+```
+Expected: `test result: ok. 3 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/larql-vindex/src/canonical/ crates/larql-vindex/src/lib.rs
+git commit -m "feat(canonical): add CanonicalMeta, LayerCanonicalInfo, Regime types"
+```
+
+---
+
+## Task 4: C-score-only reader for down_meta
+
+We need to read `down_meta.bin` without constructing token strings (no tokenizer dependency).
+
+**Files:**
+- Modify: `crates/larql-vindex/src/format/down_meta.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/larql-vindex/src/format/down_meta.rs`, inside the existing `#[cfg(test)]` block, add:
+
+```rust
+#[test]
+fn read_cscores_binary_matches_full_read() {
+    // Build a tiny down_meta.bin with known c_scores, then verify
+    // read_cscores_binary extracts them correctly.
+    let dir = tempfile::tempdir().unwrap();
+    let meta: Vec<Option<Vec<Option<FeatureMeta>>>> = vec![
+        Some(vec![
+            Some(FeatureMeta {
+                top_token: "hello".into(),
+                top_token_id: 1,
+                c_score: 3.5,
+                top_k: vec![larql_models::TopKEntry {
+                    token: "hello".into(), token_id: 1, logit: 3.5,
+                }],
+            }),
+            Some(FeatureMeta {
+                top_token: "world".into(),
+                top_token_id: 2,
+                c_score: 1.2,
+                top_k: vec![larql_models::TopKEntry {
+                    token: "world".into(), token_id: 2, logit: 1.2,
+                }],
+            }),
+        ]),
+        None,
+    ];
+    write_binary(dir.path(), &meta, 1).unwrap();
+    let cscores = read_cscores_binary(dir.path()).unwrap();
+    assert_eq!(cscores.len(), 2);
+    assert_eq!(cscores[0], vec![3.5f32, 1.2f32]);
+    assert!(cscores[1].is_empty(), "None layer should give empty vec");
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```
+cargo test -p larql-vindex read_cscores_binary_matches_full_read 2>&1 | tail -5
+```
+Expected: FAIL — `read_cscores_binary` not defined.
+
+- [ ] **Step 3: Implement `read_cscores_binary`**
+
+Add to `crates/larql-vindex/src/format/down_meta.rs` after the `read_binary` function:
+
+```rust
+/// Read only c_scores from down_meta.bin — no tokenizer needed.
+/// Returns a Vec (per layer) of Vec<f32> (per feature).
+/// Layers with no features (None in the full format) yield an empty Vec.
+pub fn read_cscores_binary(dir: &Path) -> Result<Vec<Vec<f32>>, VindexError> {
+    let path = dir.join(DOWN_META_BIN);
+    let file = std::fs::File::open(&path)?;
+    let mut r = BufReader::new(file);
+
+    let magic = read_u32(&mut r)?;
+    if magic != MAGIC && magic != LEGACY_LITERAL_MAGIC {
+        return Err(VindexError::Parse(format!(
+            "invalid down_meta.bin magic: 0x{magic:08X}"
+        )));
+    }
+    let version = read_u32(&mut r)?;
+    if version != FORMAT_VERSION {
+        return Err(VindexError::Parse(format!(
+            "unsupported down_meta.bin version: {version}"
+        )));
+    }
+    let num_layers = read_u32(&mut r)? as usize;
+    let top_k_count = read_u32(&mut r)? as usize;
+    // Bytes to skip per feature after reading c_score:
+    // top_k_count × (u32 token_id + f32 logit) = top_k_count × 8 bytes
+    let skip_per_feature = top_k_count * (U32_BYTES + F32_BYTES);
+
+    let mut result = Vec::with_capacity(num_layers);
+    for _ in 0..num_layers {
+        let num_features = read_u32(&mut r)? as usize;
+        if num_features == 0 {
+            result.push(Vec::new());
+            continue;
+        }
+        let mut cscores = Vec::with_capacity(num_features);
+        for _ in 0..num_features {
+            let _top_token_id = read_u32(&mut r)?;
+            let c_score = read_f32(&mut r)?;
+            cscores.push(c_score);
+            // Skip top_k entries
+            let mut skip_buf = vec![0u8; skip_per_feature];
+            r.read_exact(&mut skip_buf)?;
+        }
+        result.push(cscores);
+    }
+    Ok(result)
+}
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+```
+cargo test -p larql-vindex read_cscores_binary_matches_full_read 2>&1 | tail -5
+```
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 5: Run full larql-vindex tests**
+
+```
+cargo test -p larql-vindex 2>&1 | tail -8
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/larql-vindex/src/format/down_meta.rs
+git commit -m "feat(down_meta): add read_cscores_binary (no tokenizer dependency)"
+```
+
+---
+
+## Task 5: Covariance estimation
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/covariance.rs`
+- Modify: `crates/larql-vindex/src/canonical/mod.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/larql-vindex/src/canonical/covariance.rs`:
+
+```rust
+use ndarray::{Array2, s};
+
+/// Estimate the activation covariance G = (1/N) Σ (s·W_E[v])^T (s·W_E[v])
+/// using at most `max_samples` rows from the embedding matrix.
+/// Rows are subsampled deterministically (every stride-th row).
+/// Returns a [hidden_size, hidden_size] f64 matrix.
+pub fn estimate_covariance(
+    embed: &Array2<f32>,
+    embed_scale: f32,
+    max_samples: usize,
+) -> Array2<f64> {
+    let (vocab, d) = (embed.shape()[0], embed.shape()[1]);
+    let stride = (vocab / max_samples).max(1);
+    let indices: Vec<usize> = (0..vocab).step_by(stride).collect();
+    let n = indices.len();
+
+    let mut g = Array2::<f64>::zeros((d, d));
+    let scale = embed_scale as f64;
+
+    for &v in &indices {
+        let row = embed.slice(s![v, ..]);
+        for i in 0..d {
+            let xi = row[i] as f64 * scale;
+            for j in 0..=i {
+                let xj = row[j] as f64 * scale;
+                g[[i, j]] += xi * xj;
+                if i != j {
+                    g[[j, i]] += xi * xj;
+                }
+            }
+        }
+    }
+
+    let norm = n as f64;
+    g.mapv_inplace(|v| v / norm);
+    g
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn identity_embed(d: usize) -> Array2<f32> {
+        // Each row is a basis vector — G should be I/d * d = I (after normalization).
+        // Actually G = (1/d) I·I^T = I (diagonal 1.0) when embed = I_d.
+        Array2::<f32>::eye(d)
+    }
+
+    #[test]
+    fn covariance_of_identity_is_identity_scaled() {
+        // embed = 4×4 identity, embed_scale = 1.0, max_samples = 4
+        let embed = identity_embed(4);
+        let g = estimate_covariance(&embed, 1.0, 4);
+        // G = (1/4) Σ_v e_v e_v^T = (1/4) I. Diagonal = 0.25, off-diag = 0.
+        for i in 0..4 {
+            for j in 0..4 {
+                let expected = if i == j { 0.25 } else { 0.0 };
+                assert!(
+                    (g[[i, j]] - expected).abs() < 1e-10,
+                    "G[{i},{j}]={} expected={expected}", g[[i, j]]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn covariance_is_positive_semidefinite() {
+        // A PSD matrix has non-negative diagonal and the off-diagonal satisfies
+        // G[i,j]^2 <= G[i,i] * G[j,j] (Cauchy-Schwarz).
+        let embed = Array2::from_shape_fn((8, 4), |(v, d)| (v as f32 + 1.0) * (d as f32 + 1.0));
+        let g = estimate_covariance(&embed, 0.5, 8);
+        for i in 0..4 {
+            assert!(g[[i, i]] >= 0.0, "diagonal must be non-negative");
+            for j in 0..4 {
+                assert!(
+                    g[[i, j]] * g[[i, j]] <= g[[i, i]] * g[[j, j]] + 1e-10,
+                    "Cauchy-Schwarz violated at ({i},{j})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn covariance_is_symmetric() {
+        let embed = Array2::from_shape_fn((16, 4), |(v, d)| (v * d) as f32 * 0.1 + 0.01);
+        let g = estimate_covariance(&embed, 1.0, 16);
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!((g[[i, j]] - g[[j, i]]).abs() < 1e-10,
+                    "G not symmetric at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn embed_scale_squares_into_covariance() {
+        let embed = identity_embed(4);
+        let g1 = estimate_covariance(&embed, 1.0, 4);
+        let g2 = estimate_covariance(&embed, 2.0, 4);
+        // Scaling by s multiplies G by s^2
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!((g2[[i, j]] - 4.0 * g1[[i, j]]).abs() < 1e-10,
+                    "scale^2 law violated at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn subsampling_reduces_sample_count_not_shape() {
+        let embed = Array2::from_shape_fn((100, 4), |(v, _)| v as f32);
+        let g = estimate_covariance(&embed, 1.0, 10);
+        assert_eq!(g.shape(), [4, 4]);
+    }
+}
+```
+
+- [ ] **Step 2: Add to `mod.rs`**
+
+In `crates/larql-vindex/src/canonical/mod.rs`, add:
+
+```rust
+pub mod covariance;
+pub use covariance::estimate_covariance;
+```
+
+- [ ] **Step 3: Run tests to confirm they fail first**
+
+```
+cargo test -p larql-vindex canonical::covariance 2>&1 | tail -5
+```
+Expected: compile error — module doesn't exist yet (you just created the file, so this should compile but tests should pass; if the impl is in the file you wrote, they should pass immediately).
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```
+cargo test -p larql-vindex canonical::covariance 2>&1 | tail -5
+```
+Expected: `test result: ok. 5 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/larql-vindex/src/canonical/covariance.rs crates/larql-vindex/src/canonical/mod.rs
+git commit -m "feat(canonical): add estimate_covariance from token embeddings"
+```
+
+---
+
+## Task 6: Cholesky whitening
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/whitening.rs`
+- Modify: `crates/larql-vindex/src/canonical/mod.rs`
+
+- [ ] **Step 1: Write the failing tests and implementation together**
+
+Create `crates/larql-vindex/src/canonical/whitening.rs`:
+
+```rust
+use ndarray::Array2;
+
+use larql_compute::cholesky;
+// back_solve_lt and compute_l_inv_t are re-exported from larql_compute
+pub use larql_compute::{back_solve_lt, compute_l_inv_t};
+
+/// Ridge regularisation added to G diagonal before Cholesky decomposition.
+/// Prevents failure on near-singular covariance (small hidden dims in tests).
+const DEFAULT_RIDGE: f64 = 1e-5;
+
+/// The Cholesky whitening data computed from a covariance matrix G.
+pub struct WhiteningData {
+    /// Lower triangular Cholesky factor L such that G = L L^T.
+    pub l: Array2<f64>,
+    /// Packed lower triangle of L for storage in canonical_meta.json.
+    /// Entry (i,j) with j<=i is at index i*(i+1)/2 + j.
+    pub l_packed: Vec<f64>,
+}
+
+/// Compute the Cholesky factor of the covariance matrix G.
+/// Returns `WhiteningData` containing L and its packed form.
+pub fn compute_whitening(g: &Array2<f64>) -> Result<WhiteningData, String> {
+    let l = cholesky(g, DEFAULT_RIDGE)?;
+    let d = l.shape()[0];
+    let mut l_packed = Vec::with_capacity(d * (d + 1) / 2);
+    for i in 0..d {
+        for j in 0..=i {
+            l_packed.push(l[[i, j]]);
+        }
+    }
+    Ok(WhiteningData { l, l_packed })
+}
+
+/// Unpack a lower-triangle-packed Cholesky factor back to a dense d×d matrix.
+pub fn unpack_l(packed: &[f64], d: usize) -> Array2<f64> {
+    let mut l = Array2::<f64>::zeros((d, d));
+    for i in 0..d {
+        for j in 0..=i {
+            l[[i, j]] = packed[i * (i + 1) / 2 + j];
+        }
+    }
+    l
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn spd_3x3() -> Array2<f64> {
+        // G = [[4,2,1],[2,5,3],[1,3,6]] (symmetric positive definite)
+        let data = vec![4.0_f64, 2.0, 1.0, 2.0, 5.0, 3.0, 1.0, 3.0, 6.0];
+        Array2::from_shape_vec((3, 3), data).unwrap()
+    }
+
+    #[test]
+    fn cholesky_recovers_g() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        let reconstructed = wd.l.dot(&wd.l.t());
+        // With ridge=1e-5, G_reconstructed ≈ G + 1e-5 * I
+        for i in 0..3 {
+            for j in 0..3 {
+                let expected = g[[i, j]] + if i == j { 1e-5 } else { 0.0 };
+                assert!((reconstructed[[i, j]] - expected).abs() < 1e-8,
+                    "L L^T differs from G+ridge at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn l_is_lower_triangular() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        for i in 0..3 {
+            for j in (i + 1)..3 {
+                assert_eq!(wd.l[[i, j]], 0.0, "upper triangle not zero at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn l_packed_length_is_triangular_number() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        assert_eq!(wd.l_packed.len(), 3 * 4 / 2); // 6
+    }
+
+    #[test]
+    fn unpack_roundtrips_packed() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        let l2 = unpack_l(&wd.l_packed, 3);
+        for i in 0..3 {
+            for j in 0..3 {
+                assert!((l2[[i, j]] - wd.l[[i, j]]).abs() < 1e-14,
+                    "unpack mismatch at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn whitening_makes_mahalanobis_a_dot_product() {
+        // After whitening g̃ = L^{-T} g, the Mahalanobis score g^T G^{-1} h
+        // equals the ordinary dot product g̃ · h̃.
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        let l_inv_t = compute_l_inv_t(&wd.l);
+
+        // Two test vectors
+        let g_vec = Array2::from_shape_vec((3, 1), vec![1.0f64, 2.0, 3.0]).unwrap();
+        let h_vec = Array2::from_shape_vec((3, 1), vec![4.0f64, 5.0, 6.0]).unwrap();
+
+        // Whitened vectors
+        let g_tilde = l_inv_t.dot(&g_vec); // L^{-T} g
+        let h_tilde = l_inv_t.dot(&h_vec); // L^{-T} h
+
+        // Mahalanobis: g^T G^{-1} h = g^T L^{-T} L^{-1} h = g̃^T h̃
+        let dot_whitened: f64 = (0..3).map(|i| g_tilde[[i, 0]] * h_tilde[[i, 0]]).sum();
+
+        // Direct Mahalanobis using cholesky_inverse
+        let l_inv = larql_compute::cholesky_inverse(&wd.l);
+        let g_inv = l_inv.t().dot(&l_inv);
+        let mahal: f64 = {
+            let tmp = g_inv.dot(&h_vec);
+            (0..3).map(|i| g_vec[[i, 0]] * tmp[[i, 0]]).sum()
+        };
+
+        assert!((dot_whitened - mahal).abs() < 1e-8,
+            "whitened dot={dot_whitened} mahal={mahal}");
+    }
+}
+```
+
+- [ ] **Step 2: Expose `back_solve_lt` and `compute_l_inv_t` from `larql-compute`**
+
+In `crates/larql-compute/src/lib.rs`, add to the existing public exports:
+
+```rust
+pub use cpu::ops::linalg::{back_solve_lt, cholesky, cholesky_inverse, cholesky_solve,
+    compute_l_inv_t, ridge_decomposition_solve};
+```
+
+(Find the existing `pub use cpu::ops::linalg::{cholesky, ...}` line and extend it.)
+
+- [ ] **Step 3: Add `larql-compute` dependency to `larql-vindex/Cargo.toml` if not already present**
+
+Check:
+```
+grep "larql-compute" crates/larql-vindex/Cargo.toml
+```
+If absent, add under `[dependencies]`:
+```toml
+larql-compute = { path = "../larql-compute" }
+```
+
+- [ ] **Step 4: Add to `canonical/mod.rs`**
+
+```rust
+pub mod whitening;
+pub use whitening::{compute_whitening, unpack_l, WhiteningData};
+```
+
+- [ ] **Step 5: Run tests**
+
+```
+cargo test -p larql-vindex canonical::whitening 2>&1 | tail -5
+```
+Expected: `test result: ok. 5 passed`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/larql-vindex/src/canonical/whitening.rs \
+        crates/larql-vindex/src/canonical/mod.rs \
+        crates/larql-compute/src/lib.rs \
+        crates/larql-vindex/Cargo.toml
+git commit -m "feat(canonical): add Cholesky whitening (compute_whitening, unpack_l)"
+```
+
+---
+
+## Task 7: On-shell filter
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/onshell.rs`
+- Modify: `crates/larql-vindex/src/canonical/mod.rs`
+
+- [ ] **Step 1: Write the failing tests and implementation**
+
+Create `crates/larql-vindex/src/canonical/onshell.rs`:
+
+```rust
+/// Compute a boolean on-shell mask for features in one layer.
+/// Features whose c_score ranks in the top `top_fraction` are on-shell.
+/// `top_fraction = 0.15` reproduces the "15% factual subspace" from the synthesis.
+///
+/// Returns a Vec<bool> of length equal to `c_scores`.
+/// Empty input returns an empty Vec.
+pub fn compute_onshell_mask(c_scores: &[f32], top_fraction: f32) -> Vec<bool> {
+    if c_scores.is_empty() {
+        return Vec::new();
+    }
+    let n = c_scores.len();
+    // Number of on-shell features (at least 1 if any features exist)
+    let k = ((n as f32 * top_fraction).ceil() as usize).max(1).min(n);
+    // Find the k-th largest c_score (threshold)
+    let mut sorted: Vec<f32> = c_scores.to_vec();
+    sorted.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    let threshold = sorted[k - 1];
+    // Mark as on-shell all features with c_score >= threshold.
+    // Ties are included (may yield slightly more than k on-shell features).
+    c_scores.iter().map(|&s| s >= threshold).collect()
+}
+
+/// Count on-shell features across all layers and return (on_shell_count, total).
+pub fn onshell_stats(c_scores_per_layer: &[Vec<f32>], top_fraction: f32) -> Vec<(usize, usize)> {
+    c_scores_per_layer
+        .iter()
+        .map(|cscores| {
+            let mask = compute_onshell_mask(cscores, top_fraction);
+            let on_shell = mask.iter().filter(|&&b| b).count();
+            (on_shell, cscores.len())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_15pct_of_10_is_2() {
+        // 15% of 10 = 1.5 → ceil = 2
+        let scores: Vec<f32> = (0..10).map(|i| i as f32).collect(); // 0..9
+        let mask = compute_onshell_mask(&scores, 0.15);
+        // Top 2 = scores 8 and 9
+        let on_shell_indices: Vec<usize> =
+            mask.iter().enumerate().filter(|(_, &b)| b).map(|(i, _)| i).collect();
+        assert_eq!(on_shell_indices.len(), 2);
+        assert!(on_shell_indices.contains(&8));
+        assert!(on_shell_indices.contains(&9));
+    }
+
+    #[test]
+    fn empty_scores_returns_empty_mask() {
+        assert!(compute_onshell_mask(&[], 0.15).is_empty());
+    }
+
+    #[test]
+    fn single_feature_always_on_shell() {
+        let mask = compute_onshell_mask(&[0.5], 0.15);
+        assert_eq!(mask, vec![true]);
+    }
+
+    #[test]
+    fn mask_length_matches_input() {
+        let scores: Vec<f32> = (0..100).map(|i| i as f32 * 0.01).collect();
+        let mask = compute_onshell_mask(&scores, 0.15);
+        assert_eq!(mask.len(), 100);
+    }
+
+    #[test]
+    fn on_shell_count_is_at_least_top_fraction() {
+        let scores: Vec<f32> = (0..20).map(|i| i as f32).collect();
+        let mask = compute_onshell_mask(&scores, 0.15);
+        let count = mask.iter().filter(|&&b| b).count();
+        // 15% of 20 = 3 → expect exactly 3
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn all_same_scores_all_on_shell() {
+        // When all c_scores are equal, all features tie at the threshold.
+        let scores = vec![1.0f32; 10];
+        let mask = compute_onshell_mask(&scores, 0.15);
+        // All values >= threshold (which is 1.0), so all are on-shell.
+        assert!(mask.iter().all(|&b| b));
+    }
+
+    #[test]
+    fn onshell_stats_counts_per_layer() {
+        let layers = vec![
+            vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+            vec![],
+        ];
+        let stats = onshell_stats(&layers, 0.15);
+        assert_eq!(stats.len(), 2);
+        let (on, total) = stats[0];
+        assert_eq!(total, 10);
+        assert_eq!(on, 2); // top 15% of 10 = 2
+        let (on2, total2) = stats[1];
+        assert_eq!(total2, 0);
+        assert_eq!(on2, 0);
+    }
+}
+```
+
+- [ ] **Step 2: Add to `canonical/mod.rs`**
+
+```rust
+pub mod onshell;
+pub use onshell::{compute_onshell_mask, onshell_stats};
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cargo test -p larql-vindex canonical::onshell 2>&1 | tail -5
+```
+Expected: `test result: ok. 7 passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/larql-vindex/src/canonical/onshell.rs crates/larql-vindex/src/canonical/mod.rs
+git commit -m "feat(canonical): add on-shell feature filter (top 15% by c_score)"
+```
+
+---
+
+## Task 8: Regime classifier
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/regime.rs`
+- Modify: `crates/larql-vindex/src/canonical/mod.rs`
+
+- [ ] **Step 1: Write the failing tests and implementation**
+
+Create `crates/larql-vindex/src/canonical/regime.rs`:
+
+```rust
+use crate::canonical::types::Regime;
+
+/// Activation density floor: features with c_score above this are "active".
+const ACTIVE_FLOOR: f32 = 0.1;
+
+/// Classify the regime for a single layer.
+/// `c_scores`: c_score for each feature in this layer.
+/// `mean_density` = fraction of features with c_score > ACTIVE_FLOOR.
+///   - mean_density > 0.5  → Wave
+///   - mean_density < 0.05 → Particle
+///   - otherwise           → Wavelet
+pub fn classify_layer_regime(c_scores: &[f32]) -> (Regime, f32) {
+    if c_scores.is_empty() {
+        return (Regime::Wavelet, 0.0);
+    }
+    let active = c_scores.iter().filter(|&&s| s > ACTIVE_FLOOR).count();
+    let density = active as f32 / c_scores.len() as f32;
+    let regime = if density > 0.5 {
+        Regime::Wave
+    } else if density < 0.05 {
+        Regime::Particle
+    } else {
+        Regime::Wavelet
+    };
+    (regime, density)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dense_layer_is_wave() {
+        // 80% of features active
+        let scores: Vec<f32> = (0..10).map(|i| if i < 8 { 0.5 } else { 0.0 }).collect();
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wave);
+        assert!((density - 0.8).abs() < 1e-5);
+    }
+
+    #[test]
+    fn sparse_layer_is_particle() {
+        // 2% of features active
+        let mut scores = vec![0.0f32; 100];
+        scores[0] = 0.5;
+        scores[1] = 0.5;
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Particle);
+        assert!((density - 0.02).abs() < 1e-5);
+    }
+
+    #[test]
+    fn mid_density_is_wavelet() {
+        // 20% of features active
+        let mut scores = vec![0.0f32; 10];
+        for i in 0..2 {
+            scores[i] = 0.5;
+        }
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet);
+        assert!((density - 0.2).abs() < 1e-5);
+    }
+
+    #[test]
+    fn empty_layer_is_wavelet_density_zero() {
+        let (regime, density) = classify_layer_regime(&[]);
+        assert_eq!(regime, Regime::Wavelet);
+        assert_eq!(density, 0.0);
+    }
+
+    #[test]
+    fn boundary_at_0_5_is_wave() {
+        // Exactly 50% active (density == 0.5, > 0.5 is false, so Wavelet)
+        let scores: Vec<f32> = (0..10).map(|i| if i < 5 { 0.5 } else { 0.0 }).collect();
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet, "density=0.5 is not > 0.5, should be Wavelet");
+        assert!((density - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn boundary_at_0_05_is_wavelet() {
+        // density = 0.05, which is NOT < 0.05, so Wavelet
+        let mut scores = vec![0.0f32; 20];
+        scores[0] = 0.5; // 1/20 = 0.05
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet, "density=0.05 is not < 0.05, should be Wavelet");
+        assert!((density - 0.05).abs() < 1e-5);
+    }
+}
+```
+
+- [ ] **Step 2: Add to `canonical/mod.rs`**
+
+```rust
+pub mod regime;
+pub use regime::classify_layer_regime;
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cargo test -p larql-vindex canonical::regime 2>&1 | tail -5
+```
+Expected: `test result: ok. 6 passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/larql-vindex/src/canonical/regime.rs crates/larql-vindex/src/canonical/mod.rs
+git commit -m "feat(canonical): add per-layer regime classifier (Wave/Particle/Wavelet)"
+```
+
+---
+
+## Task 9: `larql canonicalize` command
+
+This wires all the pieces together into a usable CLI command.
+
+**Files:**
+- Create: `crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs`
+- Modify: `crates/larql-cli/src/commands/extraction/mod.rs`
+- Modify: `crates/larql-cli/src/main.rs`
+
+- [ ] **Step 1: Implement `canonicalize_cmd.rs`**
+
+Create `crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs`:
+
+```rust
+use std::path::PathBuf;
+use std::time::Instant;
+
+use clap::Args;
+use larql_vindex::{
+    canonical::{
+        classify_layer_regime, compute_onshell_mask, compute_whitening, estimate_covariance,
+        CanonicalMeta, LayerCanonicalInfo,
+    },
+    format::{
+        down_meta::read_cscores_binary,
+        filenames::CANONICAL_META_JSON,
+        load::{load_vindex_config, load_vindex_embeddings},
+    },
+};
+
+/// Number of embedding rows to subsample for covariance estimation.
+const COVARIANCE_SAMPLES: usize = 4096;
+/// Fraction of features per layer that are considered "on-shell" (factual subspace).
+const ONSHELL_FRACTION: f32 = 0.15;
+
+#[derive(Args)]
+pub struct CanonicalizeArgs {
+    /// Path to the .vindex directory to canonicalize.
+    vindex: PathBuf,
+
+    /// Override the on-shell fraction (default 0.15 = top 15% by c_score).
+    #[arg(long, default_value = "0.15")]
+    onshell_fraction: f32,
+
+    /// Override the covariance sample size (default 4096 embedding rows).
+    #[arg(long, default_value = "4096")]
+    covariance_samples: usize,
+}
+
+pub fn run(args: CanonicalizeArgs) -> anyhow::Result<()> {
+    let vindex_dir = &args.vindex;
+    let onshell_fraction = args.onshell_fraction;
+    let covariance_samples = args.covariance_samples;
+
+    println!("Canonicalizing vindex at {}", vindex_dir.display());
+
+    // ── 1. Load index.json ──────────────────────────────────────────────
+    let t0 = Instant::now();
+    let config = load_vindex_config(vindex_dir)?;
+    println!(
+        "  model: {} ({}), {} layers, hidden={}, vocab={}",
+        config.model, config.family, config.num_layers, config.hidden_size, config.vocab_size
+    );
+
+    // ── 2. Load embeddings.bin ──────────────────────────────────────────
+    print!("  loading embeddings.bin ... ");
+    let (embed, embed_scale) = load_vindex_embeddings(vindex_dir)?;
+    println!(
+        "{}×{} ({:.1}ms)",
+        embed.shape()[0], embed.shape()[1],
+        t0.elapsed().as_secs_f64() * 1000.0
+    );
+
+    // ── 3. Estimate covariance G ────────────────────────────────────────
+    let t1 = Instant::now();
+    print!("  estimating G ({covariance_samples} samples) ... ");
+    let g = estimate_covariance(&embed, embed_scale, covariance_samples);
+    println!("{:.1}ms", t1.elapsed().as_secs_f64() * 1000.0);
+
+    // ── 4. Cholesky whitening ───────────────────────────────────────────
+    let t2 = Instant::now();
+    print!("  Cholesky decomposition ... ");
+    let whitening = compute_whitening(&g).map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!("{:.1}ms", t2.elapsed().as_secs_f64() * 1000.0);
+
+    // ── 5. Read c_scores from down_meta.bin ────────────────────────────
+    let t3 = Instant::now();
+    print!("  reading c_scores from down_meta.bin ... ");
+    let cscores_per_layer = read_cscores_binary(vindex_dir)?;
+    println!(
+        "{} layers, {:.1}ms",
+        cscores_per_layer.len(),
+        t3.elapsed().as_secs_f64() * 1000.0
+    );
+
+    // ── 6. Per-layer: regime + on-shell ────────────────────────────────
+    let mut layers_info: Vec<LayerCanonicalInfo> = Vec::with_capacity(config.num_layers);
+    for layer in 0..config.num_layers {
+        let cscores = cscores_per_layer
+            .get(layer)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+        let (regime, mean_density) = classify_layer_regime(cscores);
+        let mask = compute_onshell_mask(cscores, onshell_fraction);
+        let on_shell_count = mask.iter().filter(|&&b| b).count();
+        layers_info.push(LayerCanonicalInfo {
+            layer,
+            regime,
+            on_shell_count,
+            total_features: cscores.len(),
+            mean_density,
+        });
+    }
+
+    // ── 7. Build and write canonical_meta.json ─────────────────────────
+    let meta = CanonicalMeta {
+        version: 1,
+        model: config.model.clone(),
+        family: config.family.clone(),
+        num_layers: config.num_layers,
+        hidden_size: config.hidden_size,
+        covariance_sample_size: covariance_samples,
+        embed_scale,
+        cholesky_l_packed: whitening.l_packed,
+        layers: layers_info,
+    };
+
+    let out_path = vindex_dir.join(CANONICAL_META_JSON);
+    let json = serde_json::to_string_pretty(&meta)?;
+    std::fs::write(&out_path, &json)?;
+
+    let total_on_shell: usize = meta.layers.iter().map(|l| l.on_shell_count).sum();
+    let total_features: usize = meta.layers.iter().map(|l| l.total_features).sum();
+    let pct = if total_features > 0 {
+        100.0 * total_on_shell as f32 / total_features as f32
+    } else {
+        0.0
+    };
+
+    println!("  on-shell features: {total_on_shell}/{total_features} ({pct:.1}%)");
+    println!("  wrote {}", out_path.display());
+    println!("  total: {:.1}ms", t0.elapsed().as_secs_f64() * 1000.0);
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Register module in `mod.rs`**
+
+In `crates/larql-cli/src/commands/extraction/mod.rs`, add:
+
+```rust
+pub mod canonicalize_cmd;
+```
+
+- [ ] **Step 3: Add `Canonicalize` variant to `Commands` in `main.rs`**
+
+Note: `load_vindex_config` and `load_vindex_embeddings` are already `pub` in `larql_vindex::format::load` — no visibility changes needed.
+
+In `crates/larql-cli/src/main.rs`, inside the `Commands` enum, after the `Compile` variant, add:
+
+```rust
+    #[command(next_help_heading = "Build")]
+    /// Compute canonical form metadata for a vindex (writes canonical_meta.json).
+    Canonicalize(canonicalize_cmd::CanonicalizeArgs),
+```
+
+Also add `use commands::extraction::canonicalize_cmd;` to the imports if needed (the existing wildcard `use commands::extraction::*;` may not cover it — check and add explicitly if so).
+
+In the `match` arm that dispatches commands (look for the large `match cli.command {` block), add:
+
+```rust
+    Commands::Canonicalize(args) => canonicalize_cmd::run(args)?,
+```
+
+- [ ] **Step 4: Compile check**
+
+```
+cargo build -p larql-cli 2>&1 | tail -20
+```
+Expected: compiles without errors.
+
+- [ ] **Step 5: Smoke test against the SmolLM2-360M vindex**
+
+```
+cargo run -p larql-cli -- canonicalize /home/metavacua/larql-vindexes/smollm2-360m.vindex 2>&1
+```
+Expected output: something like:
+```
+Canonicalizing vindex at /home/metavacua/larql-vindexes/smollm2-360m.vindex
+  model: output/smollm2-360m-src (llama), 32 layers, hidden=960, vocab=49152
+  loading embeddings.bin ... 49152×960 (...)ms
+  estimating G (4096 samples) ... ...ms
+  Cholesky decomposition ... ...ms
+  reading c_scores from down_meta.bin ... 32 layers, ...ms
+  on-shell features: .../... (~15%)
+  wrote /home/metavacua/larql-vindexes/smollm2-360m.vindex/canonical_meta.json
+  total: ...ms
+```
+
+- [ ] **Step 6: Verify canonical_meta.json structure**
+
+```
+python3 -c "
+import json
+with open('/home/metavacua/larql-vindexes/smollm2-360m.vindex/canonical_meta.json') as f:
+    m = json.load(f)
+print('version:', m['version'])
+print('hidden_size:', m['hidden_size'])
+print('cholesky_l_packed length:', len(m['cholesky_l_packed']))
+expected_packed = m['hidden_size'] * (m['hidden_size'] + 1) // 2
+print('expected packed length:', expected_packed)
+assert len(m['cholesky_l_packed']) == expected_packed
+print('layers:', len(m['layers']))
+for l in m['layers'][:3]:
+    print(f\"  layer {l['layer']}: regime={l['regime']}, on_shell={l['on_shell_count']}/{l['total_features']}, density={l['mean_density']:.3f}\")
+print('OK')
+"
+```
+Expected: no assertion error, cholesky_l_packed length = 960*961/2 = 461280.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs \
+        crates/larql-cli/src/commands/extraction/mod.rs \
+        crates/larql-cli/src/main.rs
+git commit -m "feat(cli): add larql canonicalize command"
+```
+
+---
+
+## Task 10: Full test suite pass
+
+- [ ] **Step 1: Run all tests**
+
+```
+cargo test --workspace 2>&1 | tail -20
+```
+Expected: all tests pass, no regressions.
+
+- [ ] **Step 2: If any tests fail, diagnose and fix**
+
+Read the failing test output carefully. Common failure modes:
+- Visibility errors on `load_config`/`load_embeddings` — fix by promoting to `pub`
+- Missing `use` in `whitening.rs` — add `use larql_compute::{back_solve_lt, cholesky, cholesky_inverse, compute_l_inv_t};`
+- `cholesky_l_packed` assertion on SmolLM2 — verify `960 * 961 / 2 = 461280`
+
+- [ ] **Step 3: Final commit if any fixup patches were needed**
+
+```bash
+git add -p  # stage only the fixup changes
+git commit -m "fix(canonical): resolve visibility and import issues after integration"
+```
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- [x] G_l covariance computation — Task 5 (`estimate_covariance`)
+- [x] Gate vector whitening — Task 6 (`compute_whitening`, `back_solve_lt`, `compute_l_inv_t`)
+- [x] On-shell projection filter — Task 7 (`compute_onshell_mask` via c_score percentile)
+- [x] Regime classifier — Task 8 (`classify_layer_regime`)
+- [x] `larql canonicalize` command — Task 9
+- [ ] **Not in this plan:** Writing whitened gate vectors to `gate_vectors_whitened.bin` — the canonical form stores the Cholesky factor; applying it to gate vectors is Plan 3 prerequisite
+- [ ] **Not in this plan:** Knowledge graph integration (Plan 2)
+- [ ] **Not in this plan:** Cross-model Procrustes alignment (Plan 3)
+
+**Type consistency:**
+- `back_solve_lt` defined in Task 1, used in Task 6 (`whitening.rs`) and re-exported via `larql_compute`
+- `compute_l_inv_t` defined in Task 1, used in whitening test (`Task 6 Step 1`)
+- `CanonicalMeta.cholesky_l_packed` field name matches in types.rs (Task 3), whitening.rs (Task 6), and canonicalize_cmd.rs (Task 9)
+- `read_cscores_binary` defined in Task 4, called in Task 9
+- `LayerCanonicalInfo` fields in types.rs (Task 3) match construction in canonicalize_cmd.rs (Task 9)
+
+**No placeholders confirmed.**

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -1,0 +1,33 @@
+# OpenSpec workflow
+
+This directory holds the spec-first contract for larql.
+
+## Layout
+
+```
+openspec/
+  config.yaml                       # OpenSpec project config
+  specs/<capability>/spec.md        # canonical specs, one per capability
+  changes/<change-id>/              # in-flight proposals
+    proposal.md                     # why + what
+    design.md                       # how (cross-cutting changes only)
+    tasks.md                        # implementation backlog
+    specs/<capability>/spec.md      # delta with ## ADDED / MODIFIED / REMOVED
+    gaps-unbacked-scenarios.md      # auto-generated; lists scenarios with no test
+    gaps-untested-code.md           # auto-generated; lists code without tests
+  changes/archive/                  # archived (merged) changes
+  coverage/
+    traceability.md                 # requirement → test matrix
+    traceability.json               # machine-readable trace data
+```
+
+## Authoring rules
+
+1. **One capability per coherent feature area.** Use kebab-case names.
+2. **Each spec is a delta when in `changes/<id>/`.** Top-level header is
+   `## ADDED Requirements` (or `MODIFIED` / `REMOVED` / `RENAMED`).
+3. **Every Requirement contains SHALL or MUST** (or `SHALL NOT`).
+4. **Every Requirement has at least one Scenario.** Scenarios use four
+   hashes (`####`).
+5. **Every Scenario references at least one test.** Annotate with an HTML
+   comment: `<!-- test: path/to/test.rs::test_name -->`.

--- a/openspec/changes/canonical-extraction/proposal.md
+++ b/openspec/changes/canonical-extraction/proposal.md
@@ -1,0 +1,49 @@
+# Proposal: Canonical Vindex Extraction Pipeline
+
+## Status: in-flight
+
+## Why
+
+Vindexes today are coordinate-system-relative: gate vectors live in whatever
+basis the model trainer used, with no formal invariants beyond format
+correctness. Cross-model comparison, formal verification, and
+`wasm32v1-none` inference all require a canonical form with provable uniqueness
+properties.
+
+The flat-canonical (semi-intrinsic, single G) form is the smallest useful
+canonical vindex: it requires only data already present in a browse-level
+vindex (`embeddings.bin`, `gate_vectors.bin`, `down_meta.bin`) and produces a
+`canonical_meta.json` sidecar that is a pure function of the model weights.
+
+## What
+
+Add `larql canonicalize <vindex-path>` that writes `canonical_meta.json` into
+an existing vindex directory. The command:
+
+1. Estimates the activation covariance G from token embeddings (semi-intrinsic
+   calibration — no external corpus).
+2. Computes the Cholesky factor L of G (the whitening operator).
+3. Scores each feature's "on-shell" property using the c_score percentile from
+   existing down_meta.
+4. Classifies each layer's activation regime (Wave / Particle / Wavelet).
+5. Writes all results to `canonical_meta.json` as a pure function of the
+   existing vindex files.
+
+## Non-goals (this change)
+
+- Writing whitened gate vectors (`gate_vectors_whitened.bin`). Deferred to
+  Plan 3 (cross-model alignment) which needs them first.
+- Per-layer G_l (general-relativistic form). Flat canonical only.
+- Knowledge graph integration. Separate change.
+- Cross-model Procrustes alignment. Separate change.
+- wasm32v1-none inference target. Tracked in epic #TBD.
+
+## Related issues
+
+- Epic: canonical-vindex-pipeline (this change)
+- Blocked-by: none
+- Blocks: knowledge-graph-integration, cross-model-alignment, wasm32v1-none-lm
+
+## Risk
+
+Low. Purely additive — no existing files are modified by `larql canonicalize`.

--- a/openspec/changes/canonical-extraction/specs/canonical-vindex/spec.md
+++ b/openspec/changes/canonical-extraction/specs/canonical-vindex/spec.md
@@ -1,0 +1,228 @@
+## ADDED Requirements: canonical-vindex
+
+### REQ-CANON-001: Covariance estimation
+
+The system SHALL estimate the activation covariance matrix G of shape
+[hidden_size, hidden_size] from the token embedding matrix W_E using a
+deterministic subsample of at most `max_samples` rows.
+
+G = (1/N) Σ_{v ∈ S} (s · W_E[v])^T (s · W_E[v])
+
+where s = embed_scale and S is a uniformly-strided subsample of the vocabulary.
+
+#### Scenario: identity embeddings produce scaled identity covariance
+
+Given token embeddings equal to the d×d identity matrix and embed_scale=1.0,
+when covariance is estimated with max_samples=d,
+then G[i,i] = 1/d and G[i,j] = 0 for i≠j.
+
+<!-- test: crates/larql-vindex/src/canonical/covariance.rs::tests::covariance_of_identity_is_identity_scaled -->
+
+#### Scenario: embed_scale squares into covariance
+
+Given any embeddings and embed_scale s,
+when covariance is estimated,
+then G(s) = s² · G(1).
+
+<!-- test: crates/larql-vindex/src/canonical/covariance.rs::tests::embed_scale_squares_into_covariance -->
+
+#### Scenario: G is symmetric and positive semi-definite
+
+Given any token embeddings,
+when covariance is estimated,
+then G[i,j] = G[j,i] for all i,j and G[i,j]² ≤ G[i,i]·G[j,j] (Cauchy-Schwarz).
+
+<!-- test: crates/larql-vindex/src/canonical/covariance.rs::tests::covariance_is_symmetric -->
+<!-- test: crates/larql-vindex/src/canonical/covariance.rs::tests::covariance_is_positive_semidefinite -->
+
+---
+
+### REQ-CANON-002: Cholesky whitening factor
+
+The system SHALL compute the lower-triangular Cholesky factor L of G such that
+L L^T = G + ε·I (with ε = 1e-5 ridge for numerical stability).
+
+The system SHALL provide a packing function that represents L as a flat
+Vec<f64> of length d·(d+1)/2 in row-major lower-triangular order:
+index(i,j) = i·(i+1)/2 + j for j ≤ i.
+
+The system SHALL provide an unpacking function that recovers the dense L from
+the packed form.
+
+#### Scenario: L L^T recovers G up to ridge
+
+Given G, when L = cholesky(G, ridge=1e-5),
+then (L L^T)[i,j] ≈ G[i,j] + 1e-5·δ_{ij} within 1e-8 tolerance.
+
+<!-- test: crates/larql-vindex/src/canonical/whitening.rs::tests::cholesky_recovers_g -->
+
+#### Scenario: L is lower-triangular
+
+Given G, when L = cholesky(G, ridge), then L[i,j] = 0 for j > i.
+
+<!-- test: crates/larql-vindex/src/canonical/whitening.rs::tests::l_is_lower_triangular -->
+
+#### Scenario: pack/unpack round-trips
+
+Given a Cholesky factor L, when packed then unpacked,
+the result equals the original within f64 precision.
+
+<!-- test: crates/larql-vindex/src/canonical/whitening.rs::tests::unpack_roundtrips_packed -->
+
+#### Scenario: whitened dot product equals Mahalanobis inner product
+
+Given g and h in ℝ^d, let g̃ = L^{-T}g and h̃ = L^{-T}h.
+Then g̃·h̃ = g^T G^{-1} h (Mahalanobis inner product).
+
+<!-- test: crates/larql-vindex/src/canonical/whitening.rs::tests::whitening_makes_mahalanobis_a_dot_product -->
+
+---
+
+### REQ-CANON-003: Back-substitution for L^T
+
+The system SHALL provide `back_solve_lt(L, B)` that solves L^T X = B via
+back-substitution, where L is lower-triangular. This is the primitive used to
+compute whitened vectors g̃ = L^{-T} g.
+
+The system SHALL provide `compute_l_inv_t(L)` that returns the dense d×d
+matrix L^{-T} by solving L^T X = I.
+
+#### Scenario: back_solve_lt recovers B
+
+Given lower-triangular L and matrix B,
+when Z = back_solve_lt(L, B), then L^T Z = B within 1e-10 tolerance.
+
+<!-- test: crates/larql-compute/src/cpu/ops/linalg.rs::canonical_linalg_tests::back_solve_lt_recovers_rhs -->
+
+#### Scenario: compute_l_inv_t times L^T is identity
+
+Given L, when M = compute_l_inv_t(L), then M @ L^T = I within 1e-10.
+
+<!-- test: crates/larql-compute/src/cpu/ops/linalg.rs::canonical_linalg_tests::compute_l_inv_t_times_l_t_is_identity -->
+
+---
+
+### REQ-CANON-004: On-shell feature filter
+
+The system SHALL compute a boolean on-shell mask for each layer by ranking
+features by their c_score (logit of top down-projected token from down_meta)
+and marking the top `top_fraction` (default 0.15) as on-shell.
+
+At least one feature SHALL be on-shell even if only one feature exists.
+The mask length SHALL equal the number of features in the layer.
+An empty feature list SHALL produce an empty mask.
+
+#### Scenario: top 15% of 10 features selects 2
+
+Given 10 features with c_scores 0..9 and top_fraction=0.15 (ceil(1.5)=2),
+the on-shell features are those with the two highest c_scores (8 and 9).
+
+<!-- test: crates/larql-vindex/src/canonical/onshell.rs::tests::top_15pct_of_10_is_2 -->
+
+#### Scenario: all-equal c_scores makes all features on-shell
+
+When all c_scores are equal, the threshold equals all scores,
+so all features are on-shell.
+
+<!-- test: crates/larql-vindex/src/canonical/onshell.rs::tests::all_same_scores_all_on_shell -->
+
+---
+
+### REQ-CANON-005: Layer regime classifier
+
+The system SHALL classify each layer as Wave, Particle, or Wavelet based on
+activation density = (features with c_score > 0.1) / total_features:
+
+- density > 0.5  → Wave
+- density < 0.05 → Particle
+- otherwise      → Wavelet
+
+An empty feature list SHALL return Wavelet with density 0.0.
+
+#### Scenario: dense layer is Wave
+
+Given 80% of features with c_score > 0.1, regime = Wave.
+
+<!-- test: crates/larql-vindex/src/canonical/regime.rs::tests::dense_layer_is_wave -->
+
+#### Scenario: sparse layer is Particle
+
+Given 2% of features with c_score > 0.1, regime = Particle.
+
+<!-- test: crates/larql-vindex/src/canonical/regime.rs::tests::sparse_layer_is_particle -->
+
+#### Scenario: mid-density is Wavelet
+
+Given 20% of features active, regime = Wavelet.
+
+<!-- test: crates/larql-vindex/src/canonical/regime.rs::tests::mid_density_is_wavelet -->
+
+---
+
+### REQ-CANON-006: Canonical metadata serialization
+
+The system SHALL write `canonical_meta.json` to the vindex directory containing:
+- version (u32 = 1)
+- model, family, num_layers, hidden_size strings/ints from index.json
+- covariance_sample_size and embed_scale
+- cholesky_l_packed: Vec<f64> of length hidden_size·(hidden_size+1)/2
+- layers: array of {layer, regime, on_shell_count, total_features, mean_density}
+
+The JSON SHALL round-trip losslessly through serde_json.
+
+#### Scenario: regime serializes as snake_case
+
+Wave → "wave", Particle → "particle", Wavelet → "wavelet".
+
+<!-- test: crates/larql-vindex/src/canonical/types.rs::tests::regime_serialises_as_snake_case -->
+
+#### Scenario: CanonicalMeta round-trips
+
+Given a CanonicalMeta value, serializing to JSON and deserializing
+reproduces the original value.
+
+<!-- test: crates/larql-vindex/src/canonical/types.rs::tests::canonical_meta_round_trips_through_json -->
+
+---
+
+### REQ-CANON-007: c_score-only down_meta reader
+
+The system SHALL provide `read_cscores_binary(dir)` that reads c_score values
+from `down_meta.bin` without constructing token strings (no tokenizer
+dependency). It SHALL return Vec<Vec<f32>>, one inner Vec per layer.
+Layers with num_features=0 SHALL return an empty inner Vec.
+
+#### Scenario: c_scores match full read
+
+Given a down_meta.bin file, read_cscores_binary returns the same c_score
+values as the full read_binary function.
+
+<!-- test: crates/larql-vindex/src/format/down_meta.rs::tests::read_cscores_binary_matches_full_read -->
+
+---
+
+### REQ-CANON-008: CLI command `larql canonicalize`
+
+The system SHALL provide a `larql canonicalize <vindex-path>` subcommand
+that loads a vindex directory, runs the canonical pipeline, and writes
+`canonical_meta.json`. The command SHALL NOT modify any existing vindex files.
+
+The command SHALL accept:
+- `--onshell-fraction <f32>` (default 0.15)
+- `--covariance-samples <usize>` (default 4096)
+
+The command SHALL print progress and a summary of on-shell feature counts.
+
+#### Scenario: canonical_meta.json is written
+
+Given a valid vindex directory, after `larql canonicalize`,
+canonical_meta.json exists and is valid JSON matching the schema.
+
+<!-- test: integration: cargo run -- canonicalize <vindex> then check file exists -->
+
+#### Scenario: existing files are untouched
+
+After `larql canonicalize`, all pre-existing vindex files have the same
+content as before.
+
+<!-- test: integration: checksum vindex files before/after -->

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## Summary

Implements **Plan 1** of the canonical vindex synthesis: the flat-canonical (semi-intrinsic, single-G) extraction pipeline and the `larql canonicalize <vindex>` command. Closes the load-bearing gap that Plan 2 (knowledge-graph integration) and Plan 3 (cross-model alignment) depend on.

Epic: #131

Built spec-first (OpenSpec, REQ-CANON-001…008) and test-driven (subagent-driven development, two-stage review per task).

## What it does

`larql canonicalize <vindex>` writes a `canonical_meta.json` sidecar that is a pure function of the model weights — no external corpus, no existing vindex file modified:

1. **Covariance G** estimated from token embeddings: `G = (1/N) Σ (s·W_E[v])^T (s·W_E[v])` (deterministic strided subsample).
2. **Cholesky whitening factor** `L` (`G = L L^T + εI`, ε=1e-5), packed lower-triangular as `Vec<f64>`.
3. **On-shell filter** — top 15% features per layer by c_score (factual subspace), read from `down_meta.bin` with no tokenizer dependency.
4. **Regime classifier** per layer (Wave / Particle / Wavelet).

New numerical primitives in `larql-compute`: `back_solve_lt`, `compute_l_inv_t` (whitening via `L^{-T}g`, Mahalanobis-as-dot-product proven in tests).

## Verification

- 27 canonical unit tests + 682 larql-compute tests pass; clippy clean.
- Smoke test on `smollm2-360m.vindex`: 32 layers, `cholesky_l_packed` length 461280 (= 960·961/2), 15.0% on-shell. Release timing: ~3.9s for G, ~4.2s total.
- REQ-CANON-008 ("existing files untouched") verified by inspection — the only write is `std::fs::write` to the `canonical_meta.json` path.

## Known findings (not blocking, surfaced for decision)

- **Regime classifier is degenerate on real logits.** c_score is a top-token *logit* (≈ always > the 0.1 `ACTIVE_FLOOR`), so density ≈ 1.0 and every layer classifies as `Wave` on SmolLM2. The implementation is spec-faithful, but REQ-CANON-005's threshold/metric likely needs rethinking to be discriminating. Tracked separately.

## Notes

- Base `integration/chrishayuk-main` lags chrishayuk HEAD by one commit (`d9b761f6 improving lql for routing`), which therefore appears in the diff. Not authored here.
- Deferred to separate plans: whitened gate vectors (`gate_vectors_whitened.bin`), per-layer G_l, knowledge-graph integration, cross-model Procrustes alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
