### PR TITLE
feat(hilbert): entanglement-entropy / compressibility meter + QLM governance docs (Phase 4)

### DIFF
--- a/crates/larql-hilbert/ROADMAP.md
+++ b/crates/larql-hilbert/ROADMAP.md
@@ -1,0 +1,24 @@
+# Roadmap — larql-hilbert
+
+`larql-hilbert` is the Hilbert-space formalization crate: complex structures,
+the qubit / Bloch-sphere language models, constructive measurement, and the
+entanglement-entropy / compressibility meters. It is a pure-Rust leaf crate
+(deps: `ndarray` + `num-complex`; no BLAS) — see
+[ADR 0011](../../docs/adr/0011-qlm-quantum-language-models.md).
+
+The full phased plan, theory, and bibliography live in the QLM roadmap:
+
+➡️ **[`docs/QLM-ROADMAP.md`](../../docs/QLM-ROADMAP.md)** — Copyright © 2026
+Ian Douglas Lawrence Norman McLean, CC BY-SA 4.0.
+
+## At a glance
+
+- ✅ Phase 0–3: Hilbert foundation + Hilbertian residual (PR #137), single-qubit
+  Bloch LM (#138), constructive measurement + admissibility (#139), two-qubit
+  LM + Bell (#140).
+- 🔄 Phase 4: entanglement-entropy / compressibility meter
+  (`spectral_entropy` landed; `entanglement_entropy(matrix)` + pure-Rust
+  eigensolver per `docs/superpowers/plans/2026-06-11-matrix-entanglement-entropy.md`).
+- ⬜ Phase 5–6: GHZ/W (3+ qubits), superdense coding + quantum LQL.
+- 🔬 Phase 7–8: vindex compressibility analysis; `wasm32v1-none` minimal LM
+  (epic #132).

--- a/crates/larql-hilbert/src/eig.rs
+++ b/crates/larql-hilbert/src/eig.rs
@@ -1,0 +1,105 @@
+//! Pure-Rust symmetric eigenvalue solver (cyclic Jacobi) — no BLAS/LAPACK.
+//! Used to obtain the squared-singular spectrum for entanglement entropy.
+
+use ndarray::Array2;
+
+/// Eigenvalues of a real symmetric matrix via the cyclic Jacobi method.
+/// Returns the `n` eigenvalues (unordered). The input is assumed symmetric;
+/// only its symmetric part is meaningfully used.
+pub fn symmetric_eigenvalues(a: &Array2<f64>) -> Vec<f64> {
+    let n = a.shape()[0];
+    let mut m = a.clone();
+
+    for _sweep in 0..100 {
+        // Off-diagonal Frobenius norm; stop when negligible.
+        let mut off = 0.0;
+        for i in 0..n {
+            for j in (i + 1)..n {
+                off += m[[i, j]] * m[[i, j]];
+            }
+        }
+        if off.sqrt() < 1e-14 {
+            break;
+        }
+
+        for p in 0..n {
+            for q in (p + 1)..n {
+                let apq = m[[p, q]];
+                if apq.abs() < 1e-300 {
+                    continue;
+                }
+                let app = m[[p, p]];
+                let aqq = m[[q, q]];
+                // Stable Jacobi angle (Golub & Van Loan, sym.schur2).
+                let tau = (aqq - app) / (2.0 * apq);
+                let t = if tau >= 0.0 {
+                    1.0 / (tau + (1.0 + tau * tau).sqrt())
+                } else {
+                    -1.0 / (-tau + (1.0 + tau * tau).sqrt())
+                };
+                let c = 1.0 / (1.0 + t * t).sqrt();
+                let s = t * c;
+
+                // A <- Jᵀ A J for the (p,q) rotation: rotate columns then rows.
+                #[allow(clippy::needless_range_loop)]
+                for k in 0..n {
+                    let akp = m[[k, p]];
+                    let akq = m[[k, q]];
+                    m[[k, p]] = c * akp - s * akq;
+                    m[[k, q]] = s * akp + c * akq;
+                }
+                #[allow(clippy::needless_range_loop)]
+                for k in 0..n {
+                    let apk = m[[p, k]];
+                    let aqk = m[[q, k]];
+                    m[[p, k]] = c * apk - s * aqk;
+                    m[[q, k]] = s * apk + c * aqk;
+                }
+            }
+        }
+    }
+
+    (0..n).map(|i| m[[i, i]]).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    fn sorted(mut v: Vec<f64>) -> Vec<f64> {
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        v
+    }
+
+    fn close(a: &[f64], b: &[f64]) -> bool {
+        a.len() == b.len() && a.iter().zip(b).all(|(x, y)| (x - y).abs() < 1e-9)
+    }
+
+    #[test]
+    fn diagonal_matrix_returns_its_diagonal() {
+        let a = Array2::from_diag(&array![3.0, 1.0, 2.0]);
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 2.0, 3.0]));
+    }
+
+    #[test]
+    fn identity_has_all_unit_eigenvalues() {
+        let a = Array2::<f64>::eye(3);
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 1.0, 1.0]));
+    }
+
+    #[test]
+    fn two_by_two_symmetric_eigenvalues() {
+        // [[2,1],[1,2]] has eigenvalues 1 and 3.
+        let a = array![[2.0, 1.0], [1.0, 2.0]];
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 3.0]));
+    }
+
+    #[test]
+    fn larger_spd_matrix_eigenvalues_sum_to_trace() {
+        let a = array![[4.0, 1.0, 0.0], [1.0, 3.0, 1.0], [0.0, 1.0, 2.0]];
+        let eigs = symmetric_eigenvalues(&a);
+        let sum: f64 = eigs.iter().sum();
+        assert!((sum - 9.0).abs() < 1e-9, "trace should be 9, got {sum}");
+    }
+}

--- a/crates/larql-hilbert/src/entropy.rs
+++ b/crates/larql-hilbert/src/entropy.rs
@@ -4,6 +4,10 @@
 //! (fully compressible), log2(d) = flat spectrum (incompressible). One ebit
 //! (spectrum [½, ½]) is the superdense-coding unit.
 
+use ndarray::Array2;
+
+use crate::eig::symmetric_eigenvalues;
+
 /// Spectral entropy of a non-negative weight spectrum, in bits (ebits):
 /// `S = −Σ pᵢ log₂ pᵢ` with `pᵢ = wᵢ / Σⱼ wⱼ`. Zero weights are skipped; an
 /// empty or all-zero spectrum returns `0.0` (no NaN). For the entanglement
@@ -23,9 +27,31 @@ pub fn spectral_entropy(weights: &[f64]) -> f64 {
         .sum()
 }
 
+/// Entanglement entropy (in ebits) of a real matrix viewed as a bipartite
+/// state: the spectral entropy of its squared singular values. `0` for a
+/// rank-1 matrix, `log₂(min(rows, cols))` for a flat spectrum.
+///
+/// Computed from the eigenvalues of the smaller Gram matrix (`M Mᵀ` if
+/// `rows ≤ cols`, else `Mᵀ M`) — these are the squared singular values.
+/// Tiny negative eigenvalues from round-off are clamped to 0.
+pub fn entanglement_entropy(m: &Array2<f64>) -> f64 {
+    let (rows, cols) = (m.shape()[0], m.shape()[1]);
+    let gram = if rows <= cols {
+        m.dot(&m.t())
+    } else {
+        m.t().dot(m)
+    };
+    let weights: Vec<f64> = symmetric_eigenvalues(&gram)
+        .into_iter()
+        .map(|e| e.max(0.0))
+        .collect();
+    spectral_entropy(&weights)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ndarray::{array, Array2};
 
     #[test]
     fn rank_one_spectrum_has_zero_entropy() {
@@ -51,5 +77,26 @@ mod tests {
     fn empty_or_all_zero_is_zero() {
         assert_eq!(spectral_entropy(&[]), 0.0);
         assert_eq!(spectral_entropy(&[0.0, 0.0]), 0.0);
+    }
+
+    #[test]
+    fn rank_one_matrix_has_zero_entanglement() {
+        // [[1,2],[2,4]] = [1,2]ᵀ·[1,2], rank 1 → one nonzero singular value → 0.
+        let m = array![[1.0, 2.0], [2.0, 4.0]];
+        assert!(entanglement_entropy(&m).abs() < 1e-9);
+    }
+
+    #[test]
+    fn identity_2x2_is_one_ebit() {
+        // I₂ has singular values [1,1] → squared [1,1] → 1 ebit.
+        let m = Array2::<f64>::eye(2);
+        assert!((entanglement_entropy(&m) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn rectangular_orthonormal_rows_is_one_ebit() {
+        // 2×3 with two orthonormal rows → M Mᵀ = I₂ → 1 ebit.
+        let m = array![[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        assert!((entanglement_entropy(&m) - 1.0).abs() < 1e-9);
     }
 }

--- a/crates/larql-hilbert/src/entropy.rs
+++ b/crates/larql-hilbert/src/entropy.rs
@@ -1,0 +1,55 @@
+//! Spectral (von Neumann) entropy — the quantum-compressibility quantity, in
+//! ebits (bits). For a matrix viewed as a bipartite state the entanglement
+//! entropy is the spectral entropy of its squared singular values: 0 = rank-1
+//! (fully compressible), log2(d) = flat spectrum (incompressible). One ebit
+//! (spectrum [½, ½]) is the superdense-coding unit.
+
+/// Spectral entropy of a non-negative weight spectrum, in bits (ebits):
+/// `S = −Σ pᵢ log₂ pᵢ` with `pᵢ = wᵢ / Σⱼ wⱼ`. Zero weights are skipped; an
+/// empty or all-zero spectrum returns `0.0` (no NaN). For the entanglement
+/// entropy of a matrix, pass its squared singular values (the Schmidt weights).
+pub fn spectral_entropy(weights: &[f64]) -> f64 {
+    let total: f64 = weights.iter().sum();
+    if total <= 0.0 {
+        return 0.0;
+    }
+    let mut s = 0.0;
+    for &w in weights {
+        if w > 0.0 {
+            let p = w / total;
+            s -= p * p.log2();
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rank_one_spectrum_has_zero_entropy() {
+        assert!(spectral_entropy(&[7.0, 0.0, 0.0]).abs() < 1e-12);
+    }
+
+    #[test]
+    fn two_equal_weights_is_one_ebit() {
+        assert!((spectral_entropy(&[3.0, 3.0]) - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn uniform_spectrum_is_log2_of_dimension() {
+        assert!((spectral_entropy(&[1.0, 1.0, 1.0, 1.0]) - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn zero_weights_ignored_no_nan() {
+        assert!((spectral_entropy(&[1.0, 1.0, 0.0, 0.0]) - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn empty_or_all_zero_is_zero() {
+        assert_eq!(spectral_entropy(&[]), 0.0);
+        assert_eq!(spectral_entropy(&[0.0, 0.0]), 0.0);
+    }
+}

--- a/crates/larql-hilbert/src/entropy.rs
+++ b/crates/larql-hilbert/src/entropy.rs
@@ -3,6 +3,12 @@
 //! entropy is the spectral entropy of its squared singular values: 0 = rank-1
 //! (fully compressible), log2(d) = flat spectrum (incompressible). One ebit
 //! (spectrum [½, ½]) is the superdense-coding unit.
+//!
+//! `entanglement_entropy(M)` is the quantum-compressibility meter: low entropy
+//! ⇒ few Schmidt terms ⇒ the matrix compresses to a small tensor-network bond
+//! dimension (`χ ≈ 2^S`); a flat spectrum is incompressible. Combined with the
+//! Hilbertian residual (complex/coherence structure), it quantifies the
+//! classical-vs-quantum compressibility gap of a vindex, denominated in ebits.
 
 use ndarray::Array2;
 

--- a/crates/larql-hilbert/src/entropy.rs
+++ b/crates/larql-hilbert/src/entropy.rs
@@ -13,14 +13,14 @@ pub fn spectral_entropy(weights: &[f64]) -> f64 {
     if total <= 0.0 {
         return 0.0;
     }
-    let mut s = 0.0;
-    for &w in weights {
-        if w > 0.0 {
+    weights
+        .iter()
+        .filter(|&&w| w > 0.0)
+        .map(|&w| {
             let p = w / total;
-            s -= p * p.log2();
-        }
-    }
-    s
+            -p * p.log2()
+        })
+        .sum()
 }
 
 #[cfg(test)]

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -52,3 +52,6 @@ pub use two_qubit::{is_product, marginal_probs, measure_qubit, tensor, TwoQubit}
 pub use gate2::{bell, cnot, Gate4};
 pub mod qlm2;
 pub use qlm2::TwoQubitLM;
+
+pub mod entropy;
+pub use entropy::spectral_entropy;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -55,3 +55,5 @@ pub use qlm2::TwoQubitLM;
 
 pub mod entropy;
 pub use entropy::spectral_entropy;
+pub mod eig;
+pub use eig::symmetric_eigenvalues;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -54,6 +54,6 @@ pub mod qlm2;
 pub use qlm2::TwoQubitLM;
 
 pub mod entropy;
-pub use entropy::spectral_entropy;
+pub use entropy::{entanglement_entropy, spectral_entropy};
 pub mod eig;
 pub use eig::symmetric_eigenvalues;

--- a/crates/larql-hilbert/tests/entropy_integration.rs
+++ b/crates/larql-hilbert/tests/entropy_integration.rs
@@ -1,0 +1,35 @@
+//! End-to-end: entanglement_entropy orders matrices by compressibility —
+//! rank-1 (0 ebits, fully compressible) < skewed spectrum < flat spectrum
+//! (maximal, incompressible) — through the public crate API.
+
+use larql_hilbert::{entanglement_entropy, spectral_entropy};
+use ndarray::{array, Array2};
+
+#[test]
+fn entropy_orders_matrices_by_compressibility() {
+    // Rank-1: zero entanglement (one Schmidt term).
+    let rank1 = array![[1.0, 2.0], [2.0, 4.0]];
+    // Skewed singular values [1, 0.1] → squared [1, 0.01]: low but nonzero.
+    let skewed = Array2::from_diag(&array![1.0, 0.1]);
+    // Flat: identity, maximal entropy for 2×2 (1 ebit).
+    let flat = Array2::<f64>::eye(2);
+
+    let s_rank1 = entanglement_entropy(&rank1);
+    let s_skewed = entanglement_entropy(&skewed);
+    let s_flat = entanglement_entropy(&flat);
+
+    assert!(s_rank1 < 1e-9, "rank-1 should be ~0, got {s_rank1}");
+    assert!(s_rank1 < s_skewed, "{s_rank1} !< {s_skewed}");
+    assert!(s_skewed < s_flat, "{s_skewed} !< {s_flat}");
+    assert!((s_flat - 1.0).abs() < 1e-9, "flat 2×2 should be 1 ebit, got {s_flat}");
+}
+
+#[test]
+fn matrix_meter_agrees_with_spectral_entropy_on_squared_singular_values() {
+    // The matrix meter must equal spectral_entropy applied to the squared
+    // singular values directly. For a diagonal matrix those are the squared
+    // diagonal entries.
+    let m = Array2::from_diag(&array![2.0, 1.0]);
+    let direct = spectral_entropy(&[4.0, 1.0]); // squares of 2 and 1
+    assert!((entanglement_entropy(&m) - direct).abs() < 1e-9);
+}

--- a/docs/QLM-ROADMAP.md
+++ b/docs/QLM-ROADMAP.md
@@ -1,0 +1,167 @@
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+Copyright © 2026 Ian Douglas Lawrence Norman McLean.
+Licensed under the Creative Commons Attribution-ShareAlike 4.0 International
+License (CC BY-SA 4.0): https://creativecommons.org/licenses/by-sa/4.0/
+
+This is the QLM (Quantum Language Model) roadmap. It is a SEPARATE work from the
+LARQL project roadmap (`ROADMAP.md`), which has its own authorship and license
+and is left unmodified.
+-->
+
+# QLM Roadmap — Quantum Language Models for LARQL
+
+> **Copyright © 2026 Ian Douglas Lawrence Norman McLean · CC BY-SA 4.0.**
+> Distinct from the upstream `ROADMAP.md` (unmodified). Per-phase code lives in
+> the `larql-hilbert` crate and is cross-referenced to its PRs/issues below.
+
+This roadmap tracks the **quantum language model** line: the Hilbert-space
+formalization of language models, the minimal canonical quantum LM, and the
+classical-vs-quantum compressibility programme — built as the pure-Rust leaf
+crate `larql-hilbert` (deps: `ndarray` + `num-complex`; no BLAS), kept portable
+toward the `wasm32v1-none` minimal-LM target.
+
+---
+
+## Purpose (load-bearing — read first)
+
+A **vindex** is a queryable weight database (the object language / the data); an
+**LQL** operation is a process over it (the metalanguage / the query). The QLM
+line asks what these become at the Hilbert-space limit:
+
+- **State** = a (projective) Hilbert-space point — a qubit on the Bloch sphere
+  (`ℂP¹`) at the minimal scale.
+- **Readout** = the Born rule — a *measurement*, which (per the constructive
+  reading) is the **elimination rule** of the linear, no-cloning fragment, not a
+  new primitive.
+- **Evolution** = unitary (SU(2)/SU(2ⁿ)) gates — norm-preserving, the
+  conservative idealization of the residual-stream update.
+- **Canonical form** = the gauge-fixed representative (the dagger/metric, then
+  the projective quotient) — the same canonicalization the `larql canonicalize`
+  pipeline performs, at minimal scale.
+
+The minimal quantum LM is the **single qubit**; the place classical structure
+fails is the **Bell point** (two qubits stop factoring, `A⊗B ≠ A×B`); the
+asymptotic regime is **GHZ / W** (3+ qubits). The unifying claim is that the
+**classical/quantum compressibility gap of a vindex is denominated in ebits**,
+with **superdense coding** as the operational unit and the **entanglement
+entropy** as the measured quantity.
+
+## Theoretical frame (the four pillars)
+
+1. **Categorical quantum mechanics / the dagger.** Canonicalization is choosing
+   the dagger (the inner product), lifting `FdVect → FdHilb`; it reduces the
+   gauge group `GL(n) → U(n)/O(n)` (why cross-model alignment is Procrustes).
+   The token vocabulary is the classical structure; the hidden space is the
+   basis-free quantum object. (Baez & Stay, *Rosetta Stone*; Abramsky & Coecke.)
+2. **Zizzi quantum metalanguage.** Assertions carry **complex assertion degrees**
+   (amplitudes); Sambin's reflection turns metalinguistic bonds into the
+   object-language **superposition connective** (logic `Lq`). Maps onto
+   LQL (metalanguage) / vindex (object language); the single-qubit LM is an
+   operational model of `Lq`; entanglement is the non-factorizing bond.
+   (Zizzi, arXiv:1003.5976.)
+3. **Rosko admissibility.** Admissible measurement = finite extraction ⊆
+   **Σ⁰₁ ∪ Π⁰₂** (Δ₀-decidable core), via realizability over Heyting Arithmetic.
+   This is the *finiteness filter on Zizzi's metalanguage* — the
+   `admissibility` module (Δ₀/Σ⁰₁/Π⁰₂) is its implementation; the ⊥ outcome
+   (`project → None`, `score → −∞`) is the degree-0 / uninhabited assertion.
+   (Rosko, arXiv:2511.21296.)
+4. **Superdense coding & compressibility.** One ebit ↔ the 2-bit dense-coding
+   gain; the classical/quantum vindex compressibility ratio is set by the
+   entanglement entropy in ebits. Weight-matrix spectra are heavy-tailed
+   (Martin–Mahoney HTSR), which is why *lossy ≫ lossless* and the on-shell Zipf
+   head carries the function. (Bennett–Wiesner; Schumacher.)
+
+---
+
+## Phases (critical path)
+
+Status legend: ✅ done (PR open in `metavacua/larql-to-sparql`), 🔄 in progress,
+⬜ planned, 🔬 research.
+
+### Phase 0 — Hilbert-space foundation ✅ (PR #137)
+Complex structure `J` (`J²=−I`), commutator residual, the unifying theorem
+`commutator_residual = 2·antilinear_fraction`, the real↔complex (`realify` /
+`complex_parts`) bridge, and the **Hilbertian residual** — a per-attention-head,
+weights-only score of complex-linearity. *Result:* on SmolLM2, residuals
+0.45–1.46 (discriminating); the metric doubles as a **quantum-compressibility
+meter** (residual 0 ⇒ 2× complex-compressible). Built on the canonical pipeline
+(PR #133).
+
+### Phase 1 — Single-qubit Bloch LM ✅ (PR #138)
+`Qubit` + Bloch coordinates (`ℂP¹`), SU(2) gates, Born readout, `SingleQubitLM`
+(2-token vocab, collapse-then-unitary, autoregressive `score`/`generate`).
+With projective collapse it reduces to a first-order Markov chain — the boundary
+where quantum = classical, hence the right *minimal* object.
+
+### Phase 2 — Constructive measurement + admissibility ✅ (PR #139)
+`measurement::project` (elimination rule; `None` = ⊥), `LinearQubit` (no-cloning
+via Rust move semantics), and `admissibility` (Δ₀ `is_realizable`, Σ⁰₁
+`exists_continuation`, Π⁰₂ `uniformly_stable`). Implements the Rosko filter on
+the Zizzi metalanguage; the integration test pins `⊥ ≅ −∞`.
+
+### Phase 3 — Two-qubit LM + Bell ✅ (PR #140)
+`TwoQubit` (ℂ⁴), tensor product, `is_product` (entanglement = nonzero 2×2
+determinant), partial measurement, 4×4 gate algebra, `cnot`, `bell` (Φ⁺), and
+`TwoQubitLM`. *Result:* the Bell-init LM forbids the anti-correlated tokens
+01/10 (`−∞`) — the place the single-qubit Markov reduction provably breaks.
+
+### Phase 4 — Entanglement-entropy / compressibility meter 🔄 (branch `feat/entanglement-entropy`)
+`spectral_entropy(&[f64])` (quantum compressibility in ebits) ✅. Next:
+`entanglement_entropy(&Array2<f64>)` via a pure-Rust cyclic-Jacobi symmetric
+eigensolver (plan: `docs/superpowers/plans/2026-06-11-matrix-entanglement-entropy.md`).
+Turns `is_product` (yes/no) into "how many ebits."
+
+### Phase 5 — GHZ / W (3+ qubits) ⬜
+`ℂ^{2ⁿ}` states, n-qubit gate algebra, the GHZ and W entangling operations,
+multi-cut entanglement. The asymptotic regime where the classical/quantum size
+ratio (`Vⁿ` vs bond dimension `χ ≈ 2^S`) is a real, growing gap.
+
+### Phase 6 — Superdense coding + quantum LQL ⬜
+Superdense coding as a protocol on the Bell machinery (Pauli-gated Bell states +
+Bell-basis readout) — the first *protocol* (not just state) and the literal
+quantum factor-of-2. Then `MEASURE` (Born) and `STEP` (collapse+unitary) as
+quantum LQL operations under a linear/affine resource discipline (no-cloning at
+the type level). Generation ↔ communication as dual readouts.
+
+### Phase 7 — Vindex compressibility analysis 🔬 (depends on Phase 4)
+A CLI/analysis running `entanglement_entropy` over weight matrices: **on-shell
+vs full**, **canonical vs raw**, **von Neumann (complex) vs Shannon (real)**
+coherence defect, and a **Zipfian/HTSR** power-law check. Tests the conjecture:
+*the quantum compressibility advantage is concentrated in the canonicalized
+on-shell subspace and invisible in the raw syntactic whole.* (Prior from the
+Hilbertian data: small in the raw basis — the open question is whether
+canonicalization recovers it.)
+
+### Phase 8 — `wasm32v1-none` minimal quantum metalanguage 🔬 (epic #132)
+The constructively-admissible (Zizzi ∩ Rosko) fragment — finitely-extractable,
+computable-amplitude, sub-Turing (`¬L ∧ ¬M`) — is the minimal LM. The
+larql-hilbert primitives are the certification target: alloc-free / no_std /
+bounded-stack versions of the kernels (the Hilbertian 64×64 kernel first).
+Numerical-backend portability tracked in #135.
+
+---
+
+## Cross-references
+
+- **PR stack** (all in `metavacua/larql-to-sparql`, merge in order): #133
+  canonical → #137 hilbertian → #138 qlm-hilbert → #139 constructive-measurement
+  → #140 two-qubit-bell → (Phase 4) entanglement-entropy.
+- **Issues:** #132 (wasm32v1-none minimal LM), #134 (regime-classifier finding),
+  #135 (numerical-backend portability / BLAS-free), #136 (hilbertian
+  refinements).
+- **Plans:** `docs/superpowers/plans/` — `2026-06-10-canonical-extraction-pipeline`,
+  `2026-06-11-attention-hilbertian-residual`, `2026-06-11-qlm-hilbert-foundation`,
+  `2026-06-11-constructive-measurement-layer`, `2026-06-11-two-qubit-bell`,
+  `2026-06-11-matrix-entanglement-entropy`.
+
+## Bibliography
+
+- P. Zizzi, *From Quantum Metalanguage to the Logic of Qubits*, arXiv:1003.5976 (2010).
+- M. Rosko, *A Constructive Fragment of Physical Propositions*, arXiv:2511.21296 (2025).
+- J. Baez & M. Stay, *Physics, Topology, Logic and Computation: A Rosetta Stone* (2009).
+- S. Abramsky & B. Coecke, *Categorical Quantum Mechanics*.
+- *Towards a Computational Quantum Logic* (the `Lᶜ` calculus), arXiv:2504.07609 (2025).
+- C. Bennett & S. Wiesner, *Communication via one- and two-particle operators on EPR states* (1992) — superdense coding.
+- B. Schumacher, *Quantum coding* (1995) — quantum data compression.
+- C. Martin & M. Mahoney, *Heavy-Tailed Self-Regularization in Deep Neural Networks* — weight-spectrum power laws.

--- a/docs/adr/0011-qlm-quantum-language-models.md
+++ b/docs/adr/0011-qlm-quantum-language-models.md
@@ -1,0 +1,80 @@
+# ADR 0011 — QLM: Quantum Language Models as a Pure-Rust Leaf Crate
+
+**Status:** Accepted
+**Date:** 2026-06-11
+**Depends on:** `larql-hilbert` (new), `larql-vindex` (canonical pipeline)
+
+---
+
+## Context
+
+The QLM line (see `docs/QLM-ROADMAP.md`) formalizes language models as
+Hilbert-space objects: qubit states, unitary evolution, Born-rule readout, and
+the classical-vs-quantum compressibility programme. It is built as a new crate,
+`larql-hilbert`, across PRs #137–#140 (+ the entanglement-entropy work). Several
+non-obvious architectural choices were made that are not legible from the code
+alone; this ADR records them and their rationale.
+
+## Decision
+
+1. **`larql-hilbert` is a pure-Rust leaf crate.** Its only dependencies are
+   `ndarray` (real matrices) and `num-complex` (the qubit `Complex64` algebra).
+   It depends on **no other `larql-*` crate** and links **no BLAS/LAPACK**.
+
+2. **Measurement is an elimination rule, not a new primitive.** Projective
+   measurement is `project(&Qubit, outcome) -> Option<Qubit>`, with `None` the
+   uninhabited outcome ⊥ (coinciding with `SingleQubitLM::score` returning −∞).
+   The no-cloning discipline is enforced by the type system: `LinearQubit` is
+   `!Copy`/`!Clone`, so `measure(self, …)` consumes it (Rust move semantics =
+   linear-logic's prohibition on contraction).
+
+3. **Admissibility is a first-class layer.** Bounded extraction over the LM is
+   classified by arithmetical fragment — `is_realizable` (Δ₀), `exists_continuation`
+   (Σ⁰₁), `uniformly_stable` (Π⁰₂) — implementing Rosko's finite-extraction
+   criterion (admissible measurement ⊆ Σ⁰₁ ∪ Π⁰₂) as the quantifier shape of
+   bounded procedures.
+
+4. **Numerics are hand-written and BLAS-free.** Single/two-qubit gates are
+   fixed-size (`[[Complex64;2];2]`, `[[Complex64;4];4]`) with hand-written
+   `mat_mul`/`dagger`/`apply`; the entanglement-entropy meter uses a pure-Rust
+   cyclic-Jacobi symmetric eigensolver, not `ndarray-linalg`/LAPACK.
+
+5. **Born readout presupposes the dagger installed by canonicalization.** The
+   Born rule `|⟨t|ψ⟩|²` is only well-defined given an inner product; the
+   `larql canonicalize` whitening *is* the act of choosing that dagger/metric.
+   The QLM is therefore conceptually downstream of the canonical pipeline.
+
+## Rationale
+
+- **Portability toward `wasm32v1-none` (#132) and BLAS-free numerics (#135).**
+  A leaf crate with no native linkage and alloc-light, fixed-size kernels is the
+  certification target for the minimal-LM epic. Linking BLAS would make the
+  crate impossible on the bare wasm target; depending on `larql-compute` would
+  drag the whole inference stack.
+- **Constructive/categorical correctness.** Measurement-as-elimination and
+  no-cloning-as-move follow the Curry-Howard-Lambek / categorical-quantum-
+  mechanics reading; encoding linearity in the type system makes the no-cloning
+  theorem mechanical rather than a runtime convention.
+- **Isolation for an exploratory subproject.** The QLM is a research line with
+  its own roadmap and (separate) authorship/licence; keeping it a leaf avoids
+  coupling the main vindex/inference path to in-flux quantum-LM code.
+
+## Consequences
+
+- **Positive:** the crate builds anywhere `ndarray` + `num-complex` build; it is
+  the natural no_std/wasm certification target; the type system enforces the
+  linear discipline; the qubit core is small and auditable.
+- **Negative / accepted cost:** some numerics are reimplemented rather than
+  reused (a symmetric eigensolver, fixed-size complex matmul) — justified by the
+  no-BLAS constraint; a future shared math crate could consolidate (see #135).
+- **Reuse is deliberately forgone:** an entropy helper already exists in
+  `larql-cli` (`ov_rd/metrics.rs`), but reusing it would invert the dependency
+  hierarchy onto a leaf crate; the re-implementation is intentional (`/simplify`
+  review confirmed this is the right call).
+
+## Cross-references
+
+PRs #133 (canonical), #137 (hilbertian residual), #138 (single-qubit LM), #139
+(constructive measurement + admissibility), #140 (two-qubit/Bell). Issues #132
+(wasm32v1-none minimal LM), #135 (numerical-backend portability). Roadmap:
+`docs/QLM-ROADMAP.md`.

--- a/docs/superpowers/plans/2026-06-11-matrix-entanglement-entropy.md
+++ b/docs/superpowers/plans/2026-06-11-matrix-entanglement-entropy.md
@@ -1,0 +1,403 @@
+# Matrix Entanglement-Entropy Meter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `entanglement_entropy(&Array2<f64>) -> f64` to `larql-hilbert` — the entanglement entropy (in ebits) of a real matrix viewed as a bipartite state — backed by a pure-Rust symmetric eigensolver, so the quantum-compressibility quantity can be computed for any weight matrix with no BLAS.
+
+**Architecture:** A pure-Rust cyclic-Jacobi symmetric eigensolver (`eig.rs`) returns the eigenvalues of a real symmetric matrix. `entanglement_entropy` forms the (smaller) Gram matrix `M Mᵀ` or `Mᵀ M`, takes its eigenvalues (the squared singular values), and feeds them to the existing `spectral_entropy`. Everything stays in the leaf crate (deps: `ndarray` + `num-complex` only — no BLAS, no LAPACK), so it remains portable toward the wasm/minimal-LM goals.
+
+**Tech Stack:** Rust 2021, `ndarray` 0.16 (real matrices), the existing `larql_hilbert::spectral_entropy`.
+
+---
+
+## Scope note: foundation of the compressibility investigation
+
+- **This plan:** the matrix-level entanglement-entropy meter (eigensolver + `entanglement_entropy`). Self-contained, TDD-able with synthetic matrices.
+- **Follow-on (separate plan):** a vindex-wide compressibility analysis — a CLI that runs `entanglement_entropy` over the attention/FFN weight matrices and compares **on-shell vs full**, **canonical vs raw**, and checks for **Zipfian/power-law (heavy-tailed self-regularization)** spectra. That depends on this meter plus the vindex weight loaders (`load_attention_qk`, `load_model_weights_with_opts`).
+
+## Domain background (read once)
+
+A real matrix `M` (m×n), viewed as a bipartite pure state by vectorizing, has a Schmidt decomposition whose coefficients are its singular values `σᵢ`. Its **entanglement entropy** is the spectral entropy of the normalized **squared** singular values:
+
+```
+S(M) = −Σ pᵢ log₂ pᵢ ,  pᵢ = σᵢ² / Σ σⱼ²
+```
+
+`S = 0` for a rank-1 matrix (fully compressible to one Schmidt term), `S = log₂(min(m,n))` for a flat spectrum (incompressible). One ebit (`σ² = [½, ½]`) is the superdense-coding unit.
+
+The squared singular values of `M` are the **eigenvalues of the Gram matrix** `M Mᵀ` (m×m) — equivalently `Mᵀ M` (n×n); both share the same nonzero eigenvalues, so use the smaller one. Computing eigenvalues of a real symmetric matrix without BLAS is done with the **cyclic Jacobi method**: repeatedly apply Givens rotations that zero the largest off-diagonal entries; the diagonal converges to the eigenvalues. It is simple, exact in the limit, and quadratically convergent for symmetric matrices.
+
+The existing `spectral_entropy(weights: &[f64]) -> f64` (in `entropy.rs`) already computes `−Σ pᵢ log₂ pᵢ` of a normalized non-negative weight slice. This plan supplies the weights (squared singular values) from a matrix.
+
+## File structure
+
+New file in `crates/larql-hilbert/`:
+- `src/eig.rs` — `symmetric_eigenvalues(&Array2<f64>) -> Vec<f64>` (cyclic Jacobi).
+
+Modified:
+- `src/entropy.rs` — add `entanglement_entropy(&Array2<f64>) -> f64`.
+- `src/lib.rs` — declare `eig` module + re-export `entanglement_entropy`.
+
+Existing API used (do not modify): `spectral_entropy(&[f64]) -> f64`.
+
+---
+
+## Task 1: Pure-Rust symmetric eigensolver (cyclic Jacobi)
+
+**Files:**
+- Create: `crates/larql-hilbert/src/eig.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/eig.rs` with the tests first**
+
+Write this file (implementation + tests together; the tests reference `symmetric_eigenvalues` which the implementation defines):
+
+```rust
+//! Pure-Rust symmetric eigenvalue solver (cyclic Jacobi) — no BLAS/LAPACK.
+//! Used to obtain the squared-singular spectrum for entanglement entropy.
+
+use ndarray::Array2;
+
+/// Eigenvalues of a real symmetric matrix via the cyclic Jacobi method.
+/// Returns the `n` eigenvalues (unordered). The input is assumed symmetric;
+/// only its symmetric part is meaningfully used.
+pub fn symmetric_eigenvalues(a: &Array2<f64>) -> Vec<f64> {
+    let n = a.shape()[0];
+    let mut m = a.clone();
+
+    for _sweep in 0..100 {
+        // Off-diagonal Frobenius norm; stop when negligible.
+        let mut off = 0.0;
+        for i in 0..n {
+            for j in (i + 1)..n {
+                off += m[[i, j]] * m[[i, j]];
+            }
+        }
+        if off.sqrt() < 1e-14 {
+            break;
+        }
+
+        for p in 0..n {
+            for q in (p + 1)..n {
+                let apq = m[[p, q]];
+                if apq.abs() < 1e-300 {
+                    continue;
+                }
+                let app = m[[p, p]];
+                let aqq = m[[q, q]];
+                // Stable Jacobi angle (Golub & Van Loan, sym.schur2).
+                let tau = (aqq - app) / (2.0 * apq);
+                let t = if tau >= 0.0 {
+                    1.0 / (tau + (1.0 + tau * tau).sqrt())
+                } else {
+                    -1.0 / (-tau + (1.0 + tau * tau).sqrt())
+                };
+                let c = 1.0 / (1.0 + t * t).sqrt();
+                let s = t * c;
+
+                // A <- Jᵀ A J for the (p,q) rotation: rotate columns then rows.
+                for k in 0..n {
+                    let akp = m[[k, p]];
+                    let akq = m[[k, q]];
+                    m[[k, p]] = c * akp - s * akq;
+                    m[[k, q]] = s * akp + c * akq;
+                }
+                for k in 0..n {
+                    let apk = m[[p, k]];
+                    let aqk = m[[q, k]];
+                    m[[p, k]] = c * apk - s * aqk;
+                    m[[q, k]] = s * apk + c * aqk;
+                }
+            }
+        }
+    }
+
+    (0..n).map(|i| m[[i, i]]).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    fn sorted(mut v: Vec<f64>) -> Vec<f64> {
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        v
+    }
+
+    fn close(a: &[f64], b: &[f64]) -> bool {
+        a.len() == b.len() && a.iter().zip(b).all(|(x, y)| (x - y).abs() < 1e-9)
+    }
+
+    #[test]
+    fn diagonal_matrix_returns_its_diagonal() {
+        let a = Array2::from_diag(&array![3.0, 1.0, 2.0]);
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 2.0, 3.0]));
+    }
+
+    #[test]
+    fn identity_has_all_unit_eigenvalues() {
+        let a = Array2::<f64>::eye(3);
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 1.0, 1.0]));
+    }
+
+    #[test]
+    fn two_by_two_symmetric_eigenvalues() {
+        // [[2,1],[1,2]] has eigenvalues 1 and 3.
+        let a = array![[2.0, 1.0], [1.0, 2.0]];
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 3.0]));
+    }
+
+    #[test]
+    fn larger_spd_matrix_eigenvalues_sum_to_trace() {
+        // Eigenvalues sum to the trace and product to the determinant —
+        // a basis-independent sanity check on a non-trivial 3×3.
+        let a = array![[4.0, 1.0, 0.0], [1.0, 3.0, 1.0], [0.0, 1.0, 2.0]];
+        let eigs = symmetric_eigenvalues(&a);
+        let sum: f64 = eigs.iter().sum();
+        assert!((sum - 9.0).abs() < 1e-9, "trace should be 9, got {sum}");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they pass**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert eig 2>&1 | tail -8
+```
+Expected: `test result: ok. 4 passed`. (The implementation is in the same file, so these go green immediately — that is acceptable here because the eigensolver is a self-contained numeric kernel verified against known spectra; the failing-first discipline is exercised at the feature boundary in Task 2.)
+
+- [ ] **Step 3: Wire the module into `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod eig;
+pub use eig::symmetric_eigenvalues;
+```
+
+- [ ] **Step 4: Clippy + commit**
+
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+If clippy flags `for i in 0..n` index loops as `needless_range_loop`, restructure the off-diagonal sum with `.enumerate()` iterators (the rotation loops genuinely need index pairs `(p,q)`/`(k,p)` and may carry `#[allow(clippy::needless_range_loop)]` on the function with a one-line comment if clippy insists — these are paired-index numeric kernels where indexing is clearer). Resolve to clean.
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/eig.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): pure-Rust symmetric eigensolver (cyclic Jacobi, no BLAS)"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 2: `entanglement_entropy(&Array2<f64>)`
+
+**Files:**
+- Modify: `crates/larql-hilbert/src/entropy.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `crates/larql-hilbert/src/entropy.rs`, inside the existing `#[cfg(test)] mod tests` block, add:
+
+```rust
+    use ndarray::array;
+
+    #[test]
+    fn rank_one_matrix_has_zero_entanglement() {
+        // [[1,2],[2,4]] = [1,2]ᵀ·[1,2], rank 1 → one nonzero singular value → 0.
+        let m = array![[1.0, 2.0], [2.0, 4.0]];
+        assert!(entanglement_entropy(&m).abs() < 1e-9);
+    }
+
+    #[test]
+    fn identity_2x2_is_one_ebit() {
+        // I₂ has singular values [1,1] → squared [1,1] → 1 ebit.
+        let m = Array2::<f64>::eye(2);
+        assert!((entanglement_entropy(&m) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn rectangular_orthonormal_rows_is_one_ebit() {
+        // 2×3 with two orthonormal rows → M Mᵀ = I₂ → 1 ebit.
+        let m = array![[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        assert!((entanglement_entropy(&m) - 1.0).abs() < 1e-9);
+    }
+```
+
+Also ensure `use ndarray::Array2;` is available to the test module — add `use ndarray::Array2;` next to the new `use ndarray::array;` if `Array2` is not already in scope in the test module.
+
+- [ ] **Step 2: Run to confirm failure**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert entropy 2>&1 | tail -8
+```
+Expected: compile error — `entanglement_entropy` not defined.
+
+- [ ] **Step 3: Add the function**
+
+In `crates/larql-hilbert/src/entropy.rs`, add the import at the top of the file (below the module doc comment):
+
+```rust
+use ndarray::Array2;
+
+use crate::eig::symmetric_eigenvalues;
+```
+
+Then add, after `spectral_entropy` (before the `#[cfg(test)]` block):
+
+```rust
+/// Entanglement entropy (in ebits) of a real matrix viewed as a bipartite
+/// state: the spectral entropy of its squared singular values. `0` for a
+/// rank-1 matrix, `log₂(min(rows, cols))` for a flat spectrum.
+///
+/// Computed from the eigenvalues of the smaller Gram matrix (`M Mᵀ` if
+/// `rows ≤ cols`, else `Mᵀ M`) — these are the squared singular values.
+/// Tiny negative eigenvalues from round-off are clamped to 0.
+pub fn entanglement_entropy(m: &Array2<f64>) -> f64 {
+    let (rows, cols) = (m.shape()[0], m.shape()[1]);
+    let gram = if rows <= cols {
+        m.dot(&m.t())
+    } else {
+        m.t().dot(m)
+    };
+    let weights: Vec<f64> = symmetric_eigenvalues(&gram)
+        .into_iter()
+        .map(|e| e.max(0.0))
+        .collect();
+    spectral_entropy(&weights)
+}
+```
+
+- [ ] **Step 4: Run to confirm the tests pass**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert entropy 2>&1 | tail -8
+```
+Expected: `test result: ok. 8 passed` (5 existing `spectral_entropy` tests + 3 new).
+
+- [ ] **Step 5: Re-export + clippy + commit**
+
+In `crates/larql-hilbert/src/lib.rs`, change the entropy re-export line (currently `pub use entropy::spectral_entropy;`) to:
+
+```rust
+pub use entropy::{entanglement_entropy, spectral_entropy};
+```
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/entropy.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): entanglement_entropy(matrix) via Gram eigenvalues"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 3: Integration test (entropy as a compressibility ordering) + doc
+
+**Files:**
+- Create: `crates/larql-hilbert/tests/entropy_integration.rs`
+- Modify: `crates/larql-hilbert/src/entropy.rs` (doc only)
+
+- [ ] **Step 1: Write the integration test**
+
+Create `crates/larql-hilbert/tests/entropy_integration.rs`:
+
+```rust
+//! End-to-end: entanglement_entropy orders matrices by compressibility —
+//! rank-1 (0 ebits, fully compressible) < skewed spectrum < flat spectrum
+//! (maximal, incompressible) — through the public crate API.
+
+use larql_hilbert::{entanglement_entropy, spectral_entropy};
+use ndarray::{array, Array2};
+
+#[test]
+fn entropy_orders_matrices_by_compressibility() {
+    // Rank-1: zero entanglement (one Schmidt term).
+    let rank1 = array![[1.0, 2.0], [2.0, 4.0]];
+    // Skewed singular values [1, 0.1] → squared [1, 0.01]: low but nonzero.
+    let skewed = Array2::from_diag(&array![1.0, 0.1]);
+    // Flat: identity, maximal entropy for 2×2 (1 ebit).
+    let flat = Array2::<f64>::eye(2);
+
+    let s_rank1 = entanglement_entropy(&rank1);
+    let s_skewed = entanglement_entropy(&skewed);
+    let s_flat = entanglement_entropy(&flat);
+
+    assert!(s_rank1 < 1e-9, "rank-1 should be ~0, got {s_rank1}");
+    assert!(s_rank1 < s_skewed, "{s_rank1} !< {s_skewed}");
+    assert!(s_skewed < s_flat, "{s_skewed} !< {s_flat}");
+    assert!((s_flat - 1.0).abs() < 1e-9, "flat 2×2 should be 1 ebit, got {s_flat}");
+}
+
+#[test]
+fn matrix_meter_agrees_with_spectral_entropy_on_squared_singular_values() {
+    // The matrix meter must equal spectral_entropy applied to the squared
+    // singular values directly. For a diagonal matrix those are the squared
+    // diagonal entries.
+    let m = Array2::from_diag(&array![2.0, 1.0]);
+    let direct = spectral_entropy(&[4.0, 1.0]); // squares of 2 and 1
+    assert!((entanglement_entropy(&m) - direct).abs() < 1e-9);
+}
+```
+
+- [ ] **Step 2: Run the integration test + whole crate suite**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert --test entropy_integration 2>&1 | tail -6
+cd /home/metavacua/larql && cargo test -p larql-hilbert 2>&1 | tail -6
+```
+Expected: 2 integration tests pass; whole-crate suite passes.
+
+- [ ] **Step 3: Add a doc note to `entropy.rs`**
+
+In `crates/larql-hilbert/src/entropy.rs`, append to the END of the top `//!` module doc block:
+
+```rust
+//!
+//! `entanglement_entropy(M)` is the quantum-compressibility meter: low entropy
+//! ⇒ few Schmidt terms ⇒ the matrix compresses to a small tensor-network bond
+//! dimension (`χ ≈ 2^S`); a flat (heavy-tailed-but-broad) spectrum is
+//! incompressible. Combined with the Hilbertian residual (complex/coherence
+//! structure), it quantifies the classical-vs-quantum compressibility gap of a
+//! vindex, denominated in ebits.
+```
+
+- [ ] **Step 4: Clippy + commit**
+
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/tests/entropy_integration.rs crates/larql-hilbert/src/entropy.rs
+git commit -m "test(hilbert): entanglement entropy orders matrices by compressibility + doc"
+```
+
+## Report
+Status DONE/BLOCKED, full-crate test count, commit SHA.
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- [x] Pure-Rust symmetric eigensolver (no BLAS) — Task 1 (`symmetric_eigenvalues`, cyclic Jacobi)
+- [x] `entanglement_entropy(&Array2<f64>)` via Gram eigenvalues → `spectral_entropy` — Task 2
+- [x] Ordering/compressibility integration + agreement with `spectral_entropy` — Task 3
+- [ ] **Deferred (separate plan):** vindex-wide analysis CLI (on-shell vs full, canonical vs raw, Zipfian/HTSR check) — depends on this meter + weight loaders.
+
+**Type consistency:**
+- `symmetric_eigenvalues(&Array2<f64>) -> Vec<f64>` defined Task 1, called by `entanglement_entropy` (Task 2).
+- `entanglement_entropy(&Array2<f64>) -> f64` defined Task 2, used in Task 3; re-exported at crate root in Task 2.
+- `spectral_entropy(&[f64]) -> f64` (pre-existing) consumed by `entanglement_entropy` and cross-checked in Task 3.
+- Gram orientation: `M Mᵀ` when `rows ≤ cols` else `Mᵀ M` — same convention named in the doc and the implementation.
+
+**No placeholders:** every code step contains complete code; every run step has an exact command + expected count. Task 1's eigensolver tests pass immediately (a verified numeric kernel against known spectra); the failing-first cycle is exercised at the feature boundary in Task 2 (`entanglement_entropy` undefined → compile error → implement).

--- a/openspec/changes/qlm-foundation/proposal.md
+++ b/openspec/changes/qlm-foundation/proposal.md
@@ -1,0 +1,45 @@
+# Proposal: Quantum Language Model Foundation
+
+## Status: in-flight
+
+## Why
+
+The QLM line (see `docs/QLM-ROADMAP.md`) formalizes language models as
+Hilbert-space objects — qubit states, unitary evolution, Born-rule readout — and
+grounds the classical-vs-quantum compressibility programme. The foundation is
+the `larql-hilbert` crate (PRs #137–#140 + the entanglement-entropy work). This
+change captures its requirements as testable contracts, mirroring the
+`canonical-extraction` change.
+
+## What
+
+Specify the `quantum-language-model` capability provided by `larql-hilbert`:
+
+1. The complex-structure core and the unifying theorem
+   `commutator_residual = 2·antilinear_fraction`, plus the real↔complex bridge.
+2. The single-qubit Bloch-sphere LM: state, SU(2) gates, Born readout,
+   autoregressive scoring/generation.
+3. Constructive measurement (elimination rule, ⊥) with no-cloning enforced by
+   the type system, and the bounded-extraction admissibility layer (Δ₀/Σ⁰₁/Π⁰₂).
+4. The two-qubit LM: tensor product, entanglement (non-factorization), CNOT and
+   the Bell operation, partial measurement and its correlation.
+5. The entanglement-entropy meter (quantum compressibility, in ebits).
+
+## Non-goals (this change)
+
+- GHZ / W (3+ qubit) states — Phase 5.
+- Superdense coding protocol and quantum LQL verbs (`MEASURE`/`STEP`) — Phase 6.
+- Vindex-wide compressibility analysis CLI — Phase 7.
+- `wasm32v1-none` / `no_std` certification of the kernels — Phase 8 (epic #132).
+
+## Related
+
+- ADR: `docs/adr/0011-qlm-quantum-language-models.md`.
+- Roadmap: `docs/QLM-ROADMAP.md`.
+- Depends-on: the canonical pipeline (`canonical-extraction` change) — Born
+  readout presupposes the dagger that whitening installs.
+
+## Risk
+
+Low. `larql-hilbert` is an additive pure-Rust leaf crate; nothing in the
+inference/vindex path depends on it.

--- a/openspec/changes/qlm-foundation/specs/quantum-language-model/spec.md
+++ b/openspec/changes/qlm-foundation/specs/quantum-language-model/spec.md
@@ -1,0 +1,197 @@
+## ADDED Requirements: quantum-language-model
+
+### REQ-QLM-001: Complex structure and the antilinear-fraction equivalence
+
+The system SHALL provide the split-half complex structure `J` on `ℝⁿ` (n even)
+with `J² = −I`, the relative commutator residual `‖MJ − JM‖_F / ‖M‖_F`, and the
+antilinear fraction, satisfying the identity
+`commutator_residual(M, J) = 2 · antilinear_fraction(M)`.
+
+#### Scenario: J squares to −I
+
+Given `J = split_half_j(n)`, then `J·J = −I`.
+
+<!-- test: crates/larql-hilbert/src/complex_structure.rs::tests::j_squares_to_negative_identity -->
+
+#### Scenario: residual is twice the antilinear fraction
+
+Given any real matrix M, `commutator_residual(M, J) = 2 · antilinear_fraction(M)`.
+
+<!-- test: crates/larql-hilbert/src/complex_structure.rs::tests::equivalence_theorem_residual_is_twice_antilinear_fraction -->
+
+---
+
+### REQ-QLM-002: Real↔complex bridge
+
+The system SHALL provide `realify(A, B) = [[A, −B], [B, A]]` and `complex_parts`
+that recovers `(A, B)`, with `complex_parts ∘ realify = identity`.
+
+#### Scenario: bridge round-trips
+
+Given real m×m blocks A, B, `complex_parts(realify(A, B)) = (A, B)`.
+
+<!-- test: crates/larql-hilbert/src/complex_structure.rs::tests::complex_parts_inverts_realify -->
+
+---
+
+### REQ-QLM-003: Single-qubit state, Bloch sphere, and SU(2) gates
+
+The system SHALL provide a `Qubit` (`ℂ²`) with Bloch-sphere coordinates and a
+set of unitary gates (Pauli X/Y/Z, Hadamard, rotations) that are unitary and
+square to identity (for the involutory ones).
+
+#### Scenario: Hadamard maps north pole to +x
+
+`H|0⟩` has Bloch vector `(1, 0, 0)`.
+
+<!-- test: crates/larql-hilbert/src/qubit.rs::tests::hadamard_zero_points_to_plus_x -->
+
+#### Scenario: standard gates are unitary
+
+`identity`, `pauli_x/y/z`, `hadamard`, `rz`, `ry` are all unitary.
+
+<!-- test: crates/larql-hilbert/src/unitary.rs::tests::all_standard_gates_are_unitary -->
+
+---
+
+### REQ-QLM-004: Born-rule measurement
+
+The system SHALL provide `measure_probs(&Qubit) -> [f64; 2]` = `[|α|², |β|²]` of
+the normalized state, summing to 1.
+
+#### Scenario: Hadamard state is a fair coin
+
+`measure_probs(H|0⟩) = [0.5, 0.5]`.
+
+<!-- test: crates/larql-hilbert/src/born.rs::tests::hadamard_zero_is_fair_coin -->
+
+---
+
+### REQ-QLM-005: Single-qubit autoregressive language model
+
+The system SHALL provide `SingleQubitLM` (2-token vocabulary) with Born-rule
+`next_distribution`, collapse-then-unitary `step`, autoregressive `score`
+(−∞ on impossible tokens), and reproducible `generate`.
+
+#### Scenario: impossible token scores −∞
+
+From `|0⟩` with identity gates, `score([1])` is −∞.
+
+<!-- test: crates/larql-hilbert/src/qlm.rs::tests::impossible_token_scores_neg_infinity -->
+
+#### Scenario: out-of-vocabulary token is rejected
+
+`score`/`step` panic with a message naming the vocabulary for tokens ≥ 2.
+
+<!-- test: crates/larql-hilbert/src/qlm.rs::tests::score_rejects_out_of_vocabulary_token -->
+
+---
+
+### REQ-QLM-006: Measurement as elimination with no-cloning
+
+The system SHALL provide `project(&Qubit, outcome) -> Option<Qubit>` (the
+elimination rule; `None` = ⊥ for a zero-amplitude outcome) and a `LinearQubit`
+that is `!Copy`/`!Clone` whose `measure(self, …)` consumes it (no-cloning via
+move semantics).
+
+#### Scenario: impossible outcome is ⊥
+
+`project(&|0⟩, 1)` is `None`.
+
+<!-- test: crates/larql-hilbert/src/measurement.rs::tests::project_impossible_outcome_is_bottom -->
+
+#### Scenario: linear measurement consumes the state
+
+`LinearQubit::new(H|0⟩).measure(1)` returns the collapsed state and the
+`LinearQubit` cannot be reused (compile-time).
+
+<!-- test: crates/larql-hilbert/src/measurement.rs::tests::linear_qubit_measure_consumes_and_collapses -->
+
+---
+
+### REQ-QLM-007: Bounded-extraction admissibility (Δ₀ / Σ⁰₁ / Π⁰₂)
+
+The system SHALL classify bounded extraction over the LM by arithmetical
+fragment: `is_realizable` (Δ₀), `exists_continuation` (Σ⁰₁ bounded witness
+search), `uniformly_stable` (Π⁰₂), per Rosko's finite-extraction criterion.
+
+#### Scenario: realizability decides finite sequences
+
+For the identity-gates `|0⟩` LM, `is_realizable([0,0,0])` is true and
+`is_realizable([0,1])` is false.
+
+<!-- test: crates/larql-hilbert/src/admissibility.rs::tests::realizable_distinguishes_possible_from_impossible -->
+
+#### Scenario: Σ⁰₁ finds a bounded witness
+
+`exists_continuation` returns a realizable witness within the bound when one
+exists.
+
+<!-- test: crates/larql-hilbert/src/admissibility.rs::tests::sigma01_finds_a_witness_within_bound -->
+
+---
+
+### REQ-QLM-008: Two-qubit state, tensor product, and entanglement
+
+The system SHALL provide `TwoQubit` (`ℂ⁴`), the tensor product, and
+`is_product` (an entanglement non-factorization test: true iff the 2×2
+amplitude determinant is zero).
+
+#### Scenario: tensor of basis qubits is a basis state
+
+`tensor(|1⟩, |0⟩) = |10⟩`.
+
+<!-- test: crates/larql-hilbert/src/two_qubit.rs::tests::tensor_of_basis_qubits_is_basis_state -->
+
+#### Scenario: a Bell-like state is not a product
+
+`(|00⟩+|11⟩)/√2` is not a product state.
+
+<!-- test: crates/larql-hilbert/src/two_qubit.rs::tests::bell_like_state_is_not_product -->
+
+---
+
+### REQ-QLM-009: Bell operation, partial measurement, and the two-qubit LM
+
+The system SHALL provide CNOT, the Bell operation `Φ⁺ = CNOT·(H⊗I)·|00⟩`
+(entangled), partial single-qubit measurement showing perfect correlation, and a
+`TwoQubitLM` whose Bell-initialized statistics forbid the anti-correlated joint
+tokens (−∞).
+
+#### Scenario: the Bell state is entangled
+
+`is_product(bell())` is false.
+
+<!-- test: crates/larql-hilbert/src/gate2.rs::tests::bell_state_is_entangled -->
+
+#### Scenario: measuring one qubit forces the other
+
+Measuring qubit 0 of `Φ⁺` collapses qubit 1 to the same value.
+
+<!-- test: crates/larql-hilbert/src/two_qubit.rs::tests::measuring_one_qubit_forces_the_other -->
+
+#### Scenario: the Bell LM forbids anti-correlated tokens
+
+With a Bell initial state, joint tokens 01 and 10 score −∞.
+
+<!-- test: crates/larql-hilbert/src/qlm2.rs::tests::impossible_joint_token_scores_neg_infinity -->
+
+---
+
+### REQ-QLM-010: Entanglement-entropy meter (quantum compressibility)
+
+The system SHALL provide `spectral_entropy(&[f64])` = `−Σ pᵢ log₂ pᵢ` of a
+normalized non-negative spectrum (in ebits), with `0` for a rank-1 / single
+nonzero weight and `1` for two equal weights (one ebit).
+
+#### Scenario: two equal weights is one ebit
+
+`spectral_entropy([w, w]) = 1`.
+
+<!-- test: crates/larql-hilbert/src/entropy.rs::tests::two_equal_weights_is_one_ebit -->
+
+#### Scenario: a rank-1 spectrum has zero entropy
+
+`spectral_entropy([w, 0, 0]) = 0`.
+
+<!-- test: crates/larql-hilbert/src/entropy.rs::tests::rank_one_spectrum_has_zero_entropy -->


### PR DESCRIPTION
## Summary

Phase 4 of the QLM line: the **entanglement-entropy / quantum-compressibility meter** — `entanglement_entropy(&Array2<f64>)` in ebits, backed by a pure-Rust symmetric eigensolver (no BLAS). Turns the Phase-3 `is_product` (entangled: yes/no) into "how many ebits."

> **Stacked on #140** (two-qubit/Bell). Base branch is `feat/two-qubit-bell`; merge after #140. Also carries the **QLM governance docs** (roadmap, ADR 0011, openspec change).

## What it adds (in `larql-hilbert`)

- **`entropy.rs`** — `spectral_entropy(&[f64])` (von Neumann entropy of a normalized spectrum, in ebits: `0` = rank-1/compressible, `log₂ d` = flat/incompressible, `[½,½]` = 1 ebit) and **`entanglement_entropy(&Array2<f64>)`** = spectral entropy of a matrix's squared singular values (eigenvalues of the smaller Gram matrix).
- **`eig.rs`** — `symmetric_eigenvalues` via the cyclic Jacobi method, **pure Rust, no BLAS/LAPACK** (keeps the leaf crate's clean dep story and the wasm32v1-none path).

This is the measured quantity behind the classical-vs-quantum vindex-compressibility conjecture (ratio denominated in ebits, superdense coding as the unit, Hilbertian residual for the complex/coherence side).

## Governance docs (also in this PR)

- `docs/QLM-ROADMAP.md` — **Copyright © 2026 Ian Douglas Lawrence Norman McLean · CC BY-SA 4.0** (a separate work; the upstream `ROADMAP.md` is unmodified).
- `docs/adr/0011-qlm-quantum-language-models.md` — the QLM architecture decisions.
- `crates/larql-hilbert/ROADMAP.md` — per-crate stub.
- `openspec/changes/qlm-foundation/` — `REQ-QLM-001`…`010`, each scenario annotated with the backing test.

## Verification

79 tests pass (unit + 4 integration files), clippy clean. The eigensolver is verified against known spectra (diagonal, identity, 2×2, trace); the meter is verified by an ordering test (rank-1 0 < skewed < flat 1 ebit) and an agreement test (`entanglement_entropy(diag([2,1])) == spectral_entropy([4,1])`). Leaf crate deps unchanged: only `ndarray` + `num-complex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
