### PR TITLE
integration: full QLM stack (#133–#142) consolidated + drift reconciled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,6 +2215,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "larql-hilbert"
+version = "0.1.0"
+dependencies = [
+ "ndarray",
+ "num-complex",
+]
+
+[[package]]
 name = "larql-inference"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,6 +2149,7 @@ dependencies = [
  "larql-compute",
  "larql-compute-metal",
  "larql-core",
+ "larql-hilbert",
  "larql-inference",
  "larql-kv",
  "larql-lql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/larql-python",
     # boundary codec (Phase 1-3 of BOUNDARY_REF_PROTOCOL)
     "crates/larql-boundary",
+    "crates/larql-hilbert",
     # portable (extract to sibling repos later, names stable)
     "crates/model-compute",
 ]
@@ -36,6 +37,7 @@ default-members = [
     "crates/larql-router",
     "crates/larql-router-protocol",
     "crates/larql-boundary",
+    "crates/larql-hilbert",
     "crates/model-compute",
 ]
 

--- a/crates/larql-cli/Cargo.toml
+++ b/crates/larql-cli/Cargo.toml
@@ -19,6 +19,7 @@ larql-kv = { path = "../larql-kv" }
 larql-models = { path = "../larql-models" }
 larql-lql = { path = "../larql-lql" }
 larql-vindex = { path = "../larql-vindex" }
+larql-hilbert = { path = "../larql-hilbert" }
 clap = { version = "4", features = ["derive", "env"] }
 indicatif = "0.17"
 reqwest = { version = "0.12", features = ["blocking", "json"] }

--- a/crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use clap::Args;
+use larql_vindex::{
+    canonical::{
+        classify_layer_regime, compute_onshell_mask, compute_whitening, estimate_covariance,
+        CanonicalMeta, LayerCanonicalInfo,
+    },
+    format::{
+        down_meta::read_cscores_binary,
+        filenames::CANONICAL_META_JSON,
+        load::{load_vindex_config, load_vindex_embeddings},
+    },
+};
+
+#[derive(Args)]
+pub struct CanonicalizeArgs {
+    /// Path to the .vindex directory to canonicalize.
+    vindex: PathBuf,
+
+    /// Override the on-shell fraction (default 0.15 = top 15% by c_score).
+    #[arg(long, default_value = "0.15")]
+    onshell_fraction: f32,
+
+    /// Override the covariance sample size (default 4096 embedding rows).
+    #[arg(long, default_value = "4096")]
+    covariance_samples: usize,
+}
+
+pub fn run(args: CanonicalizeArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let vindex_dir = &args.vindex;
+    let onshell_fraction = args.onshell_fraction;
+    let covariance_samples = args.covariance_samples;
+
+    println!("Canonicalizing vindex at {}", vindex_dir.display());
+
+    // ── 1. Load index.json ──────────────────────────────────────────────
+    let t0 = Instant::now();
+    let config = load_vindex_config(vindex_dir)?;
+    println!(
+        "  model: {} ({}), {} layers, hidden={}, vocab={}",
+        config.model, config.family, config.num_layers, config.hidden_size, config.vocab_size
+    );
+
+    // ── 2. Load embeddings.bin ──────────────────────────────────────────
+    print!("  loading embeddings.bin ... ");
+    let (embed, embed_scale) = load_vindex_embeddings(vindex_dir)?;
+    println!(
+        "{}×{} ({:.1}ms)",
+        embed.shape()[0],
+        embed.shape()[1],
+        t0.elapsed().as_secs_f64() * 1000.0
+    );
+
+    // ── 3. Estimate covariance G ────────────────────────────────────────
+    let t1 = Instant::now();
+    print!("  estimating G ({covariance_samples} samples) ... ");
+    let g = estimate_covariance(&embed, embed_scale, covariance_samples);
+    println!("{:.1}ms", t1.elapsed().as_secs_f64() * 1000.0);
+
+    // ── 4. Cholesky whitening ───────────────────────────────────────────
+    let t2 = Instant::now();
+    print!("  Cholesky decomposition ... ");
+    let whitening = compute_whitening(&g).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    println!("{:.1}ms", t2.elapsed().as_secs_f64() * 1000.0);
+
+    // ── 5. Read c_scores from down_meta.bin ────────────────────────────
+    let t3 = Instant::now();
+    print!("  reading c_scores from down_meta.bin ... ");
+    let cscores_per_layer = read_cscores_binary(vindex_dir)?;
+    println!(
+        "{} layers, {:.1}ms",
+        cscores_per_layer.len(),
+        t3.elapsed().as_secs_f64() * 1000.0
+    );
+
+    // ── 6. Per-layer: regime + on-shell ────────────────────────────────
+    let mut layers_info: Vec<LayerCanonicalInfo> = Vec::with_capacity(config.num_layers);
+    for layer in 0..config.num_layers {
+        let cscores = cscores_per_layer
+            .get(layer)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+        let (regime, mean_density) = classify_layer_regime(cscores);
+        let mask = compute_onshell_mask(cscores, onshell_fraction);
+        let on_shell_count = mask.iter().filter(|&&b| b).count();
+        layers_info.push(LayerCanonicalInfo {
+            layer,
+            regime,
+            on_shell_count,
+            total_features: cscores.len(),
+            mean_density,
+        });
+    }
+
+    // ── 7. Build and write canonical_meta.json ─────────────────────────
+    let meta = CanonicalMeta {
+        version: 1,
+        model: config.model.clone(),
+        family: config.family.clone(),
+        num_layers: config.num_layers,
+        hidden_size: config.hidden_size,
+        covariance_sample_size: covariance_samples,
+        embed_scale,
+        cholesky_l_packed: whitening.l_packed,
+        layers: layers_info,
+    };
+
+    let out_path = vindex_dir.join(CANONICAL_META_JSON);
+    let json = serde_json::to_string_pretty(&meta)?;
+    std::fs::write(&out_path, &json)?;
+
+    let total_on_shell: usize = meta.layers.iter().map(|l| l.on_shell_count).sum();
+    let total_features: usize = meta.layers.iter().map(|l| l.total_features).sum();
+    let pct = if total_features > 0 {
+        100.0 * total_on_shell as f32 / total_features as f32
+    } else {
+        0.0
+    };
+
+    println!("  on-shell features: {total_on_shell}/{total_features} ({pct:.1}%)");
+    println!("  wrote {}", out_path.display());
+    println!("  total: {:.1}ms", t0.elapsed().as_secs_f64() * 1000.0);
+
+    Ok(())
+}

--- a/crates/larql-cli/src/commands/extraction/entanglement_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/entanglement_cmd.rs
@@ -48,6 +48,95 @@ fn coupling_metrics(coupling: &Array2<f64>, j: &Array2<f64>) -> (f64, f64) {
     (residual, entropy)
 }
 
+pub fn run(args: EntanglementArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = &args.vindex;
+    let t0 = Instant::now();
+    println!("Entanglement / compressibility analysis for vindex at {}", dir.display());
+
+    let config = load_vindex_config(dir)?;
+    let mc = config
+        .model_config
+        .as_ref()
+        .ok_or("entanglement: index.json has no model_config (need head_dim / head counts)")?;
+    let (num_q, num_kv, head_dim) = (mc.num_q_heads, mc.num_kv_heads, mc.head_dim);
+    println!(
+        "  model: {} ({}), {} layers, q_heads={num_q}, kv_heads={num_kv}, head_dim={head_dim}",
+        config.model, config.family, config.num_layers
+    );
+
+    let j = complex_structure_split_half(head_dim);
+
+    print!("  loading attention Q/K ... ");
+    let qk = load_attention_qk(dir, config.num_layers)?;
+    println!("{} layers ({:.1}ms)", qk.len(), t0.elapsed().as_secs_f64() * 1000.0);
+
+    let mut heads: Vec<HeadEntanglementInfo> = Vec::with_capacity(config.num_layers * num_q);
+    for (layer, (wq, wk)) in qk.iter().enumerate() {
+        if wq.nrows() < num_q * head_dim || wk.nrows() < num_kv * head_dim {
+            return Err(format!(
+                "layer {layer}: attention weights too small (wq {} rows, wk {} rows; need {} and {})",
+                wq.nrows(),
+                wk.nrows(),
+                num_q * head_dim,
+                num_kv * head_dim
+            )
+            .into());
+        }
+        let wq64 = wq.mapv(|v| v as f64);
+        let wk64 = wk.mapv(|v| v as f64);
+        for h in 0..num_q {
+            let g = kv_head_for_query(h, num_q, num_kv);
+            let wq_h = head_block(&wq64, h, head_dim);
+            let wk_g = head_block(&wk64, g, head_dim);
+            let coupling = head_coupling(&wq_h, &wk_g);
+            let (residual, entropy) = coupling_metrics(&coupling, &j);
+            heads.push(HeadEntanglementInfo {
+                layer,
+                query_head: h,
+                kv_head: g,
+                residual,
+                entropy,
+            });
+        }
+    }
+
+    let meta = EntanglementMeta {
+        version: 1,
+        model: config.model.clone(),
+        head_dim,
+        num_q_heads: num_q,
+        num_kv_heads: num_kv,
+        heads,
+    };
+
+    let out = dir.join("entanglement_meta.json");
+    std::fs::write(&out, serde_json::to_string_pretty(&meta)?)?;
+
+    let entropies: Vec<f64> = meta.heads.iter().map(|h| h.entropy).collect();
+    let residuals: Vec<f64> = meta.heads.iter().map(|h| h.residual).collect();
+    let mean = |v: &[f64]| v.iter().sum::<f64>() / v.len() as f64;
+    let min = |v: &[f64]| v.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = |v: &[f64]| v.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    println!(
+        "  entropy (ebits)  over {} heads: mean {:.3}, min {:.3}, max {:.3}  (max possible {:.1})",
+        entropies.len(),
+        mean(&entropies),
+        min(&entropies),
+        max(&entropies),
+        (head_dim as f64).log2()
+    );
+    println!(
+        "  residual         over {} heads: mean {:.3}, min {:.3}, max {:.3}",
+        residuals.len(),
+        mean(&residuals),
+        min(&residuals),
+        max(&residuals)
+    );
+    println!("  wrote {}", out.display());
+    println!("  total: {:.1}ms", t0.elapsed().as_secs_f64() * 1000.0);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/larql-cli/src/commands/extraction/entanglement_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/entanglement_cmd.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use clap::Args;
+use ndarray::Array2;
+use serde::{Deserialize, Serialize};
+
+use larql_hilbert::entanglement_entropy;
+use larql_vindex::canonical::{
+    commutator_residual, complex_structure_split_half, head_block, head_coupling, kv_head_for_query,
+};
+use larql_vindex::format::{attn_load::load_attention_qk, load::load_vindex_config};
+
+/// Per-head compressibility metrics on the QK coupling `C = W_Q W_Kᵀ`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeadEntanglementInfo {
+    pub layer: usize,
+    pub query_head: usize,
+    pub kv_head: usize,
+    /// Hilbertian residual ‖[C,J]‖/‖C‖ ∈ [0,2] — complex-linearity.
+    pub residual: f64,
+    /// Entanglement entropy of C, in ebits ∈ [0, log2(head_dim)].
+    pub entropy: f64,
+}
+
+/// Root metadata written to `entanglement_meta.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntanglementMeta {
+    pub version: u32,
+    pub model: String,
+    pub head_dim: usize,
+    pub num_q_heads: usize,
+    pub num_kv_heads: usize,
+    pub heads: Vec<HeadEntanglementInfo>,
+}
+
+#[derive(Args)]
+pub struct EntanglementArgs {
+    /// Path to the .vindex directory to analyse.
+    vindex: PathBuf,
+}
+
+/// The two compressibility metrics of a coupling matrix `C` against the
+/// split-half complex structure `J`: (Hilbertian residual, entanglement entropy).
+fn coupling_metrics(coupling: &Array2<f64>, j: &Array2<f64>) -> (f64, f64) {
+    let residual = commutator_residual(coupling, j);
+    let entropy = entanglement_entropy(coupling);
+    (residual, entropy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn identity_coupling_is_complex_linear_and_flat() {
+        // I₄ commutes with J → residual 0; flat spectrum → log2(4) = 2 ebits.
+        let c = Array2::<f64>::eye(4);
+        let j = complex_structure_split_half(4);
+        let (r, s) = coupling_metrics(&c, &j);
+        assert!(r.abs() < 1e-9, "identity should commute with J → residual 0, got {r}");
+        assert!((s - 2.0).abs() < 1e-9, "I₄ flat spectrum → 2 ebits, got {s}");
+    }
+
+    #[test]
+    fn rank_one_coupling_has_zero_entanglement() {
+        // Rank-1 4×4 (a 2×2 rank-1 block, rest zero) → 0 ebits.
+        let c = array![
+            [1.0, 2.0, 0.0, 0.0],
+            [2.0, 4.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ];
+        let j = complex_structure_split_half(4);
+        let (_r, s) = coupling_metrics(&c, &j);
+        assert!(s.abs() < 1e-9, "rank-1 coupling → 0 ebits, got {s}");
+    }
+}

--- a/crates/larql-cli/src/commands/extraction/hilbertian_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/hilbertian_cmd.rs
@@ -1,0 +1,83 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use clap::Args;
+use larql_vindex::{
+    canonical::{
+        complex_structure_split_half, head_block, head_hilbertian_residual, kv_head_for_query,
+        HeadHilbertianInfo, HilbertianMeta,
+    },
+    format::{attn_load::load_attention_qk, filenames::HILBERTIAN_META_JSON, load::load_vindex_config},
+};
+
+#[derive(Args)]
+pub struct HilbertianArgs {
+    /// Path to the .vindex directory to analyse.
+    vindex: PathBuf,
+}
+
+pub fn run(args: HilbertianArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = &args.vindex;
+    let t0 = Instant::now();
+    println!("Hilbertian residual for vindex at {}", dir.display());
+
+    let config = load_vindex_config(dir)?;
+    let mc = config
+        .model_config
+        .as_ref()
+        .ok_or("hilbertian: index.json has no model_config (need head_dim / head counts)")?;
+    let (num_q, num_kv, head_dim, hidden) =
+        (mc.num_q_heads, mc.num_kv_heads, mc.head_dim, config.hidden_size);
+    println!(
+        "  model: {} ({}), {} layers, hidden={hidden}, q_heads={num_q}, kv_heads={num_kv}, head_dim={head_dim}",
+        config.model, config.family, config.num_layers
+    );
+
+    let j = complex_structure_split_half(head_dim);
+
+    print!("  loading attention Q/K ... ");
+    let qk = load_attention_qk(dir, config.num_layers)?;
+    println!("{} layers ({:.1}ms)", qk.len(), t0.elapsed().as_secs_f64() * 1000.0);
+
+    let mut heads: Vec<HeadHilbertianInfo> = Vec::with_capacity(config.num_layers * num_q);
+    for (layer, (wq, wk)) in qk.iter().enumerate() {
+        let wq64 = wq.mapv(|v| v as f64);
+        let wk64 = wk.mapv(|v| v as f64);
+        for h in 0..num_q {
+            let g = kv_head_for_query(h, num_q, num_kv);
+            let wq_h = head_block(&wq64, h, head_dim);
+            let wk_g = head_block(&wk64, g, head_dim);
+            let residual = head_hilbertian_residual(&wq_h, &wk_g, &j);
+            heads.push(HeadHilbertianInfo { layer, query_head: h, kv_head: g, residual });
+        }
+    }
+
+    let meta = HilbertianMeta {
+        version: 1,
+        model: config.model.clone(),
+        hidden_size: hidden,
+        head_dim,
+        num_q_heads: num_q,
+        num_kv_heads: num_kv,
+        complex_structure: "split_half".into(),
+        heads,
+    };
+
+    let out = dir.join(HILBERTIAN_META_JSON);
+    std::fs::write(&out, serde_json::to_string_pretty(&meta)?)?;
+
+    let rs: Vec<f64> = meta.heads.iter().map(|h| h.residual).collect();
+    let mean = rs.iter().sum::<f64>() / rs.len() as f64;
+    let min = rs.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = rs.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    println!(
+        "  residual over {} heads: mean {:.4}, min {:.4}, max {:.4}",
+        rs.len(),
+        mean,
+        min,
+        max
+    );
+    println!("  wrote {}", out.display());
+    println!("  total: {:.1}ms", t0.elapsed().as_secs_f64() * 1000.0);
+    Ok(())
+}

--- a/crates/larql-cli/src/commands/extraction/hilbertian_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/hilbertian_cmd.rs
@@ -41,6 +41,17 @@ pub fn run(args: HilbertianArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let mut heads: Vec<HeadHilbertianInfo> = Vec::with_capacity(config.num_layers * num_q);
     for (layer, (wq, wk)) in qk.iter().enumerate() {
+        if wq.nrows() < num_q * head_dim || wk.nrows() < num_kv * head_dim {
+            return Err(format!(
+                "layer {layer}: attention weights too small (wq {} rows, wk {} rows; \
+                 need {} and {}) — config/weights mismatch",
+                wq.nrows(),
+                wk.nrows(),
+                num_q * head_dim,
+                num_kv * head_dim
+            )
+            .into());
+        }
         let wq64 = wq.mapv(|v| v as f64);
         let wk64 = wk.mapv(|v| v as f64);
         for h in 0..num_q {

--- a/crates/larql-cli/src/commands/extraction/mod.rs
+++ b/crates/larql-cli/src/commands/extraction/mod.rs
@@ -9,6 +9,7 @@ pub mod circuit_discover_cmd;
 pub mod compile_cmd;
 pub mod convert_cmd;
 pub mod embedding_jump_cmd;
+pub mod entanglement_cmd;
 pub mod extract_index_cmd;
 pub mod ffn_bottleneck_cmd;
 pub mod ffn_latency_cmd;

--- a/crates/larql-cli/src/commands/extraction/mod.rs
+++ b/crates/larql-cli/src/commands/extraction/mod.rs
@@ -4,6 +4,7 @@ pub mod attn_bottleneck_cmd;
 pub mod bfs_cmd;
 pub mod bottleneck_test_cmd;
 pub mod build_cmd;
+pub mod canonicalize_cmd;
 pub mod circuit_discover_cmd;
 pub mod compile_cmd;
 pub mod convert_cmd;

--- a/crates/larql-cli/src/commands/extraction/mod.rs
+++ b/crates/larql-cli/src/commands/extraction/mod.rs
@@ -15,6 +15,7 @@ pub mod ffn_latency_cmd;
 pub mod ffn_overlap_cmd;
 pub mod fingerprint_extract_cmd;
 pub mod hf_cmd;
+pub mod hilbertian_cmd;
 pub mod index_gates_cmd;
 pub mod kg_bench_cmd;
 pub mod ov_gate_cmd;

--- a/crates/larql-cli/src/main.rs
+++ b/crates/larql-cli/src/main.rs
@@ -155,6 +155,10 @@ enum Commands {
     /// Compute canonical form metadata for a vindex (writes canonical_meta.json).
     Canonicalize(canonicalize_cmd::CanonicalizeArgs),
 
+    #[command(next_help_heading = "Build")]
+    /// Score per-head complex-linearity (Hilbertian residual); writes hilbertian_meta.json.
+    Hilbertian(hilbertian_cmd::HilbertianArgs),
+
     // ── Query (legacy, pre-LQL graph-file surface) ──────────────────
     #[command(next_help_heading = "Query")]
     /// Query a graph file for facts.
@@ -568,6 +572,7 @@ fn real_main() -> i32 {
         Commands::Build(args) => build_cmd::run(args),
         Commands::Compile(args) => compile_cmd::run(args),
         Commands::Canonicalize(args) => canonicalize_cmd::run(args),
+        Commands::Hilbertian(args) => hilbertian_cmd::run(args),
         Commands::Convert(args) => convert_cmd::run(args),
         Commands::Hf(args) => hf_cmd::run(args),
         Commands::Verify(args) => verify_cmd::run(args),

--- a/crates/larql-cli/src/main.rs
+++ b/crates/larql-cli/src/main.rs
@@ -151,6 +151,10 @@ enum Commands {
     /// Cross-backend numerical parity diff (CPU vs Metal vs reference).
     Parity(parity::ParityArgs),
 
+    #[command(next_help_heading = "Build")]
+    /// Compute canonical form metadata for a vindex (writes canonical_meta.json).
+    Canonicalize(canonicalize_cmd::CanonicalizeArgs),
+
     // ── Query (legacy, pre-LQL graph-file surface) ──────────────────
     #[command(next_help_heading = "Query")]
     /// Query a graph file for facts.
@@ -563,6 +567,7 @@ fn real_main() -> i32 {
         Commands::ExtractIndex(args) => extract_index_cmd::run(args),
         Commands::Build(args) => build_cmd::run(args),
         Commands::Compile(args) => compile_cmd::run(args),
+        Commands::Canonicalize(args) => canonicalize_cmd::run(args),
         Commands::Convert(args) => convert_cmd::run(args),
         Commands::Hf(args) => hf_cmd::run(args),
         Commands::Verify(args) => verify_cmd::run(args),

--- a/crates/larql-cli/src/main.rs
+++ b/crates/larql-cli/src/main.rs
@@ -159,6 +159,10 @@ enum Commands {
     /// Score per-head complex-linearity (Hilbertian residual); writes hilbertian_meta.json.
     Hilbertian(hilbertian_cmd::HilbertianArgs),
 
+    #[command(next_help_heading = "Build")]
+    /// Per-head entanglement entropy + Hilbertian residual (compressibility); writes entanglement_meta.json.
+    Entanglement(entanglement_cmd::EntanglementArgs),
+
     // ── Query (legacy, pre-LQL graph-file surface) ──────────────────
     #[command(next_help_heading = "Query")]
     /// Query a graph file for facts.
@@ -573,6 +577,7 @@ fn real_main() -> i32 {
         Commands::Compile(args) => compile_cmd::run(args),
         Commands::Canonicalize(args) => canonicalize_cmd::run(args),
         Commands::Hilbertian(args) => hilbertian_cmd::run(args),
+        Commands::Entanglement(args) => entanglement_cmd::run(args),
         Commands::Convert(args) => convert_cmd::run(args),
         Commands::Hf(args) => hf_cmd::run(args),
         Commands::Verify(args) => verify_cmd::run(args),

--- a/crates/larql-compute/src/cpu/ops/linalg.rs
+++ b/crates/larql-compute/src/cpu/ops/linalg.rs
@@ -128,6 +128,34 @@ pub fn ridge_decomposition_solve(
     Ok(delta_w_f64.mapv(|v| v as f32))
 }
 
+/// Back-substitution: solve L^T X = B where L is lower-triangular.
+/// L^T is upper-triangular, so we iterate from bottom row to top.
+/// Returns X of the same shape as B.
+pub fn back_solve_lt(l: &Array2<f64>, b: &Array2<f64>) -> Array2<f64> {
+    let n = l.shape()[0];
+    let m = b.shape()[1];
+    let mut x = Array2::<f64>::zeros((n, m));
+    // L^T[i,j] = L[j,i]. Upper-triangular back-substitution:
+    for i in (0..n).rev() {
+        for col in 0..m {
+            let mut sum = b[[i, col]];
+            for k in (i + 1)..n {
+                sum -= l[[k, i]] * x[[k, col]]; // L^T[i,k] = L[k,i]
+            }
+            x[[i, col]] = sum / l[[i, i]];
+        }
+    }
+    x
+}
+
+/// Compute L^{-T} explicitly: the d×d matrix such that L^{-T} @ L^T = I.
+/// Solves L^T X = I column by column via back_solve_lt.
+pub fn compute_l_inv_t(l: &Array2<f64>) -> Array2<f64> {
+    let n = l.shape()[0];
+    let identity = Array2::<f64>::eye(n);
+    back_solve_lt(l, &identity)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -287,6 +315,52 @@ mod tests {
             let nt: f32 = t_i.iter().map(|v| v * v).sum::<f32>().sqrt();
             let cos = dot / (nr * nt + 1e-12);
             assert!(cos > 0.95, "fact {i}: cos {cos}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod canonical_linalg_tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn lower_3x3() -> Array2<f64> {
+        // L = [[2,0,0],[1,3,0],[4,5,6]]
+        let mut l = Array2::<f64>::zeros((3, 3));
+        l[[0,0]] = 2.0; l[[1,0]] = 1.0; l[[1,1]] = 3.0;
+        l[[2,0]] = 4.0; l[[2,1]] = 5.0; l[[2,2]] = 6.0;
+        l
+    }
+
+    #[test]
+    fn back_solve_lt_recovers_rhs() {
+        // L^T z = b, check L^T (back_solve_lt(L, b)) == b
+        let l = lower_3x3();
+        let b = Array2::from_shape_vec((3, 2), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        let z = back_solve_lt(&l, &b);
+        // Verify L^T z == b
+        let lt = l.t().to_owned();
+        for col in 0..2 {
+            for row in 0..3 {
+                let dot: f64 = (0..3).map(|k| lt[[row, k]] * z[[k, col]]).sum();
+                assert!((dot - b[[row, col]]).abs() < 1e-10, "row={row} col={col} dot={dot} expected={}", b[[row,col]]);
+            }
+        }
+    }
+
+    #[test]
+    fn compute_l_inv_t_times_l_t_is_identity() {
+        let l = lower_3x3();
+        let l_inv_t = compute_l_inv_t(&l);
+        // l_inv_t @ l^T should == I
+        let lt = l.t().to_owned();
+        let product = l_inv_t.dot(&lt);
+        for i in 0..3 {
+            for j in 0..3 {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!((product[[i,j]] - expected).abs() < 1e-10,
+                    "product[{i},{j}]={} expected={expected}", product[[i,j]]);
+            }
         }
     }
 }

--- a/crates/larql-compute/src/lib.rs
+++ b/crates/larql-compute/src/lib.rs
@@ -129,7 +129,10 @@ pub mod prelude {
     };
 }
 
-pub use cpu::ops::linalg::{cholesky, cholesky_inverse, cholesky_solve, ridge_decomposition_solve};
+pub use cpu::ops::linalg::{
+    back_solve_lt, cholesky, cholesky_inverse, cholesky_solve,
+    compute_l_inv_t, ridge_decomposition_solve,
+};
 pub use cpu::ops::moe::{quantize_x_to_q8k, Q8KActivation};
 pub use cpu::ops::vector::{cosine, dot, norm};
 pub use cpu::CpuBackend;

--- a/crates/larql-hilbert/Cargo.toml
+++ b/crates/larql-hilbert/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "larql-hilbert"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ndarray = "0.16"
+num-complex = "0.4"

--- a/crates/larql-hilbert/ROADMAP.md
+++ b/crates/larql-hilbert/ROADMAP.md
@@ -1,0 +1,24 @@
+# Roadmap — larql-hilbert
+
+`larql-hilbert` is the Hilbert-space formalization crate: complex structures,
+the qubit / Bloch-sphere language models, constructive measurement, and the
+entanglement-entropy / compressibility meters. It is a pure-Rust leaf crate
+(deps: `ndarray` + `num-complex`; no BLAS) — see
+[ADR 0011](../../docs/adr/0011-qlm-quantum-language-models.md).
+
+The full phased plan, theory, and bibliography live in the QLM roadmap:
+
+➡️ **[`docs/QLM-ROADMAP.md`](../../docs/QLM-ROADMAP.md)** — Copyright © 2026
+Ian Douglas Lawrence Norman McLean, CC BY-SA 4.0.
+
+## At a glance
+
+- ✅ Phase 0–3: Hilbert foundation + Hilbertian residual (PR #137), single-qubit
+  Bloch LM (#138), constructive measurement + admissibility (#139), two-qubit
+  LM + Bell (#140).
+- 🔄 Phase 4: entanglement-entropy / compressibility meter
+  (`spectral_entropy` landed; `entanglement_entropy(matrix)` + pure-Rust
+  eigensolver per `docs/superpowers/plans/2026-06-11-matrix-entanglement-entropy.md`).
+- ⬜ Phase 5–6: GHZ/W (3+ qubits), superdense coding + quantum LQL.
+- 🔬 Phase 7–8: vindex compressibility analysis; `wasm32v1-none` minimal LM
+  (epic #132).

--- a/crates/larql-hilbert/src/admissibility.rs
+++ b/crates/larql-hilbert/src/admissibility.rs
@@ -1,0 +1,52 @@
+//! Bounded-extraction admissibility over the single-qubit LM (Rosko 2025:
+//! admissible measurement = finite extraction ⊆ Σ⁰₁ ∪ Π⁰₂). The arithmetical
+//! hierarchy appears here as the quantifier shape of *bounded* procedures.
+
+use crate::qlm::SingleQubitLM;
+
+/// Arithmetical-hierarchy fragment of a bounded extraction query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArithFragment {
+    /// Bounded / decidable (e.g. "is this finite sequence realizable?").
+    Delta0,
+    /// ∃ a terminating witness (e.g. "does a realizable continuation satisfying
+    /// P exist within bound k?").
+    Sigma01,
+    /// ∀∃ uniform stability (e.g. "for every realizable prefix is there a valid
+    /// next token?").
+    Pi02,
+}
+
+/// Δ₀ decision: is `tokens` a physically realizable sequence (finite score)?
+/// An impossible token makes the score −∞.
+pub fn is_realizable(lm: &SingleQubitLM, tokens: &[usize]) -> bool {
+    lm.score(tokens).is_finite()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::qubit::Qubit;
+    use crate::unitary::identity;
+
+    /// gates = [I, I], init = |0⟩ → only all-zero sequences are realizable
+    /// (after observing 0 the state stays |0⟩; a subsequent 1 has probability 0).
+    fn repeat_lm() -> SingleQubitLM {
+        SingleQubitLM { gates: [identity(), identity()], init: Qubit::ket0() }
+    }
+
+    #[test]
+    fn realizable_distinguishes_possible_from_impossible() {
+        let lm = repeat_lm();
+        assert!(is_realizable(&lm, &[0, 0, 0]));
+        assert!(!is_realizable(&lm, &[0, 1]));
+        assert!(is_realizable(&lm, &[])); // empty sequence: score 0, finite
+    }
+
+    #[test]
+    fn arith_fragments_are_distinct() {
+        assert_ne!(ArithFragment::Delta0, ArithFragment::Sigma01);
+        assert_ne!(ArithFragment::Sigma01, ArithFragment::Pi02);
+        assert_ne!(ArithFragment::Delta0, ArithFragment::Pi02);
+    }
+}

--- a/crates/larql-hilbert/src/admissibility.rs
+++ b/crates/larql-hilbert/src/admissibility.rs
@@ -23,6 +23,32 @@ pub fn is_realizable(lm: &SingleQubitLM, tokens: &[usize]) -> bool {
     lm.score(tokens).is_finite()
 }
 
+/// Σ⁰₁ bounded witness search: is there a realizable continuation of `prefix`
+/// — appending between 0 and `max_len` tokens from the alphabet `{0, 1}` — for
+/// which `pred` holds? Returns the first such full sequence (a constructive
+/// witness), or `None` if none exists within the bound. The bound guarantees
+/// termination, i.e. admissibility. `max_len` should be modest (it is an
+/// admissible finite bound, not an unbounded search).
+pub fn exists_continuation<F: Fn(&[usize]) -> bool>(
+    lm: &SingleQubitLM,
+    prefix: &[usize],
+    max_len: usize,
+    pred: F,
+) -> Option<Vec<usize>> {
+    for len in 0..=max_len {
+        for code in 0..(1usize << len) {
+            let mut seq = prefix.to_vec();
+            for bit in 0..len {
+                seq.push((code >> bit) & 1);
+            }
+            if is_realizable(lm, &seq) && pred(&seq) {
+                return Some(seq);
+            }
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -48,5 +74,29 @@ mod tests {
         assert_ne!(ArithFragment::Delta0, ArithFragment::Sigma01);
         assert_ne!(ArithFragment::Sigma01, ArithFragment::Pi02);
         assert_ne!(ArithFragment::Delta0, ArithFragment::Pi02);
+    }
+
+    #[test]
+    fn sigma01_finds_a_witness_within_bound() {
+        let lm = repeat_lm();
+        // ∃ a realizable length-2 continuation of the empty prefix? Yes: [0, 0].
+        let w = exists_continuation(&lm, &[], 2, |s| s.len() == 2);
+        assert_eq!(w, Some(vec![0, 0]));
+    }
+
+    #[test]
+    fn sigma01_returns_none_when_no_witness_exists_in_bound() {
+        let lm = repeat_lm();
+        // No realizable sequence ever contains token 1 → no witness within bound.
+        let w = exists_continuation(&lm, &[], 4, |s| s.contains(&1));
+        assert!(w.is_none());
+    }
+
+    #[test]
+    fn sigma01_respects_the_prefix() {
+        let lm = repeat_lm();
+        // From prefix [0], the empty continuation [0] is already realizable.
+        let w = exists_continuation(&lm, &[0], 0, |_| true);
+        assert_eq!(w, Some(vec![0]));
     }
 }

--- a/crates/larql-hilbert/src/admissibility.rs
+++ b/crates/larql-hilbert/src/admissibility.rs
@@ -49,6 +49,36 @@ pub fn exists_continuation<F: Fn(&[usize]) -> bool>(
     None
 }
 
+/// Π⁰₂ uniform stability: for every realizable token sequence of length ≤
+/// `max_len`, does there exist a next token keeping it realizable? Returns
+/// `false` if any realizable prefix dead-ends within the bound.
+///
+/// For a single-qubit LM this always holds (unitary evolution followed by Born
+/// collapse can never reach a state where both outcomes have probability 0), so
+/// this verifies that structural stability property within the bound.
+pub fn uniformly_stable(lm: &SingleQubitLM, max_len: usize) -> bool {
+    for len in 0..=max_len {
+        for code in 0..(1usize << len) {
+            let mut seq = Vec::with_capacity(len);
+            for bit in 0..len {
+                seq.push((code >> bit) & 1);
+            }
+            if !is_realizable(lm, &seq) {
+                continue;
+            }
+            let has_next = (0..2).any(|t| {
+                let mut ext = seq.clone();
+                ext.push(t);
+                is_realizable(lm, &ext)
+            });
+            if !has_next {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -98,5 +128,24 @@ mod tests {
         // From prefix [0], the empty continuation [0] is already realizable.
         let w = exists_continuation(&lm, &[0], 0, |_| true);
         assert_eq!(w, Some(vec![0]));
+    }
+
+    #[test]
+    fn pi02_uniform_stability_holds_for_the_repeat_lm() {
+        let lm = repeat_lm();
+        // Every realizable prefix [0]^k extends by another 0 → always stable.
+        assert!(uniformly_stable(&lm, 4));
+    }
+
+    #[test]
+    fn pi02_uniform_stability_holds_for_a_nontrivial_lm() {
+        use crate::unitary::{hadamard, pauli_x};
+        // init |+⟩, gates [X, I]: realizable sequences are [0,1,1,…] and
+        // [1,1,1,…]; every realizable prefix still has a valid next token (1).
+        let lm = SingleQubitLM {
+            gates: [pauli_x(), identity()],
+            init: Qubit::ket0().apply(&hadamard()),
+        };
+        assert!(uniformly_stable(&lm, 4));
     }
 }

--- a/crates/larql-hilbert/src/admissibility.rs
+++ b/crates/larql-hilbert/src/admissibility.rs
@@ -35,6 +35,7 @@ pub fn exists_continuation<F: Fn(&[usize]) -> bool>(
     max_len: usize,
     pred: F,
 ) -> Option<Vec<usize>> {
+    debug_assert!(max_len < 63, "max_len must be < 63 (admissible finite bound)");
     for len in 0..=max_len {
         for code in 0..(1usize << len) {
             let mut seq = prefix.to_vec();
@@ -57,6 +58,7 @@ pub fn exists_continuation<F: Fn(&[usize]) -> bool>(
 /// collapse can never reach a state where both outcomes have probability 0), so
 /// this verifies that structural stability property within the bound.
 pub fn uniformly_stable(lm: &SingleQubitLM, max_len: usize) -> bool {
+    debug_assert!(max_len < 63, "max_len must be < 63 (admissible finite bound)");
     for len in 0..=max_len {
         for code in 0..(1usize << len) {
             let mut seq = Vec::with_capacity(len);

--- a/crates/larql-hilbert/src/admissibility.rs
+++ b/crates/larql-hilbert/src/admissibility.rs
@@ -35,7 +35,10 @@ pub fn exists_continuation<F: Fn(&[usize]) -> bool>(
     max_len: usize,
     pred: F,
 ) -> Option<Vec<usize>> {
-    debug_assert!(max_len < 63, "max_len must be < 63 (admissible finite bound)");
+    debug_assert!(
+        (max_len as u32) < usize::BITS,
+        "max_len must be < pointer width (the 1<<len enumeration must fit usize)"
+    );
     for len in 0..=max_len {
         for code in 0..(1usize << len) {
             let mut seq = prefix.to_vec();
@@ -58,7 +61,10 @@ pub fn exists_continuation<F: Fn(&[usize]) -> bool>(
 /// collapse can never reach a state where both outcomes have probability 0), so
 /// this verifies that structural stability property within the bound.
 pub fn uniformly_stable(lm: &SingleQubitLM, max_len: usize) -> bool {
-    debug_assert!(max_len < 63, "max_len must be < 63 (admissible finite bound)");
+    debug_assert!(
+        (max_len as u32) < usize::BITS,
+        "max_len must be < pointer width (the 1<<len enumeration must fit usize)"
+    );
     for len in 0..=max_len {
         for code in 0..(1usize << len) {
             let mut seq = Vec::with_capacity(len);

--- a/crates/larql-hilbert/src/born.rs
+++ b/crates/larql-hilbert/src/born.rs
@@ -1,0 +1,37 @@
+//! Born-rule measurement in the computational basis.
+
+use crate::qubit::Qubit;
+
+/// Computational-basis measurement probabilities [P(0), P(1)] = [|α|², |β|²]
+/// of the normalized state. Always sums to 1.
+pub fn measure_probs(q: &Qubit) -> [f64; 2] {
+    let qn = q.normalized();
+    [qn.amp[0].norm_sqr(), qn.amp[1].norm_sqr()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unitary::hadamard;
+
+    #[test]
+    fn ket0_measures_zero_with_certainty() {
+        let p = measure_probs(&Qubit::ket0());
+        assert!((p[0] - 1.0).abs() < 1e-12);
+        assert!(p[1].abs() < 1e-12);
+    }
+
+    #[test]
+    fn hadamard_zero_is_fair_coin() {
+        let p = measure_probs(&Qubit::ket0().apply(&hadamard()));
+        assert!((p[0] - 0.5).abs() < 1e-12);
+        assert!((p[1] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn probabilities_sum_to_one() {
+        let q = Qubit::from_bloch(0.9, 1.7);
+        let p = measure_probs(&q);
+        assert!((p[0] + p[1] - 1.0).abs() < 1e-12);
+    }
+}

--- a/crates/larql-hilbert/src/complex_structure.rs
+++ b/crates/larql-hilbert/src/complex_structure.rs
@@ -43,6 +43,36 @@ pub fn antilinear_fraction(m: &Array2<f64>, j: &Array2<f64>) -> f64 {
     if den == 0.0 { 0.0 } else { frob_norm(&antilinear_part(m, j)) / den }
 }
 
+/// Realify a complex m×m operator given as (real, imag) parts (A, B):
+/// returns the 2m×2m real matrix [[A, −B], [B, A]] (split-half convention),
+/// which commutes with `split_half_j(2m)` and represents A + iB.
+pub fn realify(a: &Array2<f64>, b: &Array2<f64>) -> Array2<f64> {
+    let m = a.shape()[0];
+    let n = 2 * m;
+    let mut out = Array2::<f64>::zeros((n, n));
+    for i in 0..m {
+        for j in 0..m {
+            out[[i, j]] = a[[i, j]];
+            out[[i, m + j]] = -b[[i, j]];
+            out[[m + i, j]] = b[[i, j]];
+            out[[m + i, m + j]] = a[[i, j]];
+        }
+    }
+    out
+}
+
+/// Read the complex (real, imag) parts (A, B) out of the top-left and
+/// bottom-left blocks of a 2m×2m real matrix. For a matrix produced by
+/// `realify` (i.e. one that commutes with J), this recovers the original
+/// (A, B). For a general matrix it returns the (A, B) of its ℂ-linear part's
+/// canonical block representative.
+pub fn complex_parts(m: &Array2<f64>) -> (Array2<f64>, Array2<f64>) {
+    let half = m.shape()[0] / 2;
+    let a = m.slice(ndarray::s![0..half, 0..half]).to_owned();
+    let b = m.slice(ndarray::s![half.., 0..half]).to_owned();
+    (a, b)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -95,5 +125,37 @@ mod tests {
         let z = Array2::<f64>::zeros((4, 4));
         assert_eq!(commutator_residual(&z, &j), 0.0);
         assert_eq!(antilinear_fraction(&z, &j), 0.0);
+    }
+
+    #[test]
+    fn realify_builds_block_form() {
+        // realify(A, B) = [[A, -B], [B, A]].
+        let a = array![[1.0, 2.0], [3.0, 4.0]];
+        let b = array![[5.0, 6.0], [7.0, 8.0]];
+        let m = realify(&a, &b);
+        assert_eq!(m.shape(), [4, 4]);
+        assert_eq!(m[[0, 0]], 1.0);
+        assert_eq!(m[[0, 2]], -5.0); // -B
+        assert_eq!(m[[2, 0]], 5.0);  //  B
+        assert_eq!(m[[2, 2]], 1.0);  //  A
+    }
+
+    #[test]
+    fn complex_parts_inverts_realify() {
+        let a = array![[1.0, 2.0], [3.0, 4.0]];
+        let b = array![[5.0, 6.0], [7.0, 8.0]];
+        let m = realify(&a, &b);
+        let (a2, b2) = complex_parts(&m);
+        assert_eq!(a2, a);
+        assert_eq!(b2, b);
+    }
+
+    #[test]
+    fn realified_matrix_commutes_with_j() {
+        let a = array![[1.0, 2.0], [3.0, 4.0]];
+        let b = array![[5.0, 6.0], [7.0, 8.0]];
+        let m = realify(&a, &b);
+        let j = split_half_j(4);
+        assert!(commutator_residual(&m, &j) < 1e-12);
     }
 }

--- a/crates/larql-hilbert/src/complex_structure.rs
+++ b/crates/larql-hilbert/src/complex_structure.rs
@@ -1,0 +1,99 @@
+//! Real-matrix complex structures and the antilinear-fraction reformulation of
+//! the `larql hilbertian` residual.
+
+use ndarray::Array2;
+
+/// Split-half complex structure J on R^n (n even): J e_i = e_{i+half},
+/// J e_{i+half} = −e_i, so J·J = −I. Panics if n is odd.
+pub fn split_half_j(n: usize) -> Array2<f64> {
+    assert!(n.is_multiple_of(2), "complex structure requires even dimension, got {n}");
+    let half = n / 2;
+    let mut j = Array2::<f64>::zeros((n, n));
+    for i in 0..half {
+        j[[half + i, i]] = 1.0;
+        j[[i, half + i]] = -1.0;
+    }
+    j
+}
+
+fn frob_norm(a: &Array2<f64>) -> f64 {
+    a.iter().map(|&x| x * x).sum::<f64>().sqrt()
+}
+
+/// Relative commutator residual ‖M J − J M‖_F / ‖M‖_F ∈ [0, 2].
+/// Returns 0.0 for the zero matrix.
+pub fn commutator_residual(m: &Array2<f64>, j: &Array2<f64>) -> f64 {
+    let comm = &m.dot(j) - &j.dot(m);
+    let den = frob_norm(m);
+    if den == 0.0 { 0.0 } else { frob_norm(&comm) / den }
+}
+
+/// The ℂ-antilinear (conjugate-linear) part of M under J: (M + J M J) / 2.
+/// This part anticommutes with J; M − this commutes with J (is ℂ-linear).
+pub fn antilinear_part(m: &Array2<f64>, j: &Array2<f64>) -> Array2<f64> {
+    let jmj = j.dot(m).dot(j);
+    (m + &jmj) * 0.5
+}
+
+/// Fraction of M that is ℂ-antilinear under J: ‖P_antilin(M)‖_F / ‖M‖_F.
+/// Returns 0.0 for the zero matrix. By construction this equals exactly half
+/// the commutator residual (see `equivalence_theorem` test).
+pub fn antilinear_fraction(m: &Array2<f64>, j: &Array2<f64>) -> f64 {
+    let den = frob_norm(m);
+    if den == 0.0 { 0.0 } else { frob_norm(&antilinear_part(m, j)) / den }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn j_squares_to_negative_identity() {
+        let j = split_half_j(4);
+        let jj = j.dot(&j);
+        let neg_i = -Array2::<f64>::eye(4);
+        for i in 0..4 {
+            for k in 0..4 {
+                assert!((jj[[i, k]] - neg_i[[i, k]]).abs() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn equivalence_theorem_residual_is_twice_antilinear_fraction() {
+        // commutator_residual(M, J) = 2 · antilinear_fraction(M) for any M.
+        let j = split_half_j(4);
+        let m = array![
+            [1.0, 2.0, 3.0, 4.0],
+            [0.5, 1.5, 2.5, 3.5],
+            [9.0, 8.0, 7.0, 6.0],
+            [0.1, 0.2, 0.3, 0.4],
+        ];
+        let r = commutator_residual(&m, &j);
+        let af = antilinear_fraction(&m, &j);
+        assert!((r - 2.0 * af).abs() < 1e-12, "r={r} 2*af={}", 2.0 * af);
+    }
+
+    #[test]
+    fn complex_linear_matrix_has_zero_antilinear_fraction() {
+        // M = [[A, -B], [B, A]] commutes with split-half J → antilinear fraction 0.
+        let a = array![[1.0, 2.0], [3.0, 4.0]];
+        let b = array![[5.0, 6.0], [7.0, 8.0]];
+        let mut m = Array2::<f64>::zeros((4, 4));
+        m.slice_mut(ndarray::s![0..2, 0..2]).assign(&a);
+        m.slice_mut(ndarray::s![0..2, 2..4]).assign(&(-&b));
+        m.slice_mut(ndarray::s![2..4, 0..2]).assign(&b);
+        m.slice_mut(ndarray::s![2..4, 2..4]).assign(&a);
+        let j = split_half_j(4);
+        assert!(antilinear_fraction(&m, &j) < 1e-12);
+    }
+
+    #[test]
+    fn zero_matrix_is_safe() {
+        let j = split_half_j(4);
+        let z = Array2::<f64>::zeros((4, 4));
+        assert_eq!(commutator_residual(&z, &j), 0.0);
+        assert_eq!(antilinear_fraction(&z, &j), 0.0);
+    }
+}

--- a/crates/larql-hilbert/src/eig.rs
+++ b/crates/larql-hilbert/src/eig.rs
@@ -1,0 +1,105 @@
+//! Pure-Rust symmetric eigenvalue solver (cyclic Jacobi) — no BLAS/LAPACK.
+//! Used to obtain the squared-singular spectrum for entanglement entropy.
+
+use ndarray::Array2;
+
+/// Eigenvalues of a real symmetric matrix via the cyclic Jacobi method.
+/// Returns the `n` eigenvalues (unordered). The input is assumed symmetric;
+/// only its symmetric part is meaningfully used.
+pub fn symmetric_eigenvalues(a: &Array2<f64>) -> Vec<f64> {
+    let n = a.shape()[0];
+    let mut m = a.clone();
+
+    for _sweep in 0..100 {
+        // Off-diagonal Frobenius norm; stop when negligible.
+        let mut off = 0.0;
+        for i in 0..n {
+            for j in (i + 1)..n {
+                off += m[[i, j]] * m[[i, j]];
+            }
+        }
+        if off.sqrt() < 1e-14 {
+            break;
+        }
+
+        for p in 0..n {
+            for q in (p + 1)..n {
+                let apq = m[[p, q]];
+                if apq.abs() < 1e-300 {
+                    continue;
+                }
+                let app = m[[p, p]];
+                let aqq = m[[q, q]];
+                // Stable Jacobi angle (Golub & Van Loan, sym.schur2).
+                let tau = (aqq - app) / (2.0 * apq);
+                let t = if tau >= 0.0 {
+                    1.0 / (tau + (1.0 + tau * tau).sqrt())
+                } else {
+                    -1.0 / (-tau + (1.0 + tau * tau).sqrt())
+                };
+                let c = 1.0 / (1.0 + t * t).sqrt();
+                let s = t * c;
+
+                // A <- Jᵀ A J for the (p,q) rotation: rotate columns then rows.
+                #[allow(clippy::needless_range_loop)]
+                for k in 0..n {
+                    let akp = m[[k, p]];
+                    let akq = m[[k, q]];
+                    m[[k, p]] = c * akp - s * akq;
+                    m[[k, q]] = s * akp + c * akq;
+                }
+                #[allow(clippy::needless_range_loop)]
+                for k in 0..n {
+                    let apk = m[[p, k]];
+                    let aqk = m[[q, k]];
+                    m[[p, k]] = c * apk - s * aqk;
+                    m[[q, k]] = s * apk + c * aqk;
+                }
+            }
+        }
+    }
+
+    (0..n).map(|i| m[[i, i]]).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    fn sorted(mut v: Vec<f64>) -> Vec<f64> {
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        v
+    }
+
+    fn close(a: &[f64], b: &[f64]) -> bool {
+        a.len() == b.len() && a.iter().zip(b).all(|(x, y)| (x - y).abs() < 1e-9)
+    }
+
+    #[test]
+    fn diagonal_matrix_returns_its_diagonal() {
+        let a = Array2::from_diag(&array![3.0, 1.0, 2.0]);
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 2.0, 3.0]));
+    }
+
+    #[test]
+    fn identity_has_all_unit_eigenvalues() {
+        let a = Array2::<f64>::eye(3);
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 1.0, 1.0]));
+    }
+
+    #[test]
+    fn two_by_two_symmetric_eigenvalues() {
+        // [[2,1],[1,2]] has eigenvalues 1 and 3.
+        let a = array![[2.0, 1.0], [1.0, 2.0]];
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 3.0]));
+    }
+
+    #[test]
+    fn larger_spd_matrix_eigenvalues_sum_to_trace() {
+        let a = array![[4.0, 1.0, 0.0], [1.0, 3.0, 1.0], [0.0, 1.0, 2.0]];
+        let eigs = symmetric_eigenvalues(&a);
+        let sum: f64 = eigs.iter().sum();
+        assert!((sum - 9.0).abs() < 1e-9, "trace should be 9, got {sum}");
+    }
+}

--- a/crates/larql-hilbert/src/entropy.rs
+++ b/crates/larql-hilbert/src/entropy.rs
@@ -4,6 +4,10 @@
 //! (fully compressible), log2(d) = flat spectrum (incompressible). One ebit
 //! (spectrum [½, ½]) is the superdense-coding unit.
 
+use ndarray::Array2;
+
+use crate::eig::symmetric_eigenvalues;
+
 /// Spectral entropy of a non-negative weight spectrum, in bits (ebits):
 /// `S = −Σ pᵢ log₂ pᵢ` with `pᵢ = wᵢ / Σⱼ wⱼ`. Zero weights are skipped; an
 /// empty or all-zero spectrum returns `0.0` (no NaN). For the entanglement
@@ -23,9 +27,31 @@ pub fn spectral_entropy(weights: &[f64]) -> f64 {
         .sum()
 }
 
+/// Entanglement entropy (in ebits) of a real matrix viewed as a bipartite
+/// state: the spectral entropy of its squared singular values. `0` for a
+/// rank-1 matrix, `log₂(min(rows, cols))` for a flat spectrum.
+///
+/// Computed from the eigenvalues of the smaller Gram matrix (`M Mᵀ` if
+/// `rows ≤ cols`, else `Mᵀ M`) — these are the squared singular values.
+/// Tiny negative eigenvalues from round-off are clamped to 0.
+pub fn entanglement_entropy(m: &Array2<f64>) -> f64 {
+    let (rows, cols) = (m.shape()[0], m.shape()[1]);
+    let gram = if rows <= cols {
+        m.dot(&m.t())
+    } else {
+        m.t().dot(m)
+    };
+    let weights: Vec<f64> = symmetric_eigenvalues(&gram)
+        .into_iter()
+        .map(|e| e.max(0.0))
+        .collect();
+    spectral_entropy(&weights)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ndarray::{array, Array2};
 
     #[test]
     fn rank_one_spectrum_has_zero_entropy() {
@@ -51,5 +77,26 @@ mod tests {
     fn empty_or_all_zero_is_zero() {
         assert_eq!(spectral_entropy(&[]), 0.0);
         assert_eq!(spectral_entropy(&[0.0, 0.0]), 0.0);
+    }
+
+    #[test]
+    fn rank_one_matrix_has_zero_entanglement() {
+        // [[1,2],[2,4]] = [1,2]ᵀ·[1,2], rank 1 → one nonzero singular value → 0.
+        let m = array![[1.0, 2.0], [2.0, 4.0]];
+        assert!(entanglement_entropy(&m).abs() < 1e-9);
+    }
+
+    #[test]
+    fn identity_2x2_is_one_ebit() {
+        // I₂ has singular values [1,1] → squared [1,1] → 1 ebit.
+        let m = Array2::<f64>::eye(2);
+        assert!((entanglement_entropy(&m) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn rectangular_orthonormal_rows_is_one_ebit() {
+        // 2×3 with two orthonormal rows → M Mᵀ = I₂ → 1 ebit.
+        let m = array![[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        assert!((entanglement_entropy(&m) - 1.0).abs() < 1e-9);
     }
 }

--- a/crates/larql-hilbert/src/entropy.rs
+++ b/crates/larql-hilbert/src/entropy.rs
@@ -1,0 +1,55 @@
+//! Spectral (von Neumann) entropy — the quantum-compressibility quantity, in
+//! ebits (bits). For a matrix viewed as a bipartite state the entanglement
+//! entropy is the spectral entropy of its squared singular values: 0 = rank-1
+//! (fully compressible), log2(d) = flat spectrum (incompressible). One ebit
+//! (spectrum [½, ½]) is the superdense-coding unit.
+
+/// Spectral entropy of a non-negative weight spectrum, in bits (ebits):
+/// `S = −Σ pᵢ log₂ pᵢ` with `pᵢ = wᵢ / Σⱼ wⱼ`. Zero weights are skipped; an
+/// empty or all-zero spectrum returns `0.0` (no NaN). For the entanglement
+/// entropy of a matrix, pass its squared singular values (the Schmidt weights).
+pub fn spectral_entropy(weights: &[f64]) -> f64 {
+    let total: f64 = weights.iter().sum();
+    if total <= 0.0 {
+        return 0.0;
+    }
+    let mut s = 0.0;
+    for &w in weights {
+        if w > 0.0 {
+            let p = w / total;
+            s -= p * p.log2();
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rank_one_spectrum_has_zero_entropy() {
+        assert!(spectral_entropy(&[7.0, 0.0, 0.0]).abs() < 1e-12);
+    }
+
+    #[test]
+    fn two_equal_weights_is_one_ebit() {
+        assert!((spectral_entropy(&[3.0, 3.0]) - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn uniform_spectrum_is_log2_of_dimension() {
+        assert!((spectral_entropy(&[1.0, 1.0, 1.0, 1.0]) - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn zero_weights_ignored_no_nan() {
+        assert!((spectral_entropy(&[1.0, 1.0, 0.0, 0.0]) - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn empty_or_all_zero_is_zero() {
+        assert_eq!(spectral_entropy(&[]), 0.0);
+        assert_eq!(spectral_entropy(&[0.0, 0.0]), 0.0);
+    }
+}

--- a/crates/larql-hilbert/src/entropy.rs
+++ b/crates/larql-hilbert/src/entropy.rs
@@ -3,6 +3,12 @@
 //! entropy is the spectral entropy of its squared singular values: 0 = rank-1
 //! (fully compressible), log2(d) = flat spectrum (incompressible). One ebit
 //! (spectrum [½, ½]) is the superdense-coding unit.
+//!
+//! `entanglement_entropy(M)` is the quantum-compressibility meter: low entropy
+//! ⇒ few Schmidt terms ⇒ the matrix compresses to a small tensor-network bond
+//! dimension (`χ ≈ 2^S`); a flat spectrum is incompressible. Combined with the
+//! Hilbertian residual (complex/coherence structure), it quantifies the
+//! classical-vs-quantum compressibility gap of a vindex, denominated in ebits.
 
 use ndarray::Array2;
 

--- a/crates/larql-hilbert/src/entropy.rs
+++ b/crates/larql-hilbert/src/entropy.rs
@@ -13,14 +13,14 @@ pub fn spectral_entropy(weights: &[f64]) -> f64 {
     if total <= 0.0 {
         return 0.0;
     }
-    let mut s = 0.0;
-    for &w in weights {
-        if w > 0.0 {
+    weights
+        .iter()
+        .filter(|&&w| w > 0.0)
+        .map(|&w| {
             let p = w / total;
-            s -= p * p.log2();
-        }
-    }
-    s
+            -p * p.log2()
+        })
+        .sum()
 }
 
 #[cfg(test)]

--- a/crates/larql-hilbert/src/gate2.rs
+++ b/crates/larql-hilbert/src/gate2.rs
@@ -1,0 +1,122 @@
+//! Two-qubit gates as 4×4 complex matrices, with hand-written algebra and the
+//! Kronecker lift of single-qubit gates.
+
+use num_complex::Complex64;
+
+use crate::two_qubit::TwoQubit;
+use crate::unitary::Gate;
+
+#[inline]
+fn c(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+/// A two-qubit gate: a 4×4 complex matrix, row-major.
+pub type Gate4 = [[Complex64; 4]; 4];
+
+/// Multiply two 4×4 gates: A·B.
+pub fn mat_mul4(a: &Gate4, b: &Gate4) -> Gate4 {
+    let mut out = [[c(0.0, 0.0); 4]; 4];
+    for (i, row) in out.iter_mut().enumerate() {
+        for (j, cell) in row.iter_mut().enumerate() {
+            let mut s = c(0.0, 0.0);
+            for k in 0..4 {
+                s += a[i][k] * b[k][j];
+            }
+            *cell = s;
+        }
+    }
+    out
+}
+
+/// Conjugate transpose (dagger) of a 4×4 gate.
+pub fn dagger4(a: &Gate4) -> Gate4 {
+    let mut out = [[c(0.0, 0.0); 4]; 4];
+    for (i, row) in out.iter_mut().enumerate() {
+        for (j, cell) in row.iter_mut().enumerate() {
+            *cell = a[j][i].conj();
+        }
+    }
+    out
+}
+
+/// Whether a 4×4 gate is unitary: U U† ≈ I within 1e-10.
+pub fn is_unitary4(a: &Gate4) -> bool {
+    let p = mat_mul4(a, &dagger4(a));
+    for i in 0..4 {
+        for j in 0..4 {
+            let expected = if i == j { c(1.0, 0.0) } else { c(0.0, 0.0) };
+            if (p[i][j] - expected).norm() > 1e-10 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Apply a 4×4 gate to a two-qubit state.
+pub fn apply4(g: &Gate4, s: &TwoQubit) -> TwoQubit {
+    let mut amp = [c(0.0, 0.0); 4];
+    for (i, slot) in amp.iter_mut().enumerate() {
+        let mut acc = c(0.0, 0.0);
+        for j in 0..4 {
+            acc += g[i][j] * s.amp[j];
+        }
+        *slot = acc;
+    }
+    TwoQubit { amp }
+}
+
+/// Kronecker product of two single-qubit gates: (A⊗B) acting on |q0 q1⟩,
+/// with A on qubit 0 and B on qubit 1.
+pub fn tensor_gate(a: &Gate, b: &Gate) -> Gate4 {
+    let mut out = [[c(0.0, 0.0); 4]; 4];
+    for i0 in 0..2 {
+        for i1 in 0..2 {
+            for j0 in 0..2 {
+                for j1 in 0..2 {
+                    out[2 * i0 + i1][2 * j0 + j1] = a[i0][j0] * b[i1][j1];
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unitary::{hadamard, identity, pauli_x};
+
+    #[test]
+    fn tensor_gate_identity_is_4x4_identity() {
+        let ii = tensor_gate(&identity(), &identity());
+        assert!(is_unitary4(&ii));
+        let applied = apply4(&ii, &TwoQubit::ket(1, 0));
+        assert_eq!(applied, TwoQubit::ket(1, 0));
+    }
+
+    #[test]
+    fn tensor_gate_x_on_qubit0_flips_first_index() {
+        // (X⊗I)|00⟩ = |10⟩
+        let xi = tensor_gate(&pauli_x(), &identity());
+        let r = apply4(&xi, &TwoQubit::ket(0, 0));
+        assert_eq!(r, TwoQubit::ket(1, 0));
+    }
+
+    #[test]
+    fn tensor_gate_h_on_qubit0_superposes_first_index() {
+        // (H⊗I)|00⟩ = (|00⟩ + |10⟩)/√2
+        let hi = tensor_gate(&hadamard(), &identity());
+        let r = apply4(&hi, &TwoQubit::ket(0, 0));
+        let s = 1.0 / std::f64::consts::SQRT_2;
+        assert!((r.amp[0].re - s).abs() < 1e-12);
+        assert!((r.amp[2].re - s).abs() < 1e-12);
+        assert!(r.amp[1].norm() < 1e-12 && r.amp[3].norm() < 1e-12);
+    }
+
+    #[test]
+    fn tensor_gate_is_unitary() {
+        assert!(is_unitary4(&tensor_gate(&hadamard(), &pauli_x())));
+    }
+}

--- a/crates/larql-hilbert/src/gate2.rs
+++ b/crates/larql-hilbert/src/gate2.rs
@@ -43,10 +43,10 @@ pub fn dagger4(a: &Gate4) -> Gate4 {
 /// Whether a 4×4 gate is unitary: U U† ≈ I within 1e-10.
 pub fn is_unitary4(a: &Gate4) -> bool {
     let p = mat_mul4(a, &dagger4(a));
-    for i in 0..4 {
-        for j in 0..4 {
+    for (i, row) in p.iter().enumerate() {
+        for (j, &val) in row.iter().enumerate() {
             let expected = if i == j { c(1.0, 0.0) } else { c(0.0, 0.0) };
-            if (p[i][j] - expected).norm() > 1e-10 {
+            if (val - expected).norm() > 1e-10 {
                 return false;
             }
         }
@@ -57,10 +57,10 @@ pub fn is_unitary4(a: &Gate4) -> bool {
 /// Apply a 4×4 gate to a two-qubit state.
 pub fn apply4(g: &Gate4, s: &TwoQubit) -> TwoQubit {
     let mut amp = [c(0.0, 0.0); 4];
-    for (i, slot) in amp.iter_mut().enumerate() {
+    for (slot, row) in amp.iter_mut().zip(g.iter()) {
         let mut acc = c(0.0, 0.0);
-        for j in 0..4 {
-            acc += g[i][j] * s.amp[j];
+        for (gij, sj) in row.iter().zip(s.amp.iter()) {
+            acc += gij * sj;
         }
         *slot = acc;
     }

--- a/crates/larql-hilbert/src/gate2.rs
+++ b/crates/larql-hilbert/src/gate2.rs
@@ -83,10 +83,31 @@ pub fn tensor_gate(a: &Gate, b: &Gate) -> Gate4 {
     out
 }
 
+/// CNOT with control = qubit 0, target = qubit 1:
+/// |00⟩→|00⟩, |01⟩→|01⟩, |10⟩→|11⟩, |11⟩→|10⟩.
+pub fn cnot() -> Gate4 {
+    [
+        [c(1.0, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(0.0, 0.0)],
+        [c(0.0, 0.0), c(1.0, 0.0), c(0.0, 0.0), c(0.0, 0.0)],
+        [c(0.0, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(1.0, 0.0)],
+        [c(0.0, 0.0), c(0.0, 0.0), c(1.0, 0.0), c(0.0, 0.0)],
+    ]
+}
+
+/// The Bell state Φ⁺ = (|00⟩ + |11⟩)/√2 = CNOT·(H⊗I)·|00⟩. The canonical
+/// entangling operation: its output does not factor as |a⟩⊗|b⟩.
+pub fn bell() -> TwoQubit {
+    use crate::unitary::{hadamard, identity};
+    let h_i = tensor_gate(&hadamard(), &identity());
+    let prepared = apply4(&h_i, &TwoQubit::ket(0, 0));
+    apply4(&cnot(), &prepared)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::unitary::{hadamard, identity, pauli_x};
+    use crate::two_qubit::is_product;
 
     #[test]
     fn tensor_gate_identity_is_4x4_identity() {
@@ -118,5 +139,29 @@ mod tests {
     #[test]
     fn tensor_gate_is_unitary() {
         assert!(is_unitary4(&tensor_gate(&hadamard(), &pauli_x())));
+    }
+
+    #[test]
+    fn cnot_is_unitary_and_flips_target_when_control_set() {
+        assert!(is_unitary4(&cnot()));
+        // |10⟩ → |11⟩ (control=1 flips target)
+        assert_eq!(apply4(&cnot(), &TwoQubit::ket(1, 0)), TwoQubit::ket(1, 1));
+        // |00⟩ → |00⟩ (control=0 leaves target)
+        assert_eq!(apply4(&cnot(), &TwoQubit::ket(0, 0)), TwoQubit::ket(0, 0));
+    }
+
+    #[test]
+    fn bell_is_the_phi_plus_state() {
+        let b = bell();
+        let s = 1.0 / std::f64::consts::SQRT_2;
+        assert!((b.amp[0].re - s).abs() < 1e-12);
+        assert!((b.amp[3].re - s).abs() < 1e-12);
+        assert!(b.amp[1].norm() < 1e-12 && b.amp[2].norm() < 1e-12);
+        assert!((b.norm() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn bell_state_is_entangled() {
+        assert!(!is_product(&bell()));
     }
 }

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -31,6 +31,7 @@ pub mod born;
 pub mod qlm;
 pub mod measurement;
 pub mod admissibility;
+pub mod two_qubit;
 
 pub use complex_structure::{
     antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j,
@@ -41,3 +42,4 @@ pub use born::measure_probs;
 pub use qlm::SingleQubitLM;
 pub use measurement::{project, LinearQubit};
 pub use admissibility::{exists_continuation, is_realizable, uniformly_stable, ArithFragment};
+pub use two_qubit::TwoQubit;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -14,6 +14,15 @@
 //! at which states no longer factor into single-qubit parts, so the algebra
 //! becomes non-commutative and non-idempotent. GHZ / W states generalize this
 //! to 3+ qubits. Each is a separate plan built on these primitives.
+//!
+//! # Measurement as elimination
+//!
+//! Measurement is not a new primitive but an elimination rule in the linear
+//! (no-cloning) fragment: `measurement::project` consumes a state to a basis
+//! outcome or `None` (⊥ ≅ `SingleQubitLM::score` returning −∞). `LinearQubit`
+//! enforces no-cloning via Rust move semantics. `admissibility` bounds
+//! extraction to the finite, decidable fragment (Δ₀) with Σ⁰₁/Π⁰₂ query shapes
+//! — Rosko 2025, arXiv:2511.21296.
 
 pub mod complex_structure;
 pub mod unitary;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -42,4 +42,4 @@ pub use born::measure_probs;
 pub use qlm::SingleQubitLM;
 pub use measurement::{project, LinearQubit};
 pub use admissibility::{exists_continuation, is_realizable, uniformly_stable, ArithFragment};
-pub use two_qubit::{is_product, tensor, TwoQubit};
+pub use two_qubit::{is_product, marginal_probs, measure_qubit, tensor, TwoQubit};

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -31,4 +31,4 @@ pub use qubit::Qubit;
 pub use born::measure_probs;
 pub use qlm::SingleQubitLM;
 pub use measurement::{project, LinearQubit};
-pub use admissibility::{exists_continuation, is_realizable, ArithFragment};
+pub use admissibility::{exists_continuation, is_realizable, uniformly_stable, ArithFragment};

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -44,4 +44,4 @@ pub use qlm::SingleQubitLM;
 pub use measurement::{project, LinearQubit};
 pub use admissibility::{exists_continuation, is_realizable, uniformly_stable, ArithFragment};
 pub use two_qubit::{is_product, marginal_probs, measure_qubit, tensor, TwoQubit};
-pub use gate2::Gate4;
+pub use gate2::{bell, cnot, Gate4};

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -52,3 +52,6 @@ pub use two_qubit::{is_product, marginal_probs, measure_qubit, tensor, TwoQubit}
 pub use gate2::{bell, cnot, Gate4};
 pub mod qlm2;
 pub use qlm2::TwoQubitLM;
+
+pub mod entropy;
+pub use entropy::spectral_entropy;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -32,6 +32,7 @@ pub mod qlm;
 pub mod measurement;
 pub mod admissibility;
 pub mod two_qubit;
+pub mod gate2;
 
 pub use complex_structure::{
     antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j,
@@ -43,3 +44,4 @@ pub use qlm::SingleQubitLM;
 pub use measurement::{project, LinearQubit};
 pub use admissibility::{exists_continuation, is_realizable, uniformly_stable, ArithFragment};
 pub use two_qubit::{is_product, marginal_probs, measure_qubit, tensor, TwoQubit};
+pub use gate2::Gate4;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -9,8 +9,10 @@
 
 pub mod complex_structure;
 pub mod unitary;
+pub mod qubit;
 
 pub use complex_structure::{
     antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j,
 };
 pub use unitary::Gate;
+pub use qubit::Qubit;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -6,6 +6,14 @@
 //! `commutator_residual(M, J) = 2 · antilinear_fraction(M)`. The qubit side
 //! (`unitary`, `qubit`, `born`, `qlm`) is the first concrete model built on the
 //! same formalism — a single qubit, ℂP¹ = the Bloch sphere.
+//!
+//! # Roadmap
+//!
+//! This crate is the single-qubit foundation. Next: a 2-qubit model (ℂ⁴ states,
+//! the tensor product) introduces the Bell entanglement operation — the point
+//! at which states no longer factor into single-qubit parts, so the algebra
+//! becomes non-commutative and non-idempotent. GHZ / W states generalize this
+//! to 3+ qubits. Each is a separate plan built on these primitives.
 
 pub mod complex_structure;
 pub mod unitary;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -9,4 +9,6 @@
 
 pub mod complex_structure;
 
-pub use complex_structure::{antilinear_fraction, commutator_residual, split_half_j};
+pub use complex_structure::{
+    antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j,
+};

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -10,9 +10,11 @@
 pub mod complex_structure;
 pub mod unitary;
 pub mod qubit;
+pub mod born;
 
 pub use complex_structure::{
     antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j,
 };
 pub use unitary::Gate;
 pub use qubit::Qubit;
+pub use born::measure_probs;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -42,4 +42,4 @@ pub use born::measure_probs;
 pub use qlm::SingleQubitLM;
 pub use measurement::{project, LinearQubit};
 pub use admissibility::{exists_continuation, is_realizable, uniformly_stable, ArithFragment};
-pub use two_qubit::TwoQubit;
+pub use two_qubit::{is_product, tensor, TwoQubit};

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -21,6 +21,7 @@ pub mod qubit;
 pub mod born;
 pub mod qlm;
 pub mod measurement;
+pub mod admissibility;
 
 pub use complex_structure::{
     antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j,
@@ -30,3 +31,4 @@ pub use qubit::Qubit;
 pub use born::measure_probs;
 pub use qlm::SingleQubitLM;
 pub use measurement::{project, LinearQubit};
+pub use admissibility::{is_realizable, ArithFragment};

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -55,3 +55,5 @@ pub use qlm2::TwoQubitLM;
 
 pub mod entropy;
 pub use entropy::spectral_entropy;
+pub mod eig;
+pub use eig::symmetric_eigenvalues;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -15,6 +15,11 @@
 //! becomes non-commutative and non-idempotent. GHZ / W states generalize this
 //! to 3+ qubits. Each is a separate plan built on these primitives.
 //!
+//! Two qubits (`two_qubit`, `gate2`, `qlm2`) add the tensor product, the Bell
+//! entangling operation, and partial measurement — where states stop factoring
+//! (`A⊗B ≠ A×B`) and the single-qubit Markov reduction breaks. Next: GHZ / W
+//! states for 3+ qubits (`ℂ^{2ⁿ}`), generalizing these primitives.
+//!
 //! # Measurement as elimination
 //!
 //! Measurement is not a new primitive but an elimination rule in the linear
@@ -45,3 +50,5 @@ pub use measurement::{project, LinearQubit};
 pub use admissibility::{exists_continuation, is_realizable, uniformly_stable, ArithFragment};
 pub use two_qubit::{is_product, marginal_probs, measure_qubit, tensor, TwoQubit};
 pub use gate2::{bell, cnot, Gate4};
+pub mod qlm2;
+pub use qlm2::TwoQubitLM;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -1,0 +1,16 @@
+//! Hilbert-space formalization for larql: complex structures, the real↔complex
+//! bridge, and the minimal single-qubit Bloch-sphere language model.
+//!
+//! The real-matrix side (`complex_structure`) re-expresses the `larql hilbertian`
+//! residual in genuine complex terms via the identity
+//! `commutator_residual(M, J) = 2 · antilinear_fraction(M)`. The qubit side
+//! (`unitary`, `qubit`, `born`, `qlm`) is the first concrete model built on the
+//! same formalism — a single qubit, ℂP¹ = the Bloch sphere.
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn crate_builds() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -8,7 +8,9 @@
 //! same formalism — a single qubit, ℂP¹ = the Bloch sphere.
 
 pub mod complex_structure;
+pub mod unitary;
 
 pub use complex_structure::{
     antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j,
 };
+pub use unitary::Gate;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -7,10 +7,6 @@
 //! (`unitary`, `qubit`, `born`, `qlm`) is the first concrete model built on the
 //! same formalism — a single qubit, ℂP¹ = the Bloch sphere.
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn crate_builds() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+pub mod complex_structure;
+
+pub use complex_structure::{antilinear_fraction, commutator_residual, split_half_j};

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -54,6 +54,6 @@ pub mod qlm2;
 pub use qlm2::TwoQubitLM;
 
 pub mod entropy;
-pub use entropy::spectral_entropy;
+pub use entropy::{entanglement_entropy, spectral_entropy};
 pub mod eig;
 pub use eig::symmetric_eigenvalues;

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -20,6 +20,7 @@ pub mod unitary;
 pub mod qubit;
 pub mod born;
 pub mod qlm;
+pub mod measurement;
 
 pub use complex_structure::{
     antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j,
@@ -28,3 +29,4 @@ pub use unitary::Gate;
 pub use qubit::Qubit;
 pub use born::measure_probs;
 pub use qlm::SingleQubitLM;
+pub use measurement::{project, LinearQubit};

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -31,4 +31,4 @@ pub use qubit::Qubit;
 pub use born::measure_probs;
 pub use qlm::SingleQubitLM;
 pub use measurement::{project, LinearQubit};
-pub use admissibility::{is_realizable, ArithFragment};
+pub use admissibility::{exists_continuation, is_realizable, ArithFragment};

--- a/crates/larql-hilbert/src/lib.rs
+++ b/crates/larql-hilbert/src/lib.rs
@@ -11,6 +11,7 @@ pub mod complex_structure;
 pub mod unitary;
 pub mod qubit;
 pub mod born;
+pub mod qlm;
 
 pub use complex_structure::{
     antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j,
@@ -18,3 +19,4 @@ pub use complex_structure::{
 pub use unitary::Gate;
 pub use qubit::Qubit;
 pub use born::measure_probs;
+pub use qlm::SingleQubitLM;

--- a/crates/larql-hilbert/src/measurement.rs
+++ b/crates/larql-hilbert/src/measurement.rs
@@ -1,0 +1,88 @@
+//! Measurement as a (linear, destructive) elimination rule.
+//!
+//! `project` is the projective-measurement eliminator: given an outcome it
+//! returns the collapsed post-measurement state, or `None` when that outcome is
+//! impossible — the uninhabited type ⊥ (mirroring `SingleQubitLM::score`
+//! returning −∞). `LinearQubit` enforces the no-cloning discipline: it is
+//! `!Copy`/`!Clone`, so measuring it *consumes* it (Rust move semantics = the
+//! linear-logic restriction on contraction).
+
+use num_complex::Complex64;
+
+use crate::qubit::Qubit;
+
+/// Projective measurement onto `|outcome⟩`: returns the normalized projection
+/// (the collapsed state), or `None` if the outcome has amplitude 0 (⊥).
+///
+/// # Panics
+/// Panics if `outcome` is ≥ 2 (the basis is `{0, 1}`).
+pub fn project(state: &Qubit, outcome: usize) -> Option<Qubit> {
+    let amp = state.amp[outcome];
+    let mag = amp.norm();
+    if mag == 0.0 {
+        return None;
+    }
+    let mut new_amp = [Complex64::new(0.0, 0.0); 2];
+    new_amp[outcome] = amp / mag;
+    Some(Qubit { amp: new_amp })
+}
+
+/// A single-use qubit. NOT `Copy`/`Clone`, so the borrow checker enforces the
+/// no-cloning theorem: `measure` takes `self` by value and consumes it.
+pub struct LinearQubit {
+    state: Qubit,
+}
+
+impl LinearQubit {
+    /// Wrap a qubit as a single-use (linear) resource.
+    pub fn new(state: Qubit) -> Self {
+        LinearQubit { state }
+    }
+
+    /// Consume this state by measuring `outcome`; returns the collapsed state,
+    /// or `None` if the outcome was impossible (⊥). After this call the
+    /// `LinearQubit` has been moved and cannot be measured (or copied) again —
+    /// enforced at compile time.
+    ///
+    /// # Panics
+    /// Panics if `outcome` is ≥ 2.
+    pub fn measure(self, outcome: usize) -> Option<Qubit> {
+        project(&self.state, outcome)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::born::measure_probs;
+    use crate::unitary::hadamard;
+
+    #[test]
+    fn project_impossible_outcome_is_bottom() {
+        // |0⟩ has zero amplitude on outcome 1 → ⊥.
+        assert!(project(&Qubit::ket0(), 1).is_none());
+    }
+
+    #[test]
+    fn project_collapses_to_the_measured_basis_state() {
+        let plus = Qubit::ket0().apply(&hadamard()); // |+⟩
+        let collapsed = project(&plus, 0).unwrap();
+        let p = measure_probs(&collapsed);
+        assert!((p[0] - 1.0).abs() < 1e-12 && p[1].abs() < 1e-12);
+    }
+
+    #[test]
+    fn linear_qubit_measure_consumes_and_collapses() {
+        let lq = LinearQubit::new(Qubit::ket0().apply(&hadamard()));
+        let collapsed = lq.measure(1).unwrap();
+        // lq has been moved here; a second `lq.measure(..)` would not compile.
+        let p = measure_probs(&collapsed);
+        assert!(p[1] > 0.999);
+    }
+
+    #[test]
+    fn linear_qubit_impossible_outcome_is_bottom() {
+        let lq = LinearQubit::new(Qubit::ket0());
+        assert!(lq.measure(1).is_none());
+    }
+}

--- a/crates/larql-hilbert/src/qlm.rs
+++ b/crates/larql-hilbert/src/qlm.rs
@@ -26,6 +26,7 @@ impl SingleQubitLM {
     /// # Panics
     /// Panics if `state_token` is ≥ 2 (the vocabulary is `{0, 1}`).
     pub fn step(&self, state_token: usize) -> Qubit {
+        assert!(state_token < 2, "token {state_token} out of vocabulary {{0,1}}");
         let collapsed = if state_token == 0 { Qubit::ket0() } else { Qubit::ket1() };
         collapsed.apply(&self.gates[state_token])
     }
@@ -39,6 +40,7 @@ impl SingleQubitLM {
         let mut state = self.init;
         let mut ll = 0.0;
         for &t in tokens {
+            assert!(t < 2, "token {t} out of vocabulary {{0,1}}");
             let p = self.next_distribution(&state);
             ll += p[t].ln();
             state = self.step(t);
@@ -134,5 +136,19 @@ mod tests {
             init: Qubit::ket0().apply(&hadamard()),
         };
         assert_eq!(lm.generate(8, 12345), lm.generate(8, 12345));
+    }
+
+    #[test]
+    #[should_panic(expected = "out of vocabulary")]
+    fn score_rejects_out_of_vocabulary_token() {
+        let lm = lm_identity_from_zero();
+        let _ = lm.score(&[2]);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of vocabulary")]
+    fn step_rejects_out_of_vocabulary_token() {
+        let lm = lm_identity_from_zero();
+        let _ = lm.step(2);
     }
 }

--- a/crates/larql-hilbert/src/qlm.rs
+++ b/crates/larql-hilbert/src/qlm.rs
@@ -22,6 +22,9 @@ impl SingleQubitLM {
     }
 
     /// State after observing token `t`: collapse to |t⟩, then apply gates[t].
+    ///
+    /// # Panics
+    /// Panics if `state_token` is ≥ 2 (the vocabulary is `{0, 1}`).
     pub fn step(&self, state_token: usize) -> Qubit {
         let collapsed = if state_token == 0 { Qubit::ket0() } else { Qubit::ket1() };
         collapsed.apply(&self.gates[state_token])
@@ -29,6 +32,9 @@ impl SingleQubitLM {
 
     /// Autoregressive log-likelihood (natural log) of a token sequence.
     /// A token with zero probability yields −∞.
+    ///
+    /// # Panics
+    /// Panics if any token in `tokens` is ≥ 2 (the vocabulary is `{0, 1}`).
     pub fn score(&self, tokens: &[usize]) -> f64 {
         let mut state = self.init;
         let mut ll = 0.0;

--- a/crates/larql-hilbert/src/qlm.rs
+++ b/crates/larql-hilbert/src/qlm.rs
@@ -1,0 +1,132 @@
+//! Minimal single-qubit language model: a 2-token vocabulary {0, 1}. The state
+//! is a qubit; the next-token distribution is the Born rule; after observing a
+//! token `t` the state collapses to |t⟩ and the token-dependent unitary
+//! `gates[t]` is applied. This is a minimal hidden-quantum-Markov LM.
+
+use crate::born::measure_probs;
+use crate::qubit::Qubit;
+use crate::unitary::Gate;
+
+/// A single-qubit autoregressive language model over the alphabet {0, 1}.
+pub struct SingleQubitLM {
+    /// `gates[t]` is applied (after collapse to |t⟩) when token `t` is observed.
+    pub gates: [Gate; 2],
+    /// Initial state before any token.
+    pub init: Qubit,
+}
+
+impl SingleQubitLM {
+    /// Next-token distribution from a state: the Born rule.
+    pub fn next_distribution(&self, state: &Qubit) -> [f64; 2] {
+        measure_probs(state)
+    }
+
+    /// State after observing token `t`: collapse to |t⟩, then apply gates[t].
+    pub fn step(&self, state_token: usize) -> Qubit {
+        let collapsed = if state_token == 0 { Qubit::ket0() } else { Qubit::ket1() };
+        collapsed.apply(&self.gates[state_token])
+    }
+
+    /// Autoregressive log-likelihood (natural log) of a token sequence.
+    /// A token with zero probability yields −∞.
+    pub fn score(&self, tokens: &[usize]) -> f64 {
+        let mut state = self.init;
+        let mut ll = 0.0;
+        for &t in tokens {
+            let p = self.next_distribution(&state);
+            ll += p[t].ln();
+            state = self.step(t);
+        }
+        ll
+    }
+
+    /// Generate `len` tokens, sampling each from the Born distribution using a
+    /// deterministic LCG seeded by `seed` (reproducible; no external rng dep).
+    pub fn generate(&self, len: usize, seed: u64) -> Vec<usize> {
+        let mut rng_state = seed ^ 0x9E37_79B9_7F4A_7C15;
+        let mut next_uniform = || {
+            // SplitMix64-style step → uniform in [0, 1).
+            rng_state = rng_state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = rng_state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^= z >> 31;
+            (z >> 11) as f64 / (1u64 << 53) as f64
+        };
+
+        let mut state = self.init;
+        let mut out = Vec::with_capacity(len);
+        for _ in 0..len {
+            let p = self.next_distribution(&state);
+            let u = next_uniform();
+            let t = if u < p[0] { 0 } else { 1 };
+            out.push(t);
+            state = self.step(t);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unitary::{hadamard, identity};
+
+    fn lm_identity_from_zero() -> SingleQubitLM {
+        SingleQubitLM { gates: [identity(), identity()], init: Qubit::ket0() }
+    }
+
+    #[test]
+    fn next_distribution_sums_to_one() {
+        let lm = lm_identity_from_zero();
+        let p = lm.next_distribution(&Qubit::from_bloch(0.6, 1.1));
+        assert!((p[0] + p[1] - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn deterministic_zero_state_scores_all_zeros_at_log_prob_zero() {
+        // init |0⟩, identity gates: state stays |0⟩ forever → P(0)=1.
+        let lm = lm_identity_from_zero();
+        assert!((lm.score(&[0, 0, 0])).abs() < 1e-12); // ln(1)+ln(1)+ln(1) = 0
+    }
+
+    #[test]
+    fn impossible_token_scores_neg_infinity() {
+        let lm = lm_identity_from_zero();
+        let s = lm.score(&[1]); // P(1)=0 from |0⟩
+        assert!(s.is_infinite() && s < 0.0);
+    }
+
+    #[test]
+    fn generate_from_certain_state_is_deterministic() {
+        // init |0⟩, identity gates: every step P(0)=1 → all zeros regardless of seed.
+        let lm = lm_identity_from_zero();
+        assert_eq!(lm.generate(5, 42), vec![0, 0, 0, 0, 0]);
+        assert_eq!(lm.generate(5, 7), vec![0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn hadamard_init_first_step_is_fair_then_collapses() {
+        // init H|0⟩ (P=[.5,.5]); identity gates. Sequence [0,0] has prob 0.5·1,
+        // sequence [0,1] has prob 0.5·0 = 0 (after observing 0, state collapses
+        // to |0⟩ and stays there).
+        let lm = SingleQubitLM {
+            gates: [identity(), identity()],
+            init: Qubit::ket0().apply(&hadamard()),
+        };
+        let s00 = lm.score(&[0, 0]);
+        assert!((s00 - 0.5_f64.ln()).abs() < 1e-12);
+        let s01 = lm.score(&[0, 1]);
+        assert!(s01.is_infinite() && s01 < 0.0);
+    }
+
+    #[test]
+    fn generate_is_reproducible_for_a_seed() {
+        // Non-trivial dynamics: X gate after observing 0 flips to |1⟩.
+        let lm = SingleQubitLM {
+            gates: [crate::unitary::pauli_x(), identity()],
+            init: Qubit::ket0().apply(&hadamard()),
+        };
+        assert_eq!(lm.generate(8, 12345), lm.generate(8, 12345));
+    }
+}

--- a/crates/larql-hilbert/src/qlm2.rs
+++ b/crates/larql-hilbert/src/qlm2.rs
@@ -31,6 +31,7 @@ impl TwoQubitLM {
     /// # Panics
     /// Panics if `t` ≥ 4 (the vocabulary is {0,1,2,3}).
     pub fn step(&self, t: usize) -> TwoQubit {
+        assert!(t < 4, "token {t} out of vocabulary {{0,1,2,3}}");
         let collapsed = TwoQubit::ket(t / 2, t % 2);
         apply4(&self.gates[t], &collapsed)
     }
@@ -43,6 +44,7 @@ impl TwoQubitLM {
         let mut state = self.init;
         let mut ll = 0.0;
         for &t in tokens {
+            assert!(t < 4, "token {t} out of vocabulary {{0,1,2,3}}");
             let p = self.next_distribution(&state);
             ll += p[t].ln();
             state = self.step(t);
@@ -88,5 +90,19 @@ mod tests {
         let lm = TwoQubitLM { gates: identity_gates(), init: bell() };
         let p = lm.next_distribution(&TwoQubit::ket(0, 1));
         assert!((p.iter().sum::<f64>() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of vocabulary")]
+    fn score_rejects_out_of_vocabulary_token() {
+        let lm = TwoQubitLM { gates: identity_gates(), init: bell() };
+        let _ = lm.score(&[4]);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of vocabulary")]
+    fn step_rejects_out_of_vocabulary_token() {
+        let lm = TwoQubitLM { gates: identity_gates(), init: bell() };
+        let _ = lm.step(4);
     }
 }

--- a/crates/larql-hilbert/src/qlm2.rs
+++ b/crates/larql-hilbert/src/qlm2.rs
@@ -1,0 +1,92 @@
+//! Minimal two-qubit language model: a 4-token vocabulary {0,1,2,3} = the joint
+//! computational-basis outcomes |00⟩,|01⟩,|10⟩,|11⟩. The next-token
+//! distribution is the joint Born rule; after observing outcome `t` the state
+//! collapses to |t⟩ (as a two-qubit basis state) and `gates[t]` is applied.
+
+use crate::gate2::{apply4, Gate4};
+use crate::two_qubit::TwoQubit;
+
+/// A two-qubit autoregressive language model over the alphabet {0,1,2,3}.
+pub struct TwoQubitLM {
+    /// `gates[t]` is applied (after collapse to |t⟩) when joint outcome `t` is observed.
+    pub gates: [Gate4; 4],
+    /// Initial two-qubit state before any token.
+    pub init: TwoQubit,
+}
+
+impl TwoQubitLM {
+    /// Joint Born next-token distribution [P(00),P(01),P(10),P(11)].
+    pub fn next_distribution(&self, state: &TwoQubit) -> [f64; 4] {
+        let sn = state.normalized();
+        [
+            sn.amp[0].norm_sqr(),
+            sn.amp[1].norm_sqr(),
+            sn.amp[2].norm_sqr(),
+            sn.amp[3].norm_sqr(),
+        ]
+    }
+
+    /// State after observing joint outcome `t`: collapse to |t⟩, apply gates[t].
+    ///
+    /// # Panics
+    /// Panics if `t` ≥ 4 (the vocabulary is {0,1,2,3}).
+    pub fn step(&self, t: usize) -> TwoQubit {
+        let collapsed = TwoQubit::ket(t / 2, t % 2);
+        apply4(&self.gates[t], &collapsed)
+    }
+
+    /// Autoregressive log-likelihood; an impossible token yields −∞.
+    ///
+    /// # Panics
+    /// Panics if any token is ≥ 4.
+    pub fn score(&self, tokens: &[usize]) -> f64 {
+        let mut state = self.init;
+        let mut ll = 0.0;
+        for &t in tokens {
+            let p = self.next_distribution(&state);
+            ll += p[t].ln();
+            state = self.step(t);
+        }
+        ll
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gate2::{bell, tensor_gate};
+    use crate::unitary::identity;
+
+    fn identity_gates() -> [Gate4; 4] {
+        let ii = tensor_gate(&identity(), &identity());
+        [ii, ii, ii, ii]
+    }
+
+    #[test]
+    fn bell_init_distribution_is_correlated() {
+        // init = Bell Φ⁺ → joint distribution [0.5, 0, 0, 0.5]:
+        // tokens 0 (=00) and 3 (=11) likely; 1 (=01) and 2 (=10) impossible.
+        let lm = TwoQubitLM { gates: identity_gates(), init: bell() };
+        let p = lm.next_distribution(&bell());
+        assert!((p[0] - 0.5).abs() < 1e-12);
+        assert!((p[3] - 0.5).abs() < 1e-12);
+        assert!(p[1].abs() < 1e-12 && p[2].abs() < 1e-12);
+    }
+
+    #[test]
+    fn impossible_joint_token_scores_neg_infinity() {
+        // From Bell init, token 1 (=01) is impossible → −∞.
+        let lm = TwoQubitLM { gates: identity_gates(), init: bell() };
+        let s = lm.score(&[1]);
+        assert!(s.is_infinite() && s < 0.0);
+        // token 0 (=00) is possible → finite.
+        assert!(lm.score(&[0]).is_finite());
+    }
+
+    #[test]
+    fn next_distribution_sums_to_one() {
+        let lm = TwoQubitLM { gates: identity_gates(), init: bell() };
+        let p = lm.next_distribution(&TwoQubit::ket(0, 1));
+        assert!((p.iter().sum::<f64>() - 1.0).abs() < 1e-12);
+    }
+}

--- a/crates/larql-hilbert/src/qubit.rs
+++ b/crates/larql-hilbert/src/qubit.rs
@@ -1,0 +1,113 @@
+//! A single qubit: a unit vector in ℂ², with Bloch-sphere coordinates.
+//! The Bloch sphere S² = ℂP¹ is the canonical state space (global phase and
+//! norm quotiented out).
+
+use num_complex::Complex64;
+
+use crate::unitary::{apply_gate, Gate, State};
+
+#[inline]
+fn c(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+/// A single-qubit pure state. Not assumed normalized; use `normalized()`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Qubit {
+    pub amp: State,
+}
+
+impl Qubit {
+    /// |0⟩.
+    pub fn ket0() -> Qubit {
+        Qubit { amp: [c(1.0, 0.0), c(0.0, 0.0)] }
+    }
+
+    /// |1⟩.
+    pub fn ket1() -> Qubit {
+        Qubit { amp: [c(0.0, 0.0), c(1.0, 0.0)] }
+    }
+
+    /// State from Bloch angles: cos(θ/2)|0⟩ + e^{iφ} sin(θ/2)|1⟩.
+    pub fn from_bloch(theta: f64, phi: f64) -> Qubit {
+        let h = theta / 2.0;
+        Qubit { amp: [c(h.cos(), 0.0), Complex64::from_polar(h.sin(), phi)] }
+    }
+
+    /// L2 norm sqrt(|α|² + |β|²).
+    pub fn norm(&self) -> f64 {
+        (self.amp[0].norm_sqr() + self.amp[1].norm_sqr()).sqrt()
+    }
+
+    /// A normalized copy (unchanged if already unit norm; panics on the zero vector).
+    pub fn normalized(&self) -> Qubit {
+        let n = self.norm();
+        assert!(n > 0.0, "cannot normalize the zero state");
+        Qubit { amp: [self.amp[0] / n, self.amp[1] / n] }
+    }
+
+    /// Bloch vector (x, y, z) = (2 Re(ᾱβ), 2 Im(ᾱβ), |α|² − |β|²) of the
+    /// normalized state.
+    pub fn bloch_vector(&self) -> [f64; 3] {
+        let q = self.normalized();
+        let (a, b) = (q.amp[0], q.amp[1]);
+        let ab = a.conj() * b;
+        [2.0 * ab.re, 2.0 * ab.im, a.norm_sqr() - b.norm_sqr()]
+    }
+
+    /// Apply a gate, returning the new (un-normalized-if-gate-non-unitary) state.
+    pub fn apply(&self, g: &Gate) -> Qubit {
+        Qubit { amp: apply_gate(g, &self.amp) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unitary::{hadamard, pauli_x};
+
+    fn close(a: [f64; 3], b: [f64; 3]) -> bool {
+        (0..3).all(|i| (a[i] - b[i]).abs() < 1e-12)
+    }
+
+    #[test]
+    fn ket0_points_to_north_pole() {
+        assert!(close(Qubit::ket0().bloch_vector(), [0.0, 0.0, 1.0]));
+    }
+
+    #[test]
+    fn ket1_points_to_south_pole() {
+        assert!(close(Qubit::ket1().bloch_vector(), [0.0, 0.0, -1.0]));
+    }
+
+    #[test]
+    fn hadamard_zero_points_to_plus_x() {
+        let plus = Qubit::ket0().apply(&hadamard());
+        assert!(close(plus.bloch_vector(), [1.0, 0.0, 0.0]));
+    }
+
+    #[test]
+    fn from_bloch_round_trips() {
+        let theta = 0.9;
+        let phi = 1.7;
+        let q = Qubit::from_bloch(theta, phi);
+        let bv = q.bloch_vector();
+        let expected = [
+            theta.sin() * phi.cos(),
+            theta.sin() * phi.sin(),
+            theta.cos(),
+        ];
+        assert!(close(bv, expected), "got {bv:?} expected {expected:?}");
+    }
+
+    #[test]
+    fn x_gate_swaps_poles() {
+        let flipped = Qubit::ket0().apply(&pauli_x());
+        assert!(close(flipped.bloch_vector(), [0.0, 0.0, -1.0]));
+    }
+
+    #[test]
+    fn norm_of_basis_state_is_one() {
+        assert!((Qubit::ket0().norm() - 1.0).abs() < 1e-12);
+    }
+}

--- a/crates/larql-hilbert/src/two_qubit.rs
+++ b/crates/larql-hilbert/src/two_qubit.rs
@@ -1,0 +1,64 @@
+//! Two-qubit pure states in ℂ⁴ (basis |00⟩,|01⟩,|10⟩,|11⟩, index = 2·q0 + q1),
+//! the tensor product, the entanglement (non-factorization) test, and partial
+//! single-qubit measurement.
+
+use num_complex::Complex64;
+
+#[inline]
+fn c(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+/// A two-qubit pure state. Not assumed normalized.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TwoQubit {
+    pub amp: [Complex64; 4],
+}
+
+impl TwoQubit {
+    /// Computational basis state |q0 q1⟩ (each of q0, q1 ∈ {0, 1}).
+    pub fn ket(q0: usize, q1: usize) -> TwoQubit {
+        let mut amp = [c(0.0, 0.0); 4];
+        amp[2 * q0 + q1] = c(1.0, 0.0);
+        TwoQubit { amp }
+    }
+
+    /// L2 norm.
+    pub fn norm(&self) -> f64 {
+        self.amp.iter().map(|a| a.norm_sqr()).sum::<f64>().sqrt()
+    }
+
+    /// A normalized copy (panics on the zero state).
+    pub fn normalized(&self) -> TwoQubit {
+        let n = self.norm();
+        assert!(n > 0.0, "cannot normalize the zero state");
+        let mut amp = self.amp;
+        for a in amp.iter_mut() {
+            *a /= n;
+        }
+        TwoQubit { amp }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ket_sets_the_right_basis_index() {
+        assert_eq!(TwoQubit::ket(0, 0).amp[0], c(1.0, 0.0));
+        assert_eq!(TwoQubit::ket(1, 0).amp[2], c(1.0, 0.0));
+        assert_eq!(TwoQubit::ket(1, 1).amp[3], c(1.0, 0.0));
+    }
+
+    #[test]
+    fn norm_of_basis_state_is_one() {
+        assert!((TwoQubit::ket(0, 1).norm() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn normalized_scales_to_unit_norm() {
+        let s = TwoQubit { amp: [c(2.0, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(0.0, 0.0)] };
+        assert!((s.normalized().norm() - 1.0).abs() < 1e-12);
+    }
+}

--- a/crates/larql-hilbert/src/two_qubit.rs
+++ b/crates/larql-hilbert/src/two_qubit.rs
@@ -61,6 +61,47 @@ pub fn is_product(s: &TwoQubit) -> bool {
     det.norm() < 1e-10
 }
 
+/// Marginal Born probabilities [P(q=0), P(q=1)] for measuring qubit `which`
+/// (0 or 1) of the normalized state.
+pub fn marginal_probs(s: &TwoQubit, which: usize) -> [f64; 2] {
+    let sn = s.normalized();
+    let mut p = [0.0, 0.0];
+    for q0 in 0..2 {
+        for q1 in 0..2 {
+            let bit = if which == 0 { q0 } else { q1 };
+            p[bit] += sn.amp[2 * q0 + q1].norm_sqr();
+        }
+    }
+    p
+}
+
+/// Partial measurement: project onto the subspace where qubit `which` equals
+/// `outcome`, then renormalize. Returns `None` if that outcome has probability
+/// 0 (⊥) — the two-qubit analogue of `measurement::project`'s ⊥.
+pub fn measure_qubit(s: &TwoQubit, which: usize, outcome: usize) -> Option<TwoQubit> {
+    let sn = s.normalized();
+    let mut amp = [c(0.0, 0.0); 4];
+    let mut norm_sq = 0.0;
+    for q0 in 0..2 {
+        for q1 in 0..2 {
+            let bit = if which == 0 { q0 } else { q1 };
+            if bit == outcome {
+                let a = sn.amp[2 * q0 + q1];
+                amp[2 * q0 + q1] = a;
+                norm_sq += a.norm_sqr();
+            }
+        }
+    }
+    if norm_sq < 1e-300 {
+        return None;
+    }
+    let nrm = norm_sq.sqrt();
+    for a in amp.iter_mut() {
+        *a /= nrm;
+    }
+    Some(TwoQubit { amp })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -104,5 +145,36 @@ mod tests {
             amp: [c(s, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(s, 0.0)],
         };
         assert!(!is_product(&entangled));
+    }
+
+    fn entangled_phi_plus() -> TwoQubit {
+        // (|00⟩ + |11⟩)/√2, built directly (gate construction lands in Task 5).
+        let s = 1.0 / std::f64::consts::SQRT_2;
+        TwoQubit { amp: [c(s, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(s, 0.0)] }
+    }
+
+    #[test]
+    fn marginal_probs_of_phi_plus_are_fair() {
+        let p = marginal_probs(&entangled_phi_plus(), 0);
+        assert!((p[0] - 0.5).abs() < 1e-12 && (p[1] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn measuring_one_qubit_forces_the_other() {
+        let b = entangled_phi_plus();
+        // measure qubit 0 = 0 → collapses to |00⟩ → qubit 1 is certainly 0.
+        let after0 = measure_qubit(&b, 0, 0).unwrap();
+        let m1 = marginal_probs(&after0, 1);
+        assert!((m1[0] - 1.0).abs() < 1e-12);
+        // measure qubit 0 = 1 → |11⟩ → qubit 1 certainly 1.
+        let after1 = measure_qubit(&b, 0, 1).unwrap();
+        let m1b = marginal_probs(&after1, 1);
+        assert!((m1b[1] - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn impossible_partial_outcome_is_bottom() {
+        // |00⟩: measuring qubit 0 = 1 is impossible → None (⊥).
+        assert!(measure_qubit(&TwoQubit::ket(0, 0), 0, 1).is_none());
     }
 }

--- a/crates/larql-hilbert/src/two_qubit.rs
+++ b/crates/larql-hilbert/src/two_qubit.rs
@@ -4,6 +4,8 @@
 
 use num_complex::Complex64;
 
+use crate::qubit::Qubit;
+
 #[inline]
 fn c(re: f64, im: f64) -> Complex64 {
     Complex64::new(re, im)
@@ -40,9 +42,29 @@ impl TwoQubit {
     }
 }
 
+/// Tensor (Kronecker) product of two single qubits: amp[2·q0+q1] = a[q0]·b[q1].
+pub fn tensor(a: &Qubit, b: &Qubit) -> TwoQubit {
+    let mut amp = [c(0.0, 0.0); 4];
+    for q0 in 0..2 {
+        for q1 in 0..2 {
+            amp[2 * q0 + q1] = a.amp[q0] * b.amp[q1];
+        }
+    }
+    TwoQubit { amp }
+}
+
+/// Whether a two-qubit state factors as |a⟩⊗|b⟩ (i.e. is NOT entangled). True
+/// iff the 2×2 amplitude matrix [[c0,c1],[c2,c3]] has rank 1, equivalently
+/// c0·c3 − c1·c2 = 0. The determinant's magnitude is the entanglement witness.
+pub fn is_product(s: &TwoQubit) -> bool {
+    let det = s.amp[0] * s.amp[3] - s.amp[1] * s.amp[2];
+    det.norm() < 1e-10
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::unitary::hadamard;
 
     #[test]
     fn ket_sets_the_right_basis_index() {
@@ -60,5 +82,27 @@ mod tests {
     fn normalized_scales_to_unit_norm() {
         let s = TwoQubit { amp: [c(2.0, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(0.0, 0.0)] };
         assert!((s.normalized().norm() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn tensor_of_basis_qubits_is_basis_state() {
+        let t = tensor(&Qubit::ket1(), &Qubit::ket0()); // |1⟩⊗|0⟩ = |10⟩
+        assert_eq!(t, TwoQubit::ket(1, 0));
+    }
+
+    #[test]
+    fn product_states_are_recognized_as_product() {
+        let t = tensor(&Qubit::ket0().apply(&hadamard()), &Qubit::ket1());
+        assert!(is_product(&t));
+    }
+
+    #[test]
+    fn bell_like_state_is_not_product() {
+        // (|00⟩ + |11⟩)/√2 — determinant c0·c3 − c1·c2 = 1/2 ≠ 0.
+        let s = 1.0 / std::f64::consts::SQRT_2;
+        let entangled = TwoQubit {
+            amp: [c(s, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(s, 0.0)],
+        };
+        assert!(!is_product(&entangled));
     }
 }

--- a/crates/larql-hilbert/src/unitary.rs
+++ b/crates/larql-hilbert/src/unitary.rs
@@ -1,0 +1,157 @@
+//! Single-qubit gates as 2×2 complex matrices with hand-written algebra
+//! (no BLAS, no ndarray-complex) — keeps the qubit core minimal and portable.
+
+use num_complex::Complex64;
+
+/// A single-qubit gate: a 2×2 complex matrix, row-major `[[a, b], [c, d]]`.
+pub type Gate = [[Complex64; 2]; 2];
+/// A single-qubit state vector `[amp0, amp1]`.
+pub type State = [Complex64; 2];
+
+#[inline]
+fn c(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+/// 2×2 identity gate.
+pub fn identity() -> Gate {
+    [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(1.0, 0.0)]]
+}
+
+/// Pauli X (bit flip).
+pub fn pauli_x() -> Gate {
+    [[c(0.0, 0.0), c(1.0, 0.0)], [c(1.0, 0.0), c(0.0, 0.0)]]
+}
+
+/// Pauli Y.
+pub fn pauli_y() -> Gate {
+    [[c(0.0, 0.0), c(0.0, -1.0)], [c(0.0, 1.0), c(0.0, 0.0)]]
+}
+
+/// Pauli Z (phase flip).
+pub fn pauli_z() -> Gate {
+    [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(-1.0, 0.0)]]
+}
+
+/// Hadamard.
+pub fn hadamard() -> Gate {
+    let s = 1.0 / std::f64::consts::SQRT_2;
+    [[c(s, 0.0), c(s, 0.0)], [c(s, 0.0), c(-s, 0.0)]]
+}
+
+/// Rotation about Z by angle theta: diag(e^{-iθ/2}, e^{+iθ/2}).
+pub fn rz(theta: f64) -> Gate {
+    let h = theta / 2.0;
+    [
+        [Complex64::from_polar(1.0, -h), c(0.0, 0.0)],
+        [c(0.0, 0.0), Complex64::from_polar(1.0, h)],
+    ]
+}
+
+/// Rotation about Y by angle theta: [[cos, -sin], [sin, cos]] at θ/2 (real).
+pub fn ry(theta: f64) -> Gate {
+    let h = theta / 2.0;
+    let (co, si) = (h.cos(), h.sin());
+    [[c(co, 0.0), c(-si, 0.0)], [c(si, 0.0), c(co, 0.0)]]
+}
+
+/// Multiply two gates: returns A·B.
+pub fn mat_mul(a: &Gate, b: &Gate) -> Gate {
+    let mut out = [[c(0.0, 0.0); 2]; 2];
+    for i in 0..2 {
+        for j in 0..2 {
+            out[i][j] = a[i][0] * b[0][j] + a[i][1] * b[1][j];
+        }
+    }
+    out
+}
+
+/// Conjugate transpose (dagger) of a gate.
+pub fn dagger(a: &Gate) -> Gate {
+    [[a[0][0].conj(), a[1][0].conj()], [a[0][1].conj(), a[1][1].conj()]]
+}
+
+/// Whether a gate is unitary: U U† ≈ I within 1e-10.
+pub fn is_unitary(a: &Gate) -> bool {
+    let p = mat_mul(a, &dagger(a));
+    let id = identity();
+    for i in 0..2 {
+        for j in 0..2 {
+            if (p[i][j] - id[i][j]).norm() > 1e-10 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Apply a gate to a state: returns g·|ψ⟩.
+pub fn apply_gate(g: &Gate, s: &State) -> State {
+    [
+        g[0][0] * s[0] + g[0][1] * s[1],
+        g[1][0] * s[0] + g[1][1] * s[1],
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx_eq(a: Complex64, re: f64, im: f64) -> bool {
+        (a.re - re).abs() < 1e-12 && (a.im - im).abs() < 1e-12
+    }
+
+    #[test]
+    fn paulis_square_to_identity() {
+        for g in [pauli_x(), pauli_y(), pauli_z(), hadamard()] {
+            let sq = mat_mul(&g, &g);
+            let id = identity();
+            for i in 0..2 {
+                for j in 0..2 {
+                    assert!((sq[i][j] - id[i][j]).norm() < 1e-12);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn all_standard_gates_are_unitary() {
+        assert!(is_unitary(&identity()));
+        assert!(is_unitary(&pauli_x()));
+        assert!(is_unitary(&pauli_y()));
+        assert!(is_unitary(&pauli_z()));
+        assert!(is_unitary(&hadamard()));
+        assert!(is_unitary(&rz(0.7)));
+        assert!(is_unitary(&ry(1.3)));
+    }
+
+    #[test]
+    fn xy_equals_i_times_z() {
+        // X·Y = iZ
+        let xy = mat_mul(&pauli_x(), &pauli_y());
+        let iz = {
+            let z = pauli_z();
+            [[z[0][0] * c(0.0, 1.0), z[0][1] * c(0.0, 1.0)],
+             [z[1][0] * c(0.0, 1.0), z[1][1] * c(0.0, 1.0)]]
+        };
+        for i in 0..2 {
+            for j in 0..2 {
+                assert!((xy[i][j] - iz[i][j]).norm() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn apply_x_flips_basis() {
+        let zero: State = [c(1.0, 0.0), c(0.0, 0.0)];
+        let flipped = apply_gate(&pauli_x(), &zero);
+        assert!(approx_eq(flipped[0], 0.0, 0.0));
+        assert!(approx_eq(flipped[1], 1.0, 0.0));
+    }
+
+    #[test]
+    fn non_unitary_is_rejected() {
+        let bad: Gate = [[c(1.0, 0.0), c(1.0, 0.0)], [c(0.0, 0.0), c(1.0, 0.0)]];
+        assert!(!is_unitary(&bad));
+    }
+}

--- a/crates/larql-hilbert/tests/bell_integration.rs
+++ b/crates/larql-hilbert/tests/bell_integration.rs
@@ -1,0 +1,36 @@
+//! End-to-end: the Bell operation produces a non-factorizing state whose partial
+//! measurement is perfectly correlated, and whose LM statistics forbid the
+//! anti-correlated tokens — the place the single-qubit Markov reduction breaks.
+
+use larql_hilbert::gate2::bell;
+use larql_hilbert::gate2::tensor_gate;
+use larql_hilbert::qlm2::TwoQubitLM;
+use larql_hilbert::two_qubit::{is_product, marginal_probs, measure_qubit};
+use larql_hilbert::unitary::identity;
+
+#[test]
+fn bell_is_entangled_and_correlated_end_to_end() {
+    let b = bell();
+    // 1. Non-factorization: the Bell state is genuinely entangled.
+    assert!(!is_product(&b));
+    // 2. Each qubit alone looks fair...
+    assert!((marginal_probs(&b, 0)[0] - 0.5).abs() < 1e-12);
+    // 3. ...but measuring qubit 0 forces qubit 1 (perfect correlation).
+    let after0 = measure_qubit(&b, 0, 0).unwrap();
+    assert!((marginal_probs(&after0, 1)[0] - 1.0).abs() < 1e-12);
+    let after1 = measure_qubit(&b, 0, 1).unwrap();
+    assert!((marginal_probs(&after1, 1)[1] - 1.0).abs() < 1e-12);
+}
+
+#[test]
+fn bell_lm_forbids_anticorrelated_tokens() {
+    let ii = tensor_gate(&identity(), &identity());
+    let lm = TwoQubitLM { gates: [ii, ii, ii, ii], init: bell() };
+    // Anti-correlated joint outcomes 01 and 10 are impossible (−∞);
+    // correlated 00 and 11 are possible (finite). No product of two independent
+    // single-qubit chains can reproduce this.
+    assert!(lm.score(&[1]).is_infinite());
+    assert!(lm.score(&[2]).is_infinite());
+    assert!(lm.score(&[0]).is_finite());
+    assert!(lm.score(&[3]).is_finite());
+}

--- a/crates/larql-hilbert/tests/entropy_integration.rs
+++ b/crates/larql-hilbert/tests/entropy_integration.rs
@@ -1,0 +1,35 @@
+//! End-to-end: entanglement_entropy orders matrices by compressibility —
+//! rank-1 (0 ebits, fully compressible) < skewed spectrum < flat spectrum
+//! (maximal, incompressible) — through the public crate API.
+
+use larql_hilbert::{entanglement_entropy, spectral_entropy};
+use ndarray::{array, Array2};
+
+#[test]
+fn entropy_orders_matrices_by_compressibility() {
+    // Rank-1: zero entanglement (one Schmidt term).
+    let rank1 = array![[1.0, 2.0], [2.0, 4.0]];
+    // Skewed singular values [1, 0.1] → squared [1, 0.01]: low but nonzero.
+    let skewed = Array2::from_diag(&array![1.0, 0.1]);
+    // Flat: identity, maximal entropy for 2×2 (1 ebit).
+    let flat = Array2::<f64>::eye(2);
+
+    let s_rank1 = entanglement_entropy(&rank1);
+    let s_skewed = entanglement_entropy(&skewed);
+    let s_flat = entanglement_entropy(&flat);
+
+    assert!(s_rank1 < 1e-9, "rank-1 should be ~0, got {s_rank1}");
+    assert!(s_rank1 < s_skewed, "{s_rank1} !< {s_skewed}");
+    assert!(s_skewed < s_flat, "{s_skewed} !< {s_flat}");
+    assert!((s_flat - 1.0).abs() < 1e-9, "flat 2×2 should be 1 ebit, got {s_flat}");
+}
+
+#[test]
+fn matrix_meter_agrees_with_spectral_entropy_on_squared_singular_values() {
+    // The matrix meter must equal spectral_entropy applied to the squared
+    // singular values directly. For a diagonal matrix those are the squared
+    // diagonal entries.
+    let m = Array2::from_diag(&array![2.0, 1.0]);
+    let direct = spectral_entropy(&[4.0, 1.0]); // squares of 2 and 1
+    assert!((entanglement_entropy(&m) - direct).abs() < 1e-9);
+}

--- a/crates/larql-hilbert/tests/integration.rs
+++ b/crates/larql-hilbert/tests/integration.rs
@@ -1,0 +1,34 @@
+//! End-to-end: build a 2-token single-qubit LM, generate, score, and confirm
+//! the Hilbert-space bridge (a complex-linear real operator has zero antilinear
+//! fraction) all work through the public crate API.
+
+use larql_hilbert::complex_structure::{antilinear_fraction, realify, split_half_j};
+use larql_hilbert::qubit::Qubit;
+use larql_hilbert::unitary::{hadamard, identity, pauli_x};
+use larql_hilbert::SingleQubitLM;
+use ndarray::array;
+
+#[test]
+fn end_to_end_qlm_generate_and_score() {
+    let lm = SingleQubitLM {
+        gates: [pauli_x(), identity()],
+        init: Qubit::ket0().apply(&hadamard()),
+    };
+    // Generation is reproducible and in-alphabet.
+    let seq = lm.generate(16, 2026);
+    assert_eq!(seq.len(), 16);
+    assert!(seq.iter().all(|&t| t < 2));
+    // Scoring runs without panic on a generated sequence.
+    let _ll = lm.score(&seq);
+}
+
+#[test]
+fn hilbert_bridge_complex_linear_operator_is_pure() {
+    // A realified complex operator has zero antilinear fraction (it is exactly
+    // ℂ-linear) — the foundation the larql hilbertian residual rests on.
+    let a = array![[2.0, 1.0], [0.0, 3.0]];
+    let b = array![[0.5, -1.0], [1.0, 0.5]];
+    let m = realify(&a, &b);
+    let j = split_half_j(4);
+    assert!(antilinear_fraction(&m, &j) < 1e-12);
+}

--- a/crates/larql-hilbert/tests/measurement_integration.rs
+++ b/crates/larql-hilbert/tests/measurement_integration.rs
@@ -1,0 +1,32 @@
+//! End-to-end: the measurement eliminator's ⊥ (`project` → `None`) lines up
+//! with the QLM's −∞ (`score`), and bounded extraction stays admissible.
+
+use larql_hilbert::admissibility::{exists_continuation, is_realizable, uniformly_stable};
+use larql_hilbert::measurement::project;
+use larql_hilbert::qlm::SingleQubitLM;
+use larql_hilbert::qubit::Qubit;
+use larql_hilbert::unitary::identity;
+
+fn repeat_lm() -> SingleQubitLM {
+    SingleQubitLM { gates: [identity(), identity()], init: Qubit::ket0() }
+}
+
+#[test]
+fn bottom_outcome_matches_neg_infinity_score() {
+    // From |0⟩, outcome 1 is impossible: project → None, and the single-token
+    // score([1]) on the |0⟩-initialized LM is −∞. Both witness ⊥.
+    assert!(project(&Qubit::ket0(), 1).is_none());
+    let lm = repeat_lm();
+    assert!(lm.score(&[1]).is_infinite() && lm.score(&[1]) < 0.0);
+    assert!(!is_realizable(&lm, &[1]));
+}
+
+#[test]
+fn admissible_extraction_finds_witness_and_is_stable() {
+    let lm = repeat_lm();
+    // Σ⁰₁: a realizable 3-token continuation exists (all zeros).
+    let w = exists_continuation(&lm, &[], 3, |s| s.len() == 3);
+    assert_eq!(w, Some(vec![0, 0, 0]));
+    // Π⁰₂: the model is uniformly stable within the bound.
+    assert!(uniformly_stable(&lm, 3));
+}

--- a/crates/larql-inference/examples/fr_early_exit_bench.rs
+++ b/crates/larql-inference/examples/fr_early_exit_bench.rs
@@ -1,0 +1,290 @@
+//! Early-exit **tok/s gate** — the production-path wiring measured end to end.
+//!
+//! The probe (`fr_early_exit_probe`) showed the verified hit is stable from
+//! L24/34; the parity prototype (`fr_early_exit_parity`) proved the early-exit
+//! token is byte-identical. This drives the real production wiring
+//! (`infer_patched_early_exit`, WalkFfn path) on fact-lookup queries and times
+//! it against the full `infer_patched` (FR1 `Verified` mode), confirming the
+//! layer skip translates to wall-clock.
+//!
+//! Kill criterion: if the measured speedup on fired retrievals doesn't
+//! materialise (attention/KV/branch overhead eats the skipped layers), the lever
+//! is dead despite the clean forward ratio. Parity must also hold (early token ==
+//! full token) — one mismatch and it's dead.
+//!
+//! Usage: `cargo run --release --example fr_early_exit_bench -- [VINDEX_DIR] [N] [INSTALL_LAYER]`
+//! Writes `bench/aim-validation/fr_early_exit_bench_gemma3-4b.json`.
+
+use larql_inference::forward::{
+    infer_patched, infer_patched_early_exit, KnnRouteMode, KNN_COSINE_THRESHOLD, KNN_VERIFY_TOPK,
+};
+use larql_inference::load_tokenizer;
+use larql_inference::vindex::insert_q4k_layer_tensors;
+use larql_vindex::PatchedVindex;
+use std::time::Instant;
+
+const ENTITIES: &[&str] = &[
+    "France",
+    "Germany",
+    "Italy",
+    "Spain",
+    "Portugal",
+    "Greece",
+    "Austria",
+    "Belgium",
+    "Netherlands",
+    "Denmark",
+    "Norway",
+    "Sweden",
+    "Finland",
+    "Poland",
+    "Hungary",
+    "Romania",
+    "Japan",
+    "China",
+    "India",
+    "Pakistan",
+    "Thailand",
+    "Vietnam",
+    "Indonesia",
+    "Malaysia",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Peru",
+    "Colombia",
+    "Mexico",
+    "Canada",
+    "Australia",
+    "Egypt",
+    "Morocco",
+    "Kenya",
+    "Nigeria",
+    "Ghana",
+    "Ethiopia",
+    "Iran",
+    "Iraq",
+    "Jordan",
+    "Israel",
+    "Turkey",
+    "Russia",
+    "Ukraine",
+    "Cuba",
+];
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let vindex = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "output/gemma3-4b-q4k-v2.vindex".to_string());
+    let n: usize = args
+        .get(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(40)
+        .min(ENTITIES.len());
+    let dir = std::path::PathBuf::from(&vindex);
+    if !dir.exists() {
+        eprintln!("skipped: vindex not found at {vindex}");
+        eprintln!("  pass a Q4_K gemma3-4b vindex dir as the first arg");
+        eprintln!("  (default: output/gemma3-4b-q4k-v2.vindex). Skipping cleanly.");
+        return;
+    }
+
+    let mut cb = larql_vindex::SilentLoadCallbacks;
+    eprintln!("Loading {vindex} ...");
+    let mut weights = larql_vindex::load_model_weights_kquant(&dir, &mut cb).expect("weights");
+    let mut index = larql_vindex::VectorIndex::load_vindex(&dir, &mut cb).expect("index");
+    index.load_interleaved_kquant(&dir).expect("interleaved");
+    index.load_attn_kquant(&dir).expect("attn kquant");
+    let tok = load_tokenizer(&dir).expect("tokenizer");
+    let num_layers = weights.num_layers;
+    let last = num_layers - 1;
+    let install_layer = args
+        .get(3)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(24)
+        .min(last);
+    eprintln!("Dequantising {num_layers} layers to f32 ...");
+    for layer in 0..num_layers {
+        insert_q4k_layer_tensors(&mut weights, &index, layer).expect("dequant");
+    }
+    // Wrap as the gate index the WalkFfn routes through (production INFER path).
+    let patched = PatchedVindex::new(index);
+
+    let installed = (n * 3 / 4).max(1).min(n.saturating_sub(1).max(1));
+    let entities: Vec<String> = ENTITIES[..n].iter().map(|s| s.to_string()).collect();
+    let enc = |p: &str| tok.encode(p, true).expect("encode").get_ids().to_vec();
+
+    // ── Install facts at L* keyed in the WalkFfn residual space (exactly how
+    //    INSERT … MODE KNN keys: infer_patched residuals). ──
+    eprintln!("Installing {installed} facts at L{install_layer} ...");
+    let mut store = larql_vindex::KnnStore::default();
+    for (i, e) in entities.iter().take(installed).enumerate() {
+        let ids = enc(&format!("The capital of {e} is"));
+        let res = infer_patched(
+            &weights,
+            &tok,
+            &patched,
+            None,
+            &ids,
+            1,
+            &KnnRouteMode::Legacy,
+        )
+        .residuals;
+        let key = res
+            .into_iter()
+            .find(|(l, _)| *l == install_layer)
+            .map(|(_, v)| v)
+            .expect("install-layer residual");
+        store.add(
+            install_layer,
+            key,
+            i as u32,
+            e.clone(),
+            e.clone(),
+            "capital".to_string(),
+            1.0,
+        );
+    }
+
+    // ── Warm up (page-in, branch predictor) on one query each path. ──
+    {
+        let ids = enc("France's capital city is");
+        let _ = infer_patched(
+            &weights,
+            &tok,
+            &patched,
+            Some(&store),
+            &ids,
+            5,
+            &KnnRouteMode::Verified {
+                k: KNN_VERIFY_TOPK,
+                threshold: KNN_COSINE_THRESHOLD,
+            },
+        );
+        let _ = infer_patched_early_exit(
+            &weights,
+            &tok,
+            &patched,
+            Some(&store),
+            &ids,
+            5,
+            KNN_VERIFY_TOPK,
+            KNN_COSINE_THRESHOLD,
+        );
+    }
+
+    eprintln!("Timing {n} queries (full vs early-exit) ...");
+    let mut parity_ok = 0usize;
+    let mut parity_total = 0usize;
+    let mut exits = 0usize;
+    let mut distractor_exits = 0usize;
+    let mut full_fired_ns: u128 = 0;
+    let mut early_fired_ns: u128 = 0;
+    let mut fired = 0usize;
+
+    for (i, e) in entities.iter().enumerate() {
+        let prompt = format!("{e}'s capital city is");
+        let ids = enc(&prompt);
+        let is_distractor = i >= installed;
+
+        // FULL — production Verified-mode infer_patched (whole stack + lm_head).
+        let t0 = Instant::now();
+        let full = infer_patched(
+            &weights,
+            &tok,
+            &patched,
+            Some(&store),
+            &ids,
+            5,
+            &KnnRouteMode::Verified {
+                k: KNN_VERIFY_TOPK,
+                threshold: KNN_COSINE_THRESHOLD,
+            },
+        );
+        let full_ns = t0.elapsed().as_nanos();
+
+        // EARLY — short-circuit at L* when the verified hit fires.
+        let t1 = Instant::now();
+        let (early, exited) = infer_patched_early_exit(
+            &weights,
+            &tok,
+            &patched,
+            Some(&store),
+            &ids,
+            5,
+            KNN_VERIFY_TOPK,
+            KNN_COSINE_THRESHOLD,
+        );
+        let early_ns = t1.elapsed().as_nanos();
+
+        // Parity — the emitted token (position 0) must be identical.
+        parity_total += 1;
+        let full_tok = full.predictions.first().map(|(t, _)| t.clone());
+        let early_tok = early.predictions.first().map(|(t, _)| t.clone());
+        if full_tok == early_tok {
+            parity_ok += 1;
+        }
+        if exited {
+            exits += 1;
+            if is_distractor {
+                distractor_exits += 1;
+            }
+            fired += 1;
+            full_fired_ns += full_ns;
+            early_fired_ns += early_ns;
+        }
+    }
+
+    // ── Report ──
+    let tail = last - install_layer;
+    let full_ms = full_fired_ns as f64 / 1e6 / fired.max(1) as f64;
+    let early_ms = early_fired_ns as f64 / 1e6 / fired.max(1) as f64;
+    let speedup = if early_fired_ns > 0 {
+        full_fired_ns as f64 / early_fired_ns as f64
+    } else {
+        0.0
+    };
+    println!("\n=== FR early-exit tok/s gate on {vindex} ===");
+    println!("    stack {num_layers} layers; resolved L* = {install_layer}; {installed} installed + {} distractor", n - installed);
+    println!("    production path: WalkFfn infer_patched vs infer_patched_early_exit (Verified, top-k={KNN_VERIFY_TOPK})\n");
+    println!("  parity (emitted token early == full):  {parity_ok}/{parity_total}");
+    println!(
+        "  early-exit fired: {exits}/{n}  (skips {tail}/{num_layers} layers + lm_head; distractor false-exits: {distractor_exits})"
+    );
+    if fired > 0 {
+        println!("  on fired retrievals (n={fired}):");
+        println!("    full  infer_patched:        {full_ms:.1} ms/query");
+        println!("    early infer_patched_early:  {early_ms:.1} ms/query");
+        println!(
+            "    speedup: {speedup:.2}× ({:.0}% faster)",
+            100.0 * (1.0 - 1.0 / speedup.max(1e-9))
+        );
+    }
+
+    let parity = parity_ok == parity_total;
+    println!("\n  ── verdict ──");
+    if parity && speedup > 1.05 {
+        println!(
+            "  WIN: parity holds and early-exit is {speedup:.2}× on fact-lookup answer tokens."
+        );
+        println!("  Worth wiring into the decode loop / server generation path for RAG-style use.");
+    } else if !parity {
+        println!("  DEAD: parity broken ({parity_ok}/{parity_total}) — early-exit changes the answer. Stop.");
+    } else {
+        println!(
+            "  DEAD (speed): parity holds but speedup {speedup:.2}× ≤ 1.05 — overhead ate the layer skip."
+        );
+    }
+
+    let json = format!(
+        "{{\"experiment\":\"fr_early_exit_bench\",\"vindex\":\"{vindex}\",\"n\":{n},\"installed\":{installed},\"num_layers\":{num_layers},\"install_layer\":{install_layer},\"parity_ok\":{parity_ok},\"parity_total\":{parity_total},\"exits\":{exits},\"distractor_exits\":{distractor_exits},\"fired\":{fired},\"full_ms\":{full_ms:.4},\"early_ms\":{early_ms:.4},\"speedup\":{speedup:.4}}}"
+    );
+    let out = "bench/aim-validation/fr_early_exit_bench_gemma3-4b.json";
+    if let Err(e) = std::fs::write(out, &json) {
+        eprintln!("warning: could not write {out}: {e}");
+    } else {
+        println!("\nwrote {out}");
+    }
+}

--- a/crates/larql-inference/examples/fr_early_exit_parity.rs
+++ b/crates/larql-inference/examples/fr_early_exit_parity.rs
@@ -1,0 +1,281 @@
+//! Early-exit **parity-gated prototype** — the engineering spine before any
+//! tok/s number (the probe `fr_early_exit_probe` already showed the verified
+//! hit is stable + distractor-safe from ~L24/34).
+//!
+//! Claim under test: stopping the forward at the stored ("resolved") layer L*
+//! and emitting the verified KnnStore target — skipping layers L*+1..end +
+//! lm_head — produces the **byte-identical** token the full forward + override
+//! would. The kill criterion is parity: one mismatch and the lever is dead.
+//!
+//! Why it should hold (and what this proves empirically): a decoder is
+//! feed-forward, so the residual at L* does **not** depend on layers > L*.
+//! `capture_residuals(ids, &[L*])` already stops at `max(capture_layers)` (see
+//! `trace.rs`), so it is a genuinely partial forward that captures at the exact
+//! FFN-entry point `INSERT … MODE KNN` keys on. Therefore (1) the L* residual
+//! from the partial forward is bit-identical to the L* slice of the full forward
+//! (proven here per prompt, exactly), and (2) the verified override is a pure
+//! function of that residual + store + prompt, so the token is identical.
+//! Layers L*+1..end are still computed by the full path, but their output is
+//! discarded for a fired retrieval (the override replaces position 0).
+//!
+//! This prototype proves parity in the `capture_residuals` (WeightFfn) space and
+//! times the realised forward saving. Production INFER routes the same override
+//! through the WalkFfn residual stream; wiring early-exit there needs a partial
+//! walk-forward, but the identical structural argument (residual ⊥ later layers)
+//! carries over.
+//!
+//! Usage: `cargo run --release --example fr_early_exit_parity -- [VINDEX_DIR] [N] [INSTALL_LAYER]`
+//! Writes `bench/aim-validation/fr_early_exit_parity_gemma3-4b.json`.
+
+use larql_inference::forward::{
+    apply_knn_override_verified, KNN_COSINE_THRESHOLD, KNN_VERIFY_TOPK,
+};
+use larql_inference::vindex::insert_q4k_layer_tensors;
+use larql_inference::{capture_residuals, load_tokenizer};
+use larql_vindex::KnnStore;
+use std::time::Instant;
+
+const ENTITIES: &[&str] = &[
+    "France",
+    "Germany",
+    "Italy",
+    "Spain",
+    "Portugal",
+    "Greece",
+    "Austria",
+    "Belgium",
+    "Netherlands",
+    "Denmark",
+    "Norway",
+    "Sweden",
+    "Finland",
+    "Poland",
+    "Hungary",
+    "Romania",
+    "Japan",
+    "China",
+    "India",
+    "Pakistan",
+    "Thailand",
+    "Vietnam",
+    "Indonesia",
+    "Malaysia",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Peru",
+    "Colombia",
+    "Mexico",
+    "Canada",
+    "Australia",
+    "Egypt",
+    "Morocco",
+    "Kenya",
+    "Nigeria",
+    "Ghana",
+    "Ethiopia",
+    "Iran",
+    "Iraq",
+    "Jordan",
+    "Israel",
+    "Turkey",
+    "Russia",
+    "Ukraine",
+    "Cuba",
+];
+
+/// Compact (token, layer, cosine-bits) view of an override for exact compare.
+fn ovr_key(o: &Option<larql_inference::forward::KnnOverride>) -> Option<(String, usize, u32)> {
+    o.as_ref()
+        .map(|o| (o.token.clone(), o.layer, o.cosine.to_bits()))
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let vindex = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "output/gemma3-4b-q4k-v2.vindex".to_string());
+    let n: usize = args
+        .get(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(40)
+        .min(ENTITIES.len());
+    let dir = std::path::PathBuf::from(&vindex);
+    if !dir.exists() {
+        eprintln!("skipped: vindex not found at {vindex}");
+        eprintln!("  pass a Q4_K gemma3-4b vindex dir as the first arg");
+        eprintln!("  (default: output/gemma3-4b-q4k-v2.vindex). Skipping cleanly.");
+        return;
+    }
+
+    let mut cb = larql_vindex::SilentLoadCallbacks;
+    eprintln!("Loading {vindex} ...");
+    let mut weights = larql_vindex::load_model_weights_kquant(&dir, &mut cb).expect("weights");
+    let mut index = larql_vindex::VectorIndex::load_vindex(&dir, &mut cb).expect("index");
+    index.load_interleaved_kquant(&dir).expect("interleaved");
+    index.load_attn_kquant(&dir).expect("attn kquant");
+    let tok = load_tokenizer(&dir).expect("tokenizer");
+    let num_layers = weights.num_layers;
+    let last = num_layers - 1;
+    // Resolved layer from the probe (recall steps to 0.90 at L24/34 ≈ 0.7 depth).
+    let install_layer = args
+        .get(3)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(24)
+        .min(last);
+    eprintln!("Dequantising {num_layers} layers to f32 ...");
+    for layer in 0..num_layers {
+        insert_q4k_layer_tensors(&mut weights, &index, layer).expect("dequant");
+    }
+
+    let installed = (n * 3 / 4).max(1).min(n.saturating_sub(1).max(1));
+    let entities: Vec<String> = ENTITIES[..n].iter().map(|s| s.to_string()).collect();
+    let enc = |p: &str| tok.encode(p, true).expect("encode").get_ids().to_vec();
+
+    // ── Install: key each fact at L* via a PARTIAL forward (0..=L*). ──
+    eprintln!("Installing {installed} facts at L{install_layer} (partial forward) ...");
+    let mut store = KnnStore::default();
+    for (i, e) in entities.iter().take(installed).enumerate() {
+        let ids = enc(&format!("The capital of {e} is"));
+        let key = capture_residuals(&weights, &ids, &[install_layer])
+            .into_iter()
+            .next()
+            .map(|(_, v)| v)
+            .expect("key residual");
+        store.add(
+            install_layer,
+            key,
+            i as u32,
+            e.clone(),
+            e.clone(),
+            "capital".to_string(),
+            1.0,
+        );
+    }
+
+    // ── Per-query: early (stop at L*) vs full (whole stack), compare. ──
+    eprintln!(
+        "Checking parity over {n} queries ({installed} installed, {} distractor) ...",
+        n - installed
+    );
+    let mut residual_mismatches = 0usize;
+    let mut token_mismatches = 0usize;
+    let mut exits = 0usize; // queries where early-exit fired (skips the tail)
+    let mut distractor_exits = 0usize;
+    let mut early_ns: u128 = 0;
+    let mut full_ns: u128 = 0;
+
+    for (i, e) in entities.iter().enumerate() {
+        let prompt = format!("{e}'s capital city is");
+        let ids = enc(&prompt);
+        let is_distractor = i >= installed;
+
+        // EARLY: partial forward 0..=L*, capture at L*.
+        let t0 = Instant::now();
+        let early_res = capture_residuals(&weights, &ids, &[install_layer]);
+        early_ns += t0.elapsed().as_nanos();
+        let (_, early_ovr) = apply_knn_override_verified(
+            vec![("\u{2205}".into(), 0.0)],
+            &early_res,
+            Some(&store),
+            1,
+            &prompt,
+            KNN_VERIFY_TOPK,
+            KNN_COSINE_THRESHOLD,
+        );
+
+        // FULL: forward the whole stack; read the L* residual back out.
+        let t1 = Instant::now();
+        let full_all = capture_residuals(&weights, &ids, &[install_layer, last]);
+        full_ns += t1.elapsed().as_nanos();
+        let full_at_star: Vec<(usize, Vec<f32>)> = full_all
+            .iter()
+            .filter(|(l, _)| *l == install_layer)
+            .cloned()
+            .collect();
+        let (_, full_ovr) = apply_knn_override_verified(
+            vec![("\u{2205}".into(), 0.0)],
+            &full_at_star,
+            Some(&store),
+            1,
+            &prompt,
+            KNN_VERIFY_TOPK,
+            KNN_COSINE_THRESHOLD,
+        );
+
+        // Parity 1 — the L* residual is bit-identical (partial vs full forward).
+        let early_vec = &early_res[0].1;
+        let full_vec = &full_at_star[0].1;
+        if early_vec != full_vec {
+            residual_mismatches += 1;
+        }
+        // Parity 2 — the verified override is identical (token + layer + cosine).
+        if ovr_key(&early_ovr) != ovr_key(&full_ovr) {
+            token_mismatches += 1;
+        }
+        if early_ovr.is_some() {
+            exits += 1;
+            if is_distractor {
+                distractor_exits += 1;
+            }
+        }
+    }
+
+    // ── Report ──
+    let tail = last - install_layer; // layers skipped on a fired retrieval
+    let pct_layers = 100.0 * tail as f64 / num_layers as f64;
+    let fwd_ratio = if full_ns > 0 {
+        early_ns as f64 / full_ns as f64
+    } else {
+        0.0
+    };
+    println!("\n=== FR early-exit parity prototype on {vindex} ===");
+    println!("    stack = {num_layers} layers; install/resolved layer L* = {install_layer}");
+    println!(
+        "    {installed} installed + {} distractor; verified router top-k={KNN_VERIFY_TOPK}, floor {KNN_COSINE_THRESHOLD}\n",
+        n - installed
+    );
+    println!("  parity:");
+    println!(
+        "    residual @L{install_layer} bit-identical (partial vs full):  {}/{n}",
+        n - residual_mismatches
+    );
+    println!(
+        "    verified override identical (early vs full):        {}/{n}",
+        n - token_mismatches
+    );
+    println!("  behaviour:");
+    println!(
+        "    early-exit fired: {exits}/{n}  (installed retrievals; distractor false-exits: {distractor_exits})"
+    );
+    println!("  realised saving on a fired retrieval token:");
+    println!(
+        "    skip {tail}/{num_layers} layers (~{pct_layers:.0}%) + lm_head; measured forward 0..=L{install_layer} vs 0..=L{last}: {:.0}% of full ({:.1}× faster, lm_head extra)",
+        fwd_ratio * 100.0,
+        if fwd_ratio > 0.0 { 1.0 / fwd_ratio } else { 0.0 }
+    );
+
+    let parity = residual_mismatches == 0 && token_mismatches == 0;
+    println!("\n  ── verdict ──");
+    if parity {
+        println!("  PARITY HOLDS: every early-exit token is byte-identical to the full forward.");
+        println!("  Early-exit is correctness-safe — production wiring (partial walk-forward +");
+        println!("  decode-loop short-circuit) and a tok/s measurement on a fact-lookup workload");
+        println!("  are justified as the next stage.");
+    } else {
+        println!(
+            "  PARITY BROKEN: {residual_mismatches} residual + {token_mismatches} token mismatches — early-exit is NOT safe as wired. Dead until explained."
+        );
+    }
+
+    let json = format!(
+        "{{\"experiment\":\"fr_early_exit_parity\",\"vindex\":\"{vindex}\",\"n\":{n},\"installed\":{installed},\"num_layers\":{num_layers},\"install_layer\":{install_layer},\"residual_mismatches\":{residual_mismatches},\"token_mismatches\":{token_mismatches},\"exits\":{exits},\"distractor_exits\":{distractor_exits},\"layers_skipped\":{tail},\"forward_ratio_partial_over_full\":{fwd_ratio:.4},\"parity\":{parity}}}"
+    );
+    let out = "bench/aim-validation/fr_early_exit_parity_gemma3-4b.json";
+    if let Err(e) = std::fs::write(out, &json) {
+        eprintln!("warning: could not write {out}: {e}");
+    } else {
+        println!("\nwrote {out}");
+    }
+}

--- a/crates/larql-inference/examples/fr_early_exit_probe.rs
+++ b/crates/larql-inference/examples/fr_early_exit_probe.rs
@@ -1,0 +1,309 @@
+//! Early-exit probe — stage-1 falsification for **retrieval-augmented early
+//! exit** (the speed lever the FR1 verify makes safe). No new kernel.
+//!
+//! The question: if a *verified* KnnStore hit (FR1: top-k + entity-in-prompt +
+//! abstain) is essentially certain to be the answer token, could we stop the
+//! forward pass at the layer where that hit fires and skip the rest of the
+//! stack + lm_head? That only pays off if the verified hit is **correct and
+//! stable from an early-ish layer** — and only if it does **not** wrongly fire
+//! on queries about non-stored entities (which must run the full model).
+//!
+//! Method (faithful to production — keys + queries both from `capture_residuals`
+//! at the same layer, routed through the real `apply_knn_override_verified`):
+//!
+//! ```text
+//! INSTALL  "The capital of {e} is"   -> stored key (target = entity)
+//! QUERY    "{e}'s capital city is"   -> held-out paraphrase (names {e})
+//! ```
+//!
+//! Simulate early-exit at every layer L:
+//! - recall — installed {e}: does the verified router return {e} at L?
+//! - false-fire — distractor {e} (named, NOT installed): does it fire at L? The
+//!   verify should abstain → ~0; a non-zero rate means early-exit is unsafe there.
+//!
+//! Kill criterion: if recall only firms up at the last couple of layers, there
+//! is nothing to skip — dead. If it is stable (recall high, false-fire ~0) from
+//! a mid/late layer L*, early-exit could save (num_layers − L*) layers + lm_head
+//! on retrieval tokens, and a parity-gated prototype is justified.
+//!
+//! Usage: `cargo run --release --example fr_early_exit_probe -- [VINDEX_DIR] [N]`
+//! Writes `bench/aim-validation/fr_early_exit_probe_gemma3-4b.json`.
+
+use larql_inference::forward::{
+    apply_knn_override_verified, KNN_COSINE_THRESHOLD, KNN_VERIFY_TOPK,
+};
+use larql_inference::vindex::insert_q4k_layer_tensors;
+use larql_inference::{capture_residuals, load_tokenizer};
+use larql_vindex::KnnStore;
+use std::collections::HashMap;
+
+/// Country set (the model knows their capitals); first `installed` go in the
+/// store, the rest are named-but-unstored distractors.
+const ENTITIES: &[&str] = &[
+    "France",
+    "Germany",
+    "Italy",
+    "Spain",
+    "Portugal",
+    "Greece",
+    "Austria",
+    "Belgium",
+    "Netherlands",
+    "Denmark",
+    "Norway",
+    "Sweden",
+    "Finland",
+    "Poland",
+    "Hungary",
+    "Romania",
+    "Japan",
+    "China",
+    "India",
+    "Pakistan",
+    "Thailand",
+    "Vietnam",
+    "Indonesia",
+    "Malaysia",
+    "Brazil",
+    "Argentina",
+    "Chile",
+    "Peru",
+    "Colombia",
+    "Mexico",
+    "Canada",
+    "Australia",
+    "Egypt",
+    "Morocco",
+    "Kenya",
+    "Nigeria",
+    "Ghana",
+    "Ethiopia",
+    "Iran",
+    "Iraq",
+    "Jordan",
+    "Israel",
+    "Turkey",
+    "Russia",
+    "Ukraine",
+    "Cuba",
+];
+
+/// Recall threshold for "the verified hit is reliable at this layer".
+const RECALL_OK: f64 = 0.90;
+/// Tolerated distractor false-fire rate for "safe to early-exit at this layer".
+const FALSE_FIRE_OK: f64 = 0.05;
+
+struct LayerRow {
+    layer: usize,
+    fired: f64,      // fraction of installed queries that produced any override
+    recall: f64,     // fraction of installed queries routed to the CORRECT entity
+    false_fire: f64, // fraction of distractor queries that wrongly fired
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let vindex = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "output/gemma3-4b-q4k-v2.vindex".to_string());
+    let n: usize = args
+        .get(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(40)
+        .min(ENTITIES.len());
+    let dir = std::path::PathBuf::from(&vindex);
+    if !dir.exists() {
+        eprintln!("skipped: vindex not found at {vindex}");
+        eprintln!("  pass a Q4_K gemma3-4b vindex dir as the first arg");
+        eprintln!("  (default: output/gemma3-4b-q4k-v2.vindex). Skipping cleanly.");
+        return;
+    }
+    let installed = (n * 3 / 4).max(1).min(n.saturating_sub(1).max(1));
+    let entities: Vec<String> = ENTITIES[..n].iter().map(|s| s.to_string()).collect();
+
+    let mut cb = larql_vindex::SilentLoadCallbacks;
+    eprintln!("Loading {vindex} ...");
+    let mut weights = larql_vindex::load_model_weights_kquant(&dir, &mut cb).expect("weights");
+    let mut index = larql_vindex::VectorIndex::load_vindex(&dir, &mut cb).expect("index");
+    index.load_interleaved_kquant(&dir).expect("interleaved");
+    index.load_attn_kquant(&dir).expect("attn kquant");
+    let tok = load_tokenizer(&dir).expect("tokenizer");
+    let num_layers = weights.num_layers;
+    eprintln!("Dequantising {num_layers} layers to f32 ...");
+    for layer in 0..num_layers {
+        insert_q4k_layer_tensors(&mut weights, &index, layer).expect("dequant");
+    }
+
+    // Sweep the whole stack — capture_residuals returns every requested layer
+    // from a single forward, so the layer sweep is nearly free.
+    let layers: Vec<usize> = (0..num_layers).collect();
+    let cap = |prompt: &str| -> HashMap<usize, Vec<f32>> {
+        let ids = tok.encode(prompt, true).expect("encode").get_ids().to_vec();
+        capture_residuals(&weights, &ids, &layers)
+            .into_iter()
+            .collect()
+    };
+
+    eprintln!("Capturing residuals for {n} entities × 2 phrasings ...");
+    let mut train: Vec<HashMap<usize, Vec<f32>>> = Vec::with_capacity(n);
+    let mut query: Vec<HashMap<usize, Vec<f32>>> = Vec::with_capacity(n);
+    for (i, e) in entities.iter().enumerate() {
+        train.push(cap(&format!("The capital of {e} is")));
+        query.push(cap(&format!("{e}'s capital city is")));
+        if (i + 1) % 10 == 0 {
+            eprintln!("  {}/{n}", i + 1);
+        }
+    }
+
+    let n_recall = installed;
+    let n_distract = n - installed;
+    println!("\n=== FR early-exit probe on {vindex} (N={n}: {installed} installed, {n_distract} distractor) ===");
+    println!(
+        "    verified router: top-k={KNN_VERIFY_TOPK} + entity-in-prompt + abstain; cosine floor {KNN_COSINE_THRESHOLD}"
+    );
+    println!("    recall = correct verified hit on installed paraphrase; false-fire = any hit on a NON-stored entity\n");
+    println!("    layer   fired   recall   false-fire");
+
+    let dummy_raw = || vec![("\u{2205}".to_string(), 0.0f64)];
+    let mut rows: Vec<LayerRow> = Vec::with_capacity(num_layers);
+
+    for &layer in &layers {
+        // Store: installed entities' INSTALL-phrasing residual at this layer.
+        let mut store = KnnStore::default();
+        for (i, e) in entities.iter().take(installed).enumerate() {
+            store.add(
+                layer,
+                train[i][&layer].clone(),
+                i as u32,
+                e.clone(), // target_token = entity (routing identity)
+                e.clone(), // entity (what verify matches against the prompt)
+                "capital".to_string(),
+                1.0,
+            );
+        }
+
+        // Recall: installed entities, QUERY phrasing (names the entity).
+        let mut fired = 0usize;
+        let mut correct = 0usize;
+        for (i, e) in entities.iter().take(installed).enumerate() {
+            let prompt = format!("{e}'s capital city is");
+            let res = vec![(layer, query[i][&layer].clone())];
+            let (_, ovr) = apply_knn_override_verified(
+                dummy_raw(),
+                &res,
+                Some(&store),
+                1,
+                &prompt,
+                KNN_VERIFY_TOPK,
+                KNN_COSINE_THRESHOLD,
+            );
+            if let Some(o) = ovr {
+                fired += 1;
+                if o.token == *e {
+                    correct += 1;
+                }
+            }
+        }
+
+        // False-fire: distractor entities (named in prompt, NOT in store).
+        let mut false_fire = 0usize;
+        for (i, _e) in entities.iter().enumerate().skip(installed) {
+            let e = &entities[i];
+            let prompt = format!("{e}'s capital city is");
+            let res = vec![(layer, query[i][&layer].clone())];
+            let (_, ovr) = apply_knn_override_verified(
+                dummy_raw(),
+                &res,
+                Some(&store),
+                1,
+                &prompt,
+                KNN_VERIFY_TOPK,
+                KNN_COSINE_THRESHOLD,
+            );
+            if ovr.is_some() {
+                false_fire += 1;
+            }
+        }
+
+        let row = LayerRow {
+            layer,
+            fired: fired as f64 / n_recall as f64,
+            recall: correct as f64 / n_recall as f64,
+            false_fire: if n_distract == 0 {
+                0.0
+            } else {
+                false_fire as f64 / n_distract as f64
+            },
+        };
+        println!(
+            "    L{:<3}    {:.2}    {:.2}     {:.2}",
+            row.layer, row.fired, row.recall, row.false_fire
+        );
+        rows.push(row);
+    }
+
+    // ── Verdict: smallest layer L* such that recall ≥ RECALL_OK and false-fire
+    //    ≤ FALSE_FIRE_OK hold for L* through the LAST layer (stable, not a blip).
+    let last = num_layers - 1;
+    let stable_from = layers.iter().find(|&&l| {
+        rows[l..=last]
+            .iter()
+            .all(|r| r.recall >= RECALL_OK && r.false_fire <= FALSE_FIRE_OK)
+    });
+
+    println!("\n  ── verdict ──");
+    match stable_from {
+        Some(&l) if l < last.saturating_sub(2) => {
+            let saved = num_layers - l;
+            let pct = 100.0 * saved as f64 / num_layers as f64;
+            println!(
+                "  VIABLE: verified hit is stable (recall ≥ {RECALL_OK:.2}, false-fire ≤ {FALSE_FIRE_OK:.2}) from L{l} onward."
+            );
+            println!(
+                "  Early-exit at L{l} would skip {saved}/{num_layers} layers (~{pct:.0}% of the stack) + lm_head"
+            );
+            println!("  on retrieval tokens. A parity-gated prototype is justified (next stage).");
+        }
+        Some(&l) => {
+            println!(
+                "  MARGINAL: only stable from L{l} of {num_layers} — too late to be worth the control-flow complexity."
+            );
+        }
+        None => {
+            println!(
+                "  DEAD: no layer gives a stable, distractor-safe verified hit through L{last}. Nothing to skip."
+            );
+        }
+    }
+    // Also flag the first layer recall crosses RECALL_OK (the rise point), even
+    // if it doesn't hold — useful to see rise-vs-hold separately.
+    if let Some(rise) = rows.iter().find(|r| r.recall >= RECALL_OK) {
+        println!(
+            "  (recall first crosses {RECALL_OK:.2} at L{}; resolved-layer install target ≈ here)",
+            rise.layer
+        );
+    }
+
+    // ── JSON sidecar ──
+    let mut json_rows = String::new();
+    for r in &rows {
+        json_rows.push_str(&format!(
+            "{}{{\"layer\":{},\"fired\":{:.4},\"recall\":{:.4},\"false_fire\":{:.4}}}",
+            if json_rows.is_empty() { "" } else { "," },
+            r.layer,
+            r.fired,
+            r.recall,
+            r.false_fire
+        ));
+    }
+    let json = format!(
+        "{{\"experiment\":\"fr_early_exit_probe\",\"vindex\":\"{vindex}\",\"n\":{n},\"installed\":{installed},\"num_layers\":{num_layers},\"recall_ok\":{RECALL_OK},\"false_fire_ok\":{FALSE_FIRE_OK},\"stable_from\":{},\"layers\":[{json_rows}]}}",
+        stable_from.map(|l| l.to_string()).unwrap_or_else(|| "null".to_string())
+    );
+    let out = "bench/aim-validation/fr_early_exit_probe_gemma3-4b.json";
+    if let Err(e) = std::fs::write(out, &json) {
+        eprintln!("warning: could not write {out}: {e}");
+    } else {
+        println!("\nwrote {out}");
+    }
+}

--- a/crates/larql-inference/src/forward/infer_patched.rs
+++ b/crates/larql-inference/src/forward/infer_patched.rs
@@ -21,10 +21,10 @@ use larql_vindex::{GateIndex, KnnStore, PatchedVindex, VectorIndex, WalkHit};
 use tokenizers::Tokenizer;
 
 use crate::model::ModelWeights;
-use crate::vindex::predict_kquant_with_ffn;
 use crate::vindex::WalkFfn;
+use crate::vindex::{predict_kquant_with_ffn, predict_kquant_with_ffn_early_exit};
 
-use super::predict::predict_with_ffn;
+use super::predict::{predict_with_ffn, predict_with_ffn_early_exit};
 use super::PredictResult;
 
 /// Cosine threshold for the L0 KnnStore override. A stored key whose top-1
@@ -139,6 +139,85 @@ pub fn infer_patched(
     }
 }
 
+/// **Early-exit** variant of `infer_patched` (FR retrieval-augmented early
+/// exit). Runs the walk forward only as far as the highest stored KnnStore
+/// layer L\*, checks the FR1 verified router there, and — if a verified hit
+/// fires — returns the stored target immediately, **skipping layers L\*+1..end
+/// and the lm_head**. On a miss it transparently completes the full forward, so
+/// the result is identical to `infer_patched` in `Verified` mode (the verified
+/// router checks every stored layer ≤ L\*, which are all computed by L\*).
+///
+/// The returned `bool` is `true` when the early exit fired. Parity is structural
+/// (residuals ≤ L\* are independent of the tail) and proven bit-exact in
+/// `examples/fr_early_exit_parity.rs`; this is the production-path wiring whose
+/// tok/s win is measured in `examples/fr_early_exit_bench.rs`.
+#[allow(clippy::too_many_arguments)]
+pub fn infer_patched_early_exit(
+    weights: &ModelWeights,
+    tokenizer: &Tokenizer,
+    gate_index: &dyn GateIndex,
+    knn_store: Option<&KnnStore>,
+    token_ids: &[u32],
+    top_k: usize,
+    k_candidates: usize,
+    threshold: f32,
+) -> (InferPatchedResult, bool) {
+    let walk_ffn = WalkFfn::new_unlimited_with_trace(weights, gate_index);
+
+    // Check at the highest stored layer — by then every stored-layer residual
+    // (all ≤ L*) has been captured, so the verified route sees the same set it
+    // would post-hoc. No store / no valid layer → never exits (full forward).
+    let stop = knn_store
+        .map(|s| s.layers())
+        .and_then(|ls| ls.into_iter().filter(|l| *l < weights.num_layers).max())
+        .unwrap_or_else(|| weights.num_layers.saturating_sub(1));
+
+    let prompt = tokenizer.decode(token_ids, true).unwrap_or_default();
+    let prompt_lc = prompt.to_lowercase();
+
+    let mut fired: Option<KnnOverride> = None;
+    let start = std::time::Instant::now();
+    let (predictions, exited);
+    {
+        let mut on_stop = || -> Option<Vec<(String, f64)>> {
+            let store = knn_store?;
+            let residuals = walk_ffn.peek_residuals();
+            let ovr = verified_route(store, &residuals, &prompt_lc, k_candidates, threshold)?;
+            let preds = assemble_predictions(Vec::new(), &Some(ovr.clone()), top_k);
+            fired = Some(ovr);
+            Some(preds)
+        };
+        (predictions, exited) = predict_with_ffn_early_exit(
+            weights,
+            tokenizer,
+            token_ids,
+            top_k,
+            &walk_ffn,
+            stop,
+            &mut on_stop,
+        );
+    }
+    let walk_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let residuals = walk_ffn.take_residuals();
+    // On an exit the model's own lm_head never ran, so there is no model_top1.
+    let model_top1 = if exited {
+        None
+    } else {
+        predictions.first().cloned()
+    };
+
+    (
+        InferPatchedResult {
+            predictions,
+            model_top1,
+            knn_override: fired,
+            residuals,
+            walk_ms,
+        },
+        exited,
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 /// Q4K variant of `infer_patched`. Identical contract but routes the forward
 /// pass through `predict_kquant_with_ffn`, which dequantises one layer at a time
@@ -179,6 +258,78 @@ pub fn infer_patched_q4k(
         residuals,
         walk_ms,
     }
+}
+
+/// Q4K early-exit — the Q4_K twin of [`infer_patched_early_exit`]. Same
+/// short-circuit contract (stop at the highest stored layer L\*, emit the
+/// verified target, skip the tail + lm_head; on a miss complete the full
+/// forward), routed through the per-layer-dequant q4k forward.
+#[allow(clippy::too_many_arguments)]
+pub fn infer_patched_q4k_early_exit(
+    weights: &mut ModelWeights,
+    tokenizer: &Tokenizer,
+    gate_index: &dyn GateIndex,
+    knn_store: Option<&KnnStore>,
+    token_ids: &[u32],
+    top_k: usize,
+    index: &VectorIndex,
+    k_candidates: usize,
+    threshold: f32,
+) -> (InferPatchedResult, bool) {
+    // SAFETY: identical aliasing argument to `infer_patched_q4k` — WalkFfn reads
+    // only `weights.arch`/`weights.vectors`, the q4k forward mutates only
+    // `weights.tensors`.
+    let weights_ref: &ModelWeights = unsafe { &*(weights as *const ModelWeights) };
+    let walk_ffn = WalkFfn::new_unlimited_with_trace(weights_ref, gate_index);
+
+    let stop = knn_store
+        .map(|s| s.layers())
+        .and_then(|ls| ls.into_iter().filter(|l| *l < weights.num_layers).max())
+        .unwrap_or_else(|| weights.num_layers.saturating_sub(1));
+    let prompt = tokenizer.decode(token_ids, true).unwrap_or_default();
+    let prompt_lc = prompt.to_lowercase();
+
+    let mut fired: Option<KnnOverride> = None;
+    let start = std::time::Instant::now();
+    let (predictions, exited);
+    {
+        let mut on_stop = || -> Option<Vec<(String, f64)>> {
+            let store = knn_store?;
+            let residuals = walk_ffn.peek_residuals();
+            let ovr = verified_route(store, &residuals, &prompt_lc, k_candidates, threshold)?;
+            let preds = assemble_predictions(Vec::new(), &Some(ovr.clone()), top_k);
+            fired = Some(ovr);
+            Some(preds)
+        };
+        (predictions, exited) = predict_kquant_with_ffn_early_exit(
+            weights,
+            tokenizer,
+            token_ids,
+            top_k,
+            index,
+            &walk_ffn,
+            stop,
+            &mut on_stop,
+        );
+    }
+    let walk_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let residuals = walk_ffn.take_residuals();
+    let model_top1 = if exited {
+        None
+    } else {
+        predictions.first().cloned()
+    };
+
+    (
+        InferPatchedResult {
+            predictions,
+            model_top1,
+            knn_override: fired,
+            residuals,
+            walk_ms,
+        },
+        exited,
+    )
 }
 
 /// Pure function: given raw walk predictions, per-layer residuals, and an

--- a/crates/larql-inference/src/forward/inference_weights.rs
+++ b/crates/larql-inference/src/forward/inference_weights.rs
@@ -19,7 +19,10 @@ use larql_vindex::{
 
 use crate::model::ModelWeights;
 
-use super::infer_patched::{infer_patched, infer_patched_q4k, InferPatchedResult};
+use super::infer_patched::{
+    infer_patched, infer_patched_early_exit, infer_patched_q4k, infer_patched_q4k_early_exit,
+    InferPatchedResult,
+};
 use super::predict::predict;
 use super::PredictResult;
 
@@ -106,6 +109,47 @@ impl InferenceWeights {
             ),
             Self::Quantised { weights, index } => infer_patched_q4k(
                 weights, tokenizer, gate_index, knn_store, token_ids, top_k, index, route_mode,
+            ),
+        }
+    }
+
+    /// Early-exit INFER (FR retrieval-augmented early exit): short-circuit the
+    /// forward at the highest stored layer when the FR1 verified router fires,
+    /// skipping the tail + lm_head. Returns `(result, exited)`. On a miss it
+    /// completes the full forward, so the result matches `infer_patched` in
+    /// `Verified` mode. Dispatches Dense / Q4_K like [`Self::infer_patched`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn infer_patched_early_exit(
+        &mut self,
+        tokenizer: &Tokenizer,
+        gate_index: &dyn GateIndex,
+        knn_store: Option<&KnnStore>,
+        token_ids: &[u32],
+        top_k: usize,
+        k_candidates: usize,
+        threshold: f32,
+    ) -> (InferPatchedResult, bool) {
+        match self {
+            Self::Dense(weights) => infer_patched_early_exit(
+                weights,
+                tokenizer,
+                gate_index,
+                knn_store,
+                token_ids,
+                top_k,
+                k_candidates,
+                threshold,
+            ),
+            Self::Quantised { weights, index } => infer_patched_q4k_early_exit(
+                weights,
+                tokenizer,
+                gate_index,
+                knn_store,
+                token_ids,
+                top_k,
+                index,
+                k_candidates,
+                threshold,
             ),
         }
     }

--- a/crates/larql-inference/src/forward/mod.rs
+++ b/crates/larql-inference/src/forward/mod.rs
@@ -57,8 +57,9 @@ pub use hooks::{
 };
 pub use infer_patched::{
     apply_knn_override, apply_knn_override_two_tier, apply_knn_override_verified, infer_patched,
-    infer_patched_q4k, walk_trace_from_residuals, InferPatchedResult, KnnOverride, KnnRouteMode,
-    KNN_COSINE_THRESHOLD, KNN_VERIFY_TOPK,
+    infer_patched_early_exit, infer_patched_q4k, infer_patched_q4k_early_exit,
+    walk_trace_from_residuals, InferPatchedResult, KnnOverride, KnnRouteMode, KNN_COSINE_THRESHOLD,
+    KNN_VERIFY_TOPK,
 };
 pub use inference_weights::InferenceWeights;
 pub use layer::{run_attention_public, run_ffn, run_layer_with_capture_hooked, run_layer_with_ffn};

--- a/crates/larql-inference/src/forward/predict/ffn.rs
+++ b/crates/larql-inference/src/forward/predict/ffn.rs
@@ -51,6 +51,69 @@ pub fn predict_with_ffn(
     logits_to_predictions(weights, &h, tokenizer, top_k, 1.0)
 }
 
+/// Like [`predict_with_ffn`], but after the layer `stop_layer` completes it
+/// calls `on_stop`; if that returns `Some(predictions)`, the forward
+/// **short-circuits there** — skipping layers `stop_layer+1..` and the lm_head —
+/// and returns `(predictions, true)`. Otherwise the full forward + lm_head runs
+/// and returns `(model_predictions, false)`.
+///
+/// This is the early-exit primitive for retrieval-augmented inference: a
+/// decoder is feed-forward, so layers `≤ stop_layer` (and therefore the
+/// residuals `on_stop` inspects via the FFN trace) are computed **identically**
+/// whether or not the tail runs — the early-exit token is byte-identical to the
+/// full forward's (proven in `examples/fr_early_exit_parity.rs`).
+pub fn predict_with_ffn_early_exit(
+    weights: &ModelWeights,
+    tokenizer: &tokenizers::Tokenizer,
+    token_ids: &[u32],
+    top_k: usize,
+    ffn: &dyn FfnBackend,
+    stop_layer: usize,
+    on_stop: &mut dyn FnMut() -> Option<Vec<(String, f64)>>,
+) -> (Vec<(String, f64)>, bool) {
+    let num_layers = weights.num_layers;
+    let mut h = embed_tokens(weights, token_ids);
+    let ple_inputs = precompute_per_layer_inputs(weights, &h, token_ids);
+
+    let mut kv_cache: std::collections::HashMap<usize, SharedKV> = std::collections::HashMap::new();
+
+    for layer in 0..num_layers {
+        let shared_kv = weights
+            .arch
+            .kv_shared_source_layer(layer)
+            .and_then(|src| kv_cache.get(&src));
+
+        match run_layer_with_ffn(
+            weights,
+            &h,
+            layer,
+            ffn,
+            false,
+            ple_inputs.get(layer),
+            shared_kv,
+        ) {
+            Some((h_new, _, kv_out)) => {
+                h = h_new;
+                if let Some(kv) = kv_out {
+                    kv_cache.insert(layer, kv);
+                }
+            }
+            None => continue,
+        }
+
+        if layer == stop_layer {
+            if let Some(predictions) = on_stop() {
+                return (predictions, true);
+            }
+        }
+    }
+
+    (
+        logits_to_predictions(weights, &h, tokenizer, top_k, 1.0).predictions,
+        false,
+    )
+}
+
 /// Run a full forward pass with a custom FFN backend, capturing attention weights
 /// and per-layer residuals for logit lens.
 pub fn predict_with_ffn_attention(

--- a/crates/larql-inference/src/forward/predict/mod.rs
+++ b/crates/larql-inference/src/forward/predict/mod.rs
@@ -30,7 +30,8 @@ pub use dense::{
 };
 
 pub use ffn::{
-    predict_with_ffn, predict_with_ffn_attention, predict_with_router, predict_with_strategy,
+    predict_with_ffn, predict_with_ffn_attention, predict_with_ffn_early_exit, predict_with_router,
+    predict_with_strategy,
 };
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/crates/larql-inference/src/vindex/kquant_forward/mod.rs
+++ b/crates/larql-inference/src/vindex/kquant_forward/mod.rs
@@ -47,6 +47,8 @@ pub use metal::{
     predict_kquant_metal, predict_kquant_metal_capture_pre_wo, predict_kquant_metal_hidden,
     predict_kquant_metal_with_replaced_head_residual_delta,
 };
-pub use remote_ffn::{predict_kquant_hidden_with_ffn, predict_kquant_with_ffn};
+pub use remote_ffn::{
+    predict_kquant_hidden_with_ffn, predict_kquant_with_ffn, predict_kquant_with_ffn_early_exit,
+};
 pub use tensors::{insert_q4k_layer_tensors, remove_layer_tensors};
 pub use walk_ffn::{kquant_ffn_forward_layer, kquant_ffn_forward_layer_q8k};

--- a/crates/larql-inference/src/vindex/kquant_forward/remote_ffn.rs
+++ b/crates/larql-inference/src/vindex/kquant_forward/remote_ffn.rs
@@ -25,6 +25,53 @@ pub fn predict_kquant_with_ffn(
     crate::forward::predict::logits_to_predictions_pub(weights, &h, tokenizer, top_k, 1.0)
 }
 
+/// **Early-exit** Q4_K predict — the q4k twin of
+/// [`crate::forward::predict_with_ffn_early_exit`]. After layer `stop_layer`
+/// completes, calls `on_stop`; if it returns `Some(predictions)`, the forward
+/// short-circuits there — skipping the remaining per-layer dequant + compute
+/// and the lm_head — returning `(predictions, true)`. Otherwise the full
+/// forward + lm_head runs, returning `(model_predictions, false)`.
+#[allow(clippy::too_many_arguments)]
+pub fn predict_kquant_with_ffn_early_exit(
+    weights: &mut ModelWeights,
+    tokenizer: &Tokenizer,
+    token_ids: &[u32],
+    top_k: usize,
+    index: &VectorIndex,
+    ffn_backend: &dyn crate::ffn::FfnBackend,
+    stop_layer: usize,
+    on_stop: &mut dyn FnMut() -> Option<Vec<(String, f64)>>,
+) -> (Vec<(String, f64)>, bool) {
+    let mut early_preds: Option<Vec<(String, f64)>> = None;
+    let (h, exited);
+    {
+        let mut stop_hook = || -> bool {
+            if let Some(p) = on_stop() {
+                early_preds = Some(p);
+                true
+            } else {
+                false
+            }
+        };
+        (h, exited) = predict_kquant_hidden_inner(
+            weights,
+            token_ids,
+            index,
+            ffn_backend,
+            Some((stop_layer, &mut stop_hook)),
+        );
+    }
+    if exited {
+        (early_preds.unwrap_or_default(), true)
+    } else {
+        (
+            crate::forward::predict::logits_to_predictions_pub(weights, &h, tokenizer, top_k, 1.0)
+                .predictions,
+            false,
+        )
+    }
+}
+
 /// End-to-end hidden-state forward on a Q4_K vindex with the FFN served by an
 /// external [`crate::ffn::FfnBackend`].
 pub fn predict_kquant_hidden_with_ffn(
@@ -33,6 +80,20 @@ pub fn predict_kquant_hidden_with_ffn(
     index: &VectorIndex,
     ffn_backend: &dyn crate::ffn::FfnBackend,
 ) -> ndarray::Array2<f32> {
+    predict_kquant_hidden_inner(weights, token_ids, index, ffn_backend, None).0
+}
+
+/// Core Q4_K hidden forward with an optional early-exit hook. `early =
+/// Some((stop_layer, on_stop))` checks `on_stop()` after `stop_layer` completes;
+/// `true` returns the current hidden + `exited = true`. `None` runs the full
+/// stack (the behaviour of [`predict_kquant_hidden_with_ffn`]).
+fn predict_kquant_hidden_inner(
+    weights: &mut ModelWeights,
+    token_ids: &[u32],
+    index: &VectorIndex,
+    ffn_backend: &dyn crate::ffn::FfnBackend,
+    mut early: Option<(usize, &mut dyn FnMut() -> bool)>,
+) -> (ndarray::Array2<f32>, bool) {
     let num_layers = weights.num_layers;
     let hidden = weights.hidden_size;
 
@@ -106,9 +167,19 @@ pub fn predict_kquant_hidden_with_ffn(
         weights.tensors.remove(&k_key);
         weights.tensors.remove(&v_key);
         weights.tensors.remove(&o_key);
+
+        // Early-exit hook: after the resolved layer, let the caller short-circuit
+        // (the WalkFfn FFN trace already captured this layer's residual). MoE
+        // full-layer `continue` paths above skip this — they don't populate the
+        // residual trace, so the verified route would abstain there anyway.
+        if let Some((stop, on_stop)) = early.as_mut() {
+            if layer == *stop && on_stop() {
+                return (h, true);
+            }
+        }
     }
 
-    h
+    (h, false)
 }
 
 #[cfg(test)]

--- a/crates/larql-inference/src/vindex/mod.rs
+++ b/crates/larql-inference/src/vindex/mod.rs
@@ -31,8 +31,9 @@ pub use kquant_forward::{
     predict_kquant_hidden_with_zeroed_pre_o_heads, predict_kquant_metal,
     predict_kquant_metal_capture_pre_wo, predict_kquant_metal_hidden,
     predict_kquant_metal_with_replaced_head_residual_delta, predict_kquant_prefill,
-    predict_kquant_prefill_with_state, predict_kquant_with_ffn, remove_layer_tensors,
-    supports_cached_decode, supports_direct_matvec_decode, CachedTimings, CpuKvCache,
+    predict_kquant_prefill_with_state, predict_kquant_with_ffn, predict_kquant_with_ffn_early_exit,
+    remove_layer_tensors, supports_cached_decode, supports_direct_matvec_decode, CachedTimings,
+    CpuKvCache,
 };
 pub use l1_cache::FfnL1Cache;
 pub use loader::{open_inference_vindex, ENV_VINDEX_PATH};

--- a/crates/larql-inference/src/vindex/walk_ffn/mod.rs
+++ b/crates/larql-inference/src/vindex/walk_ffn/mod.rs
@@ -263,6 +263,15 @@ impl<'a> WalkFfn<'a> {
         self.trace_residuals.borrow_mut().drain(..).collect()
     }
 
+    /// Non-draining snapshot of the residuals captured so far. Used by the
+    /// early-exit path to inspect the stored-layer residuals at the resolved
+    /// layer *mid-forward* (after layer L*, before the tail runs) without
+    /// consuming the trace — the full forward, if it continues on a miss,
+    /// keeps appending.
+    pub fn peek_residuals(&self) -> Vec<(usize, Vec<f32>)> {
+        self.trace_residuals.borrow().clone()
+    }
+
     pub fn take_trace(&self) -> WalkTrace {
         let residuals = self
             .trace_residuals

--- a/crates/larql-lql/docs/spec.md
+++ b/crates/larql-lql/docs/spec.md
@@ -366,7 +366,7 @@ EXPLAIN WALK "The capital of France is"
 
 ```
 INFER <prompt>
-    [ROUTE VERIFY [FALLBACK] [TOPK <n>]]
+    [ROUTE VERIFY [FALLBACK] [TOPK <n>] [EXIT]]
     [TOP <n>]
     [COMPARE]
 
@@ -391,8 +391,16 @@ INFER <prompt>
 --   gate (measured 0/20 distractor-safe vs VERIFY's 20/20). Use FALLBACK only
 --   for queries known to be aliases of stored entities; VERIFY is the safe
 --   open default.
+-- ROUTE VERIFY EXIT: retrieval-augmented EARLY EXIT. When the verified router
+--   fires, the forward short-circuits at the resolved layer (~0.7 depth) — the
+--   stored target is emitted and the remaining layers + lm_head are SKIPPED.
+--   Parity-exact (the emitted token is byte-identical to the full forward) and
+--   ~1.4× faster on fact-lookup answer tokens. Verified-only: EXIT is ignored
+--   when FALLBACK is set (the FR2 fallback needs the full forward to stay
+--   parity-identical). On a verify-miss the forward completes normally.
 -- (The LARQL_KNN_VERIFY / LARQL_KNN_FALLBACK / LARQL_KNN_TOPK / LARQL_KNN_MIN_COS
---  env vars set the default when no ROUTE clause is present.)
+--  env vars set the default when no ROUTE clause is present;
+--  LARQL_KNN_EARLY_EXIT turns on EXIT for the env-default verified path.)
 
 INFER "The capital of France is" TOP 5;
 
@@ -401,6 +409,9 @@ INFER "The capital of France is" TOP 5 COMPARE;
 INFER "The capital of Atlantis is" ROUTE VERIFY TOP 3;
 
 INFER "The capital of Persia is" ROUTE VERIFY FALLBACK TOPK 8 TOP 3;
+
+-- Early-exit: emit the stored target the moment the verified hit fires.
+INFER "The capital of Atlantis is" ROUTE VERIFY EXIT TOP 3;
 ```
 
 ```

--- a/crates/larql-lql/src/ast.rs
+++ b/crates/larql-lql/src/ast.rs
@@ -217,6 +217,11 @@ pub struct InferRoute {
     pub fallback: bool,
     /// `TOPK n` — candidate count the verifier considers (None = default 5).
     pub topk: Option<u32>,
+    /// `EXIT` → retrieval-augmented early exit: when the verified router fires,
+    /// short-circuit the forward at the resolved layer (skip the remaining
+    /// layers + lm_head). Verified-only — ignored when `fallback` is set, since
+    /// the FR2 fallback needs the full forward to stay parity-identical.
+    pub exit: bool,
 }
 
 /// Display mode for DESCRIBE and SHOW RELATIONS output.

--- a/crates/larql-lql/src/executor/query/infer.rs
+++ b/crates/larql-lql/src/executor/query/infer.rs
@@ -33,6 +33,15 @@ impl Session {
             None => larql_inference::KnnRouteMode::from_env(),
         };
 
+        // Retrieval-augmented early exit (FR): opt-in via `ROUTE VERIFY … EXIT`
+        // or `LARQL_KNN_EARLY_EXIT`. Verified-only — the FR2 fallback needs the
+        // full forward to stay parity-identical, so `FALLBACK` disables it. Only
+        // takes effect below when `route_mode` actually resolves to `Verified`.
+        let exit_requested = match route {
+            Some(r) => r.exit && !r.fallback,
+            None => std::env::var_os("LARQL_KNN_EARLY_EXIT").is_some(),
+        };
+
         // Weight backend: dense inference (no vindex needed)
         if let Backend::Weight {
             weights, tokenizer, ..
@@ -88,14 +97,31 @@ impl Session {
         // 0001 (docs/adr/0001-python-lql-infer-parity.md).
         let mut iw = larql_inference::InferenceWeights::load(path, config, &mut cb)
             .map_err(|e| LqlError::exec("failed to load model weights", e))?;
-        let infer = iw.infer_patched(
-            &tokenizer,
-            patched,
-            Some(&patched.knn_store),
-            &token_ids,
-            top_k,
-            &route_mode,
-        );
+        // Early-exit applies only to the verified router (parity-safe). Any
+        // other resolved mode (Legacy / TwoTier) runs the full forward.
+        let (infer, exited) = match (exit_requested, &route_mode) {
+            (true, larql_inference::KnnRouteMode::Verified { k, threshold }) => iw
+                .infer_patched_early_exit(
+                    &tokenizer,
+                    patched,
+                    Some(&patched.knn_store),
+                    &token_ids,
+                    top_k,
+                    *k,
+                    *threshold,
+                ),
+            _ => (
+                iw.infer_patched(
+                    &tokenizer,
+                    patched,
+                    Some(&patched.knn_store),
+                    &token_ids,
+                    top_k,
+                    &route_mode,
+                ),
+                false,
+            ),
+        };
 
         let trace_layers = larql_inference::walk_trace_from_residuals(&infer.residuals, patched);
 
@@ -117,10 +143,18 @@ impl Session {
         }
         out.push(format!("  {:.0}ms", infer.walk_ms));
         if infer.knn_override.is_some() {
-            out.push(
-                "  note: KNN override is a post-logits retrieval sidecar, not an FFN/residual edit."
-                    .into(),
-            );
+            if exited {
+                out.push(
+                    "  note: early-exit — verified hit fired at the resolved layer; the stored \
+                     target was emitted and the remaining layers + lm_head were skipped."
+                        .into(),
+                );
+            } else {
+                out.push(
+                    "  note: KNN override is a post-logits retrieval sidecar, not an FFN/residual edit."
+                        .into(),
+                );
+            }
         }
 
         out.push(String::new());

--- a/crates/larql-lql/src/lexer.rs
+++ b/crates/larql-lql/src/lexer.rs
@@ -143,6 +143,7 @@ pub enum Keyword {
     Verify,
     Fallback,
     Topk,
+    Exit,
 }
 
 impl Keyword {
@@ -260,6 +261,7 @@ impl Keyword {
             Self::Verify => "verify",
             Self::Fallback => "fallback",
             Self::Topk => "topk",
+            Self::Exit => "exit",
         }
     }
 
@@ -374,6 +376,7 @@ impl Keyword {
             "VERIFY" => Some(Self::Verify),
             "FALLBACK" => Some(Self::Fallback),
             "TOPK" => Some(Self::Topk),
+            "EXIT" => Some(Self::Exit),
             _ => None,
         }
     }

--- a/crates/larql-lql/src/parser/query.rs
+++ b/crates/larql-lql/src/parser/query.rs
@@ -71,7 +71,7 @@ impl Parser {
                 }
                 Token::Keyword(Keyword::Route) => {
                     self.advance();
-                    // ROUTE VERIFY [FALLBACK] [TOPK n]
+                    // ROUTE VERIFY [FALLBACK] [TOPK n] [EXIT]
                     self.expect_keyword(Keyword::Verify)?;
                     let mut r = crate::ast::InferRoute::default();
                     loop {
@@ -83,6 +83,10 @@ impl Parser {
                             Token::Keyword(Keyword::Topk) => {
                                 self.advance();
                                 r.topk = Some(self.expect_u32()?);
+                            }
+                            Token::Keyword(Keyword::Exit) => {
+                                self.advance();
+                                r.exit = true;
                             }
                             _ => break,
                         }

--- a/crates/larql-lql/src/parser/tests.rs
+++ b/crates/larql-lql/src/parser/tests.rs
@@ -1647,6 +1647,31 @@ fn parse_infer_route_verify_fallback_topk() {
 }
 
 #[test]
+fn parse_infer_route_verify_exit() {
+    // ROUTE VERIFY [TOPK n] EXIT → early-exit flag set, fallback off.
+    let stmt =
+        parse(r#"INFER "The capital of France is" ROUTE VERIFY TOPK 5 EXIT TOP 3;"#).unwrap();
+    match stmt {
+        Statement::Infer { route, .. } => {
+            let r = route.expect("ROUTE VERIFY … EXIT → Some(route)");
+            assert!(r.exit);
+            assert!(!r.fallback);
+            assert_eq!(r.topk, Some(5));
+        }
+        _ => panic!("expected Infer"),
+    }
+}
+
+#[test]
+fn parse_infer_route_verify_no_exit_defaults_false() {
+    let stmt = parse(r#"INFER "x" ROUTE VERIFY;"#).unwrap();
+    match stmt {
+        Statement::Infer { route, .. } => assert!(!route.expect("route").exit),
+        _ => panic!("expected Infer"),
+    }
+}
+
+#[test]
 fn parse_infer_route_requires_verify() {
     // ROUTE must be followed by VERIFY.
     assert!(parse(r#"INFER "x" ROUTE FALLBACK;"#).is_err());

--- a/crates/larql-lql/tests/coverage_sweep_synthetic.rs
+++ b/crates/larql-lql/tests/coverage_sweep_synthetic.rs
@@ -276,6 +276,27 @@ fn infer_route_verify_fallback_synthetic() {
 }
 
 #[test]
+fn infer_route_verify_exit_synthetic() {
+    // ROUTE VERIFY EXIT → drives the early-exit branch of exec_infer
+    // (`infer_patched_early_exit`). The synthetic KnnStore is empty so no
+    // verified hit fires → it transparently completes the full forward; we
+    // assert only that the path runs.
+    let (mut session, _dir, _) = fresh_session();
+    let _ = try_run(&mut session, r#"INFER "[1]" ROUTE VERIFY EXIT TOP 3;"#);
+}
+
+#[test]
+fn infer_route_verify_fallback_exit_ignores_early_exit_synthetic() {
+    // FALLBACK + EXIT: early-exit is verified-only, so the fallback path
+    // disables it and the full TwoTier forward runs. Must still parse + run.
+    let (mut session, _dir, _) = fresh_session();
+    let _ = try_run(
+        &mut session,
+        r#"INFER "[1]" ROUTE VERIFY FALLBACK EXIT TOP 3;"#,
+    );
+}
+
+#[test]
 fn infer_errors_when_tokenizer_file_missing() {
     // `exec_infer` reloads `tokenizer.json` from disk on every call (the
     // vindex backend path). Removing it after USE drives the

--- a/crates/larql-vindex/src/canonical/covariance.rs
+++ b/crates/larql-vindex/src/canonical/covariance.rs
@@ -13,29 +13,25 @@ pub fn estimate_covariance(
     let indices: Vec<usize> = (0..vocab).step_by(stride).collect();
     let n = indices.len();
 
-    let mut g = Array2::<f64>::zeros((d, d));
-    let scale = embed_scale as f64;
-
-    for &v in &indices {
-        let row = embed.slice(s![v, ..]);
-        for i in 0..d {
-            let xi = row[i] as f64 * scale;
-            for j in 0..=i {
-                let xj = row[j] as f64 * scale;
-                g[[i, j]] += xi * xj;
-                if i != j {
-                    g[[j, i]] += xi * xj;
-                }
-            }
-        }
-    }
-
     // Guard against an empty subsample: dividing by 0 would fill G with NaN.
     // With no samples the (already-zero) accumulator is the right answer.
-    if n > 0 {
-        let norm = n as f64;
-        g.mapv_inplace(|v| v / norm);
+    if n == 0 {
+        return Array2::<f64>::zeros((d, d));
     }
+
+    // G = (1/N) · Sᵀ S, where S is the [n, d] matrix of subsampled, scaled rows.
+    // The single matrix multiply (ndarray's pure-Rust `matrixmultiply`, no BLAS)
+    // replaces the n·d²/2 scalar accumulation loop.
+    let scale = embed_scale as f64;
+    let mut sub = Array2::<f64>::zeros((n, d));
+    for (r, &v) in indices.iter().enumerate() {
+        let row = embed.slice(s![v, ..]);
+        for j in 0..d {
+            sub[[r, j]] = row[j] as f64 * scale;
+        }
+    }
+    let mut g = sub.t().dot(&sub);
+    g.mapv_inplace(|x| x / n as f64);
     g
 }
 

--- a/crates/larql-vindex/src/canonical/covariance.rs
+++ b/crates/larql-vindex/src/canonical/covariance.rs
@@ -30,8 +30,12 @@ pub fn estimate_covariance(
         }
     }
 
-    let norm = n as f64;
-    g.mapv_inplace(|v| v / norm);
+    // Guard against an empty subsample: dividing by 0 would fill G with NaN.
+    // With no samples the (already-zero) accumulator is the right answer.
+    if n > 0 {
+        let norm = n as f64;
+        g.mapv_inplace(|v| v / norm);
+    }
     g
 }
 

--- a/crates/larql-vindex/src/canonical/covariance.rs
+++ b/crates/larql-vindex/src/canonical/covariance.rs
@@ -1,0 +1,110 @@
+use ndarray::{Array2, s};
+
+/// Estimate G = (1/N) Σ (s·W_E[v])^T (s·W_E[v]) using at most `max_samples` rows.
+/// Rows are subsampled deterministically (every stride-th row).
+/// Returns a [hidden_size, hidden_size] f64 matrix.
+pub fn estimate_covariance(
+    embed: &Array2<f32>,
+    embed_scale: f32,
+    max_samples: usize,
+) -> Array2<f64> {
+    let (vocab, d) = (embed.shape()[0], embed.shape()[1]);
+    let stride = (vocab / max_samples).max(1);
+    let indices: Vec<usize> = (0..vocab).step_by(stride).collect();
+    let n = indices.len();
+
+    let mut g = Array2::<f64>::zeros((d, d));
+    let scale = embed_scale as f64;
+
+    for &v in &indices {
+        let row = embed.slice(s![v, ..]);
+        for i in 0..d {
+            let xi = row[i] as f64 * scale;
+            for j in 0..=i {
+                let xj = row[j] as f64 * scale;
+                g[[i, j]] += xi * xj;
+                if i != j {
+                    g[[j, i]] += xi * xj;
+                }
+            }
+        }
+    }
+
+    let norm = n as f64;
+    g.mapv_inplace(|v| v / norm);
+    g
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn identity_embed(d: usize) -> Array2<f32> {
+        Array2::<f32>::eye(d)
+    }
+
+    #[test]
+    fn covariance_of_identity_is_identity_scaled() {
+        // embed = 4×4 identity, embed_scale = 1.0, max_samples = 4
+        // G = (1/4) Σ_v e_v e_v^T = (1/4) I
+        let embed = identity_embed(4);
+        let g = estimate_covariance(&embed, 1.0, 4);
+        for i in 0..4 {
+            for j in 0..4 {
+                let expected = if i == j { 0.25 } else { 0.0 };
+                assert!(
+                    (g[[i, j]] - expected).abs() < 1e-10,
+                    "G[{i},{j}]={} expected={expected}", g[[i, j]]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn covariance_is_positive_semidefinite() {
+        let embed = Array2::from_shape_fn((8, 4), |(v, d)| (v as f32 + 1.0) * (d as f32 + 1.0));
+        let g = estimate_covariance(&embed, 0.5, 8);
+        for i in 0..4 {
+            assert!(g[[i, i]] >= 0.0, "diagonal must be non-negative");
+            for j in 0..4 {
+                assert!(
+                    g[[i, j]] * g[[i, j]] <= g[[i, i]] * g[[j, j]] + 1e-10,
+                    "Cauchy-Schwarz violated at ({i},{j})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn covariance_is_symmetric() {
+        let embed = Array2::from_shape_fn((16, 4), |(v, d)| (v * d) as f32 * 0.1 + 0.01);
+        let g = estimate_covariance(&embed, 1.0, 16);
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!((g[[i, j]] - g[[j, i]]).abs() < 1e-10,
+                    "G not symmetric at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn embed_scale_squares_into_covariance() {
+        let embed = identity_embed(4);
+        let g1 = estimate_covariance(&embed, 1.0, 4);
+        let g2 = estimate_covariance(&embed, 2.0, 4);
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!((g2[[i, j]] - 4.0 * g1[[i, j]]).abs() < 1e-10,
+                    "scale^2 law violated at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn subsampling_reduces_sample_count_not_shape() {
+        let embed = Array2::from_shape_fn((100, 4), |(v, _)| v as f32);
+        let g = estimate_covariance(&embed, 1.0, 10);
+        assert_eq!(g.shape(), [4, 4]);
+    }
+}

--- a/crates/larql-vindex/src/canonical/hilbertian.rs
+++ b/crates/larql-vindex/src/canonical/hilbertian.rs
@@ -39,12 +39,13 @@ pub fn commutator_residual(m: &Array2<f64>, j: &Array2<f64>) -> f64 {
 /// Map a query-head index to its KV-head index under grouped-query attention.
 /// `num_q_heads` must be a multiple of `num_kv_heads`.
 pub fn kv_head_for_query(query_head: usize, num_q_heads: usize, num_kv_heads: usize) -> usize {
-    let group = num_q_heads / num_kv_heads;
-    query_head / group.max(1)
+    let group = (num_q_heads / num_kv_heads.max(1)).max(1);
+    query_head / group
 }
 
 /// Extract head `head`'s `[head_dim, hidden]` block from a stacked projection
 /// matrix `[n*head_dim, hidden]` (PyTorch `[out, in]` orientation).
+/// Panics if `(head + 1) * head_dim` exceeds the number of rows in `proj`.
 pub fn head_block(proj: &Array2<f64>, head: usize, head_dim: usize) -> Array2<f64> {
     proj.slice(s![head * head_dim..(head + 1) * head_dim, ..]).to_owned()
 }
@@ -138,6 +139,12 @@ mod tests {
         assert_eq!(kv_head_for_query(2, 4, 4), 2);
         // Single kv head: everything maps to 0.
         assert_eq!(kv_head_for_query(7, 8, 1), 0);
+    }
+
+    #[test]
+    fn kv_head_for_query_handles_zero_kv_heads_without_panic() {
+        // Defensive: num_kv_heads == 0 must not divide-by-zero.
+        assert_eq!(kv_head_for_query(3, 8, 0), 0);
     }
 
     #[test]

--- a/crates/larql-vindex/src/canonical/hilbertian.rs
+++ b/crates/larql-vindex/src/canonical/hilbertian.rs
@@ -1,0 +1,99 @@
+//! Per-head "Hilbertian" residual: how close an attention head's query/key
+//! coupling is to being complex-linear w.r.t. the split-half complex
+//! structure J (J² = −I) that RoPE uses. See the plan doc for the math.
+
+use ndarray::Array2;
+
+/// Build the split-half complex structure J on R^n (n must be even):
+///   J e_i        =  e_{i+half}     for i in [0, half)
+///   J e_{i+half} = −e_i
+/// so that J·J = −I. Panics if n is odd.
+pub fn complex_structure_split_half(n: usize) -> Array2<f64> {
+    assert!(n.is_multiple_of(2), "complex structure requires even dimension, got {n}");
+    let half = n / 2;
+    let mut j = Array2::<f64>::zeros((n, n));
+    for i in 0..half {
+        j[[half + i, i]] = 1.0; // J e_i = e_{i+half}
+        j[[i, half + i]] = -1.0; // J e_{i+half} = -e_i
+    }
+    j
+}
+
+fn frob_norm(a: &Array2<f64>) -> f64 {
+    a.iter().map(|&x| x * x).sum::<f64>().sqrt()
+}
+
+/// Relative commutator residual ‖M J − J M‖_F / ‖M‖_F ∈ [0, 2].
+/// 0 ⟺ M commutes with J ⟺ M is complex-linear w.r.t. J.
+/// Returns 0.0 for the zero matrix (no division by zero).
+pub fn commutator_residual(m: &Array2<f64>, j: &Array2<f64>) -> f64 {
+    let comm = &m.dot(j) - &j.dot(m);
+    let den = frob_norm(m);
+    if den == 0.0 {
+        0.0
+    } else {
+        frob_norm(&comm) / den
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::{array, s};
+
+    #[test]
+    fn j_squares_to_negative_identity() {
+        let j = complex_structure_split_half(4);
+        let jj = j.dot(&j);
+        let neg_i = -Array2::<f64>::eye(4);
+        for i in 0..4 {
+            for k in 0..4 {
+                assert!((jj[[i, k]] - neg_i[[i, k]]).abs() < 1e-12,
+                    "J^2 != -I at ({i},{k})");
+            }
+        }
+    }
+
+    #[test]
+    fn realified_complex_matrix_has_zero_residual() {
+        // M = [[A, -B], [B, A]] (2x2 blocks) commutes with split-half J on R^4.
+        let a = array![[1.0, 2.0], [3.0, 4.0]];
+        let b = array![[5.0, 6.0], [7.0, 8.0]];
+        let mut m = Array2::<f64>::zeros((4, 4));
+        m.slice_mut(s![0..2, 0..2]).assign(&a);
+        m.slice_mut(s![0..2, 2..4]).assign(&(-&b));
+        m.slice_mut(s![2..4, 0..2]).assign(&b);
+        m.slice_mut(s![2..4, 2..4]).assign(&a);
+        let j = complex_structure_split_half(4);
+        assert!(commutator_residual(&m, &j) < 1e-12);
+    }
+
+    #[test]
+    fn diagonal_matrix_has_positive_residual() {
+        // diag(1,2,3,4) does not commute with J (it mixes paired coords).
+        let m = Array2::from_diag(&array![1.0, 2.0, 3.0, 4.0]);
+        let j = complex_structure_split_half(4);
+        assert!(commutator_residual(&m, &j) > 0.1);
+    }
+
+    #[test]
+    fn identity_has_zero_residual() {
+        let m = Array2::<f64>::eye(4);
+        let j = complex_structure_split_half(4);
+        assert!(commutator_residual(&m, &j) < 1e-12);
+    }
+
+    #[test]
+    fn zero_matrix_has_zero_residual_not_nan() {
+        let m = Array2::<f64>::zeros((4, 4));
+        let j = complex_structure_split_half(4);
+        let r = commutator_residual(&m, &j);
+        assert_eq!(r, 0.0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn odd_dimension_panics() {
+        let _ = complex_structure_split_half(3);
+    }
+}

--- a/crates/larql-vindex/src/canonical/hilbertian.rs
+++ b/crates/larql-vindex/src/canonical/hilbertian.rs
@@ -2,7 +2,7 @@
 //! coupling is to being complex-linear w.r.t. the split-half complex
 //! structure J (J² = −I) that RoPE uses. See the plan doc for the math.
 
-use ndarray::Array2;
+use ndarray::{s, Array2};
 
 /// Build the split-half complex structure J on R^n (n must be even):
 ///   J e_i        =  e_{i+half}     for i in [0, half)
@@ -34,6 +34,36 @@ pub fn commutator_residual(m: &Array2<f64>, j: &Array2<f64>) -> f64 {
     } else {
         frob_norm(&comm) / den
     }
+}
+
+/// Map a query-head index to its KV-head index under grouped-query attention.
+/// `num_q_heads` must be a multiple of `num_kv_heads`.
+pub fn kv_head_for_query(query_head: usize, num_q_heads: usize, num_kv_heads: usize) -> usize {
+    let group = num_q_heads / num_kv_heads;
+    query_head / group.max(1)
+}
+
+/// Extract head `head`'s `[head_dim, hidden]` block from a stacked projection
+/// matrix `[n*head_dim, hidden]` (PyTorch `[out, in]` orientation).
+pub fn head_block(proj: &Array2<f64>, head: usize, head_dim: usize) -> Array2<f64> {
+    proj.slice(s![head * head_dim..(head + 1) * head_dim, ..]).to_owned()
+}
+
+/// Per-head query/key coupling C = W_Q · W_Kᵀ, shape `[head_dim, head_dim]`.
+/// `wq_head` and `wk_head` are both `[head_dim, hidden]`.
+pub fn head_coupling(wq_head: &Array2<f64>, wk_head: &Array2<f64>) -> Array2<f64> {
+    wq_head.dot(&wk_head.t())
+}
+
+/// Hilbertian residual for one head: ‖[C, J]‖_F / ‖C‖_F where C = W_Q W_Kᵀ.
+/// `j` must be the split-half complex structure of dimension `head_dim`.
+pub fn head_hilbertian_residual(
+    wq_head: &Array2<f64>,
+    wk_head: &Array2<f64>,
+    j: &Array2<f64>,
+) -> f64 {
+    let c = head_coupling(wq_head, wk_head);
+    commutator_residual(&c, j)
 }
 
 #[cfg(test)]
@@ -95,5 +125,53 @@ mod tests {
     #[should_panic]
     fn odd_dimension_panics() {
         let _ = complex_structure_split_half(3);
+    }
+
+    #[test]
+    fn kv_head_for_query_maps_gqa_groups() {
+        // 15 query heads, 5 kv heads -> group size 3.
+        assert_eq!(kv_head_for_query(0, 15, 5), 0);
+        assert_eq!(kv_head_for_query(2, 15, 5), 0);
+        assert_eq!(kv_head_for_query(3, 15, 5), 1);
+        assert_eq!(kv_head_for_query(14, 15, 5), 4);
+        // No GQA (num_kv == num_q): identity.
+        assert_eq!(kv_head_for_query(2, 4, 4), 2);
+        // Single kv head: everything maps to 0.
+        assert_eq!(kv_head_for_query(7, 8, 1), 0);
+    }
+
+    #[test]
+    fn head_block_extracts_rows() {
+        // proj is [4, 3] = 2 heads of head_dim 2.
+        let proj = array![
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+            [10.0, 11.0, 12.0],
+        ];
+        let h0 = head_block(&proj, 0, 2);
+        let h1 = head_block(&proj, 1, 2);
+        assert_eq!(h0, array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        assert_eq!(h1, array![[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]);
+    }
+
+    #[test]
+    fn head_coupling_is_wq_times_wk_transpose() {
+        // wq, wk are [d_head=2, hidden=3]; C = wq · wkᵀ is [2,2].
+        let wq = array![[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        let wk = array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+        let c = head_coupling(&wq, &wk);
+        // row0·wkᵀ = [1,4]; row1·wkᵀ = [2,5]
+        assert_eq!(c, array![[1.0, 4.0], [2.0, 5.0]]);
+    }
+
+    #[test]
+    fn head_hilbertian_residual_matches_manual_composition() {
+        let wq = array![[1.0, 2.0, 0.0, 0.0], [0.0, 1.0, 1.0, 0.0]];
+        let wk = array![[0.0, 1.0, 2.0, 0.0], [1.0, 0.0, 0.0, 3.0]];
+        let j = complex_structure_split_half(2); // d_head = 2
+        let direct = head_hilbertian_residual(&wq, &wk, &j);
+        let manual = commutator_residual(&head_coupling(&wq, &wk), &j);
+        assert!((direct - manual).abs() < 1e-15);
     }
 }

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -1,2 +1,5 @@
 pub mod types;
 pub use types::{CanonicalMeta, LayerCanonicalInfo, Regime};
+
+pub mod covariance;
+pub use covariance::estimate_covariance;

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -9,3 +9,6 @@ pub use whitening::{compute_whitening, unpack_l, WhiteningData};
 
 pub mod onshell;
 pub use onshell::{compute_onshell_mask, onshell_stats};
+
+pub mod regime;
+pub use regime::classify_layer_regime;

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -1,0 +1,2 @@
+pub mod types;
+pub use types::{CanonicalMeta, LayerCanonicalInfo, Regime};

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -1,5 +1,7 @@
 pub mod types;
-pub use types::{CanonicalMeta, LayerCanonicalInfo, Regime};
+pub use types::{
+    CanonicalMeta, HeadHilbertianInfo, HilbertianMeta, LayerCanonicalInfo, Regime,
+};
 
 pub mod covariance;
 pub use covariance::estimate_covariance;

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -6,3 +6,6 @@ pub use covariance::estimate_covariance;
 
 pub mod whitening;
 pub use whitening::{compute_whitening, unpack_l, WhiteningData};
+
+pub mod onshell;
+pub use onshell::{compute_onshell_mask, onshell_stats};

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -3,3 +3,6 @@ pub use types::{CanonicalMeta, LayerCanonicalInfo, Regime};
 
 pub mod covariance;
 pub use covariance::estimate_covariance;
+
+pub mod whitening;
+pub use whitening::{compute_whitening, unpack_l, WhiteningData};

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -12,3 +12,6 @@ pub use onshell::{compute_onshell_mask, onshell_stats};
 
 pub mod regime;
 pub use regime::classify_layer_regime;
+
+pub mod hilbertian;
+pub use hilbertian::{commutator_residual, complex_structure_split_half};

--- a/crates/larql-vindex/src/canonical/mod.rs
+++ b/crates/larql-vindex/src/canonical/mod.rs
@@ -14,4 +14,7 @@ pub mod regime;
 pub use regime::classify_layer_regime;
 
 pub mod hilbertian;
-pub use hilbertian::{commutator_residual, complex_structure_split_half};
+pub use hilbertian::{
+    commutator_residual, complex_structure_split_half, head_block, head_coupling,
+    head_hilbertian_residual, kv_head_for_query,
+};

--- a/crates/larql-vindex/src/canonical/onshell.rs
+++ b/crates/larql-vindex/src/canonical/onshell.rs
@@ -1,0 +1,99 @@
+/// Compute a boolean on-shell mask for features in one layer.
+/// Features whose c_score ranks in the top `top_fraction` are on-shell.
+/// `top_fraction = 0.15` selects the top 15% factual features.
+///
+/// Returns a Vec<bool> of length equal to `c_scores`.
+/// Empty input returns an empty Vec.
+pub fn compute_onshell_mask(c_scores: &[f32], top_fraction: f32) -> Vec<bool> {
+    if c_scores.is_empty() {
+        return Vec::new();
+    }
+    let n = c_scores.len();
+    // At least 1 feature is always on-shell
+    let k = ((n as f32 * top_fraction).ceil() as usize).max(1).min(n);
+    // k-th largest threshold (descending sort)
+    let mut sorted: Vec<f32> = c_scores.to_vec();
+    sorted.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    let threshold = sorted[k - 1];
+    // Ties are included — may yield slightly more than k on-shell features
+    c_scores.iter().map(|&s| s >= threshold).collect()
+}
+
+/// Count on-shell features across all layers; returns (on_shell_count, total) per layer.
+pub fn onshell_stats(c_scores_per_layer: &[Vec<f32>], top_fraction: f32) -> Vec<(usize, usize)> {
+    c_scores_per_layer
+        .iter()
+        .map(|cscores| {
+            let mask = compute_onshell_mask(cscores, top_fraction);
+            let on_shell = mask.iter().filter(|&&b| b).count();
+            (on_shell, cscores.len())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_15pct_of_10_is_2() {
+        // 15% of 10 = 1.5 → ceil = 2
+        let scores: Vec<f32> = (0..10).map(|i| i as f32).collect();
+        let mask = compute_onshell_mask(&scores, 0.15);
+        let on_shell_indices: Vec<usize> =
+            mask.iter().enumerate().filter(|(_, &b)| b).map(|(i, _)| i).collect();
+        assert_eq!(on_shell_indices.len(), 2);
+        assert!(on_shell_indices.contains(&8));
+        assert!(on_shell_indices.contains(&9));
+    }
+
+    #[test]
+    fn empty_scores_returns_empty_mask() {
+        assert!(compute_onshell_mask(&[], 0.15).is_empty());
+    }
+
+    #[test]
+    fn single_feature_always_on_shell() {
+        let mask = compute_onshell_mask(&[0.5], 0.15);
+        assert_eq!(mask, vec![true]);
+    }
+
+    #[test]
+    fn mask_length_matches_input() {
+        let scores: Vec<f32> = (0..100).map(|i| i as f32 * 0.01).collect();
+        let mask = compute_onshell_mask(&scores, 0.15);
+        assert_eq!(mask.len(), 100);
+    }
+
+    #[test]
+    fn on_shell_count_is_at_least_top_fraction() {
+        let scores: Vec<f32> = (0..20).map(|i| i as f32).collect();
+        let mask = compute_onshell_mask(&scores, 0.15);
+        let count = mask.iter().filter(|&&b| b).count();
+        // 15% of 20 = 3
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn all_same_scores_all_on_shell() {
+        let scores = vec![1.0f32; 10];
+        let mask = compute_onshell_mask(&scores, 0.15);
+        assert!(mask.iter().all(|&b| b));
+    }
+
+    #[test]
+    fn onshell_stats_counts_per_layer() {
+        let layers = vec![
+            vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+            vec![],
+        ];
+        let stats = onshell_stats(&layers, 0.15);
+        assert_eq!(stats.len(), 2);
+        let (on, total) = stats[0];
+        assert_eq!(total, 10);
+        assert_eq!(on, 2);
+        let (on2, total2) = stats[1];
+        assert_eq!(total2, 0);
+        assert_eq!(on2, 0);
+    }
+}

--- a/crates/larql-vindex/src/canonical/regime.rs
+++ b/crates/larql-vindex/src/canonical/regime.rs
@@ -1,0 +1,85 @@
+use crate::canonical::types::Regime;
+
+const ACTIVE_FLOOR: f32 = 0.1;
+
+/// Classify the regime for a single layer.
+/// density = fraction of features with c_score > ACTIVE_FLOOR.
+///   - density > 0.5  → Wave
+///   - density < 0.05 → Particle
+///   - otherwise      → Wavelet
+/// Empty layer → (Wavelet, 0.0).
+pub fn classify_layer_regime(c_scores: &[f32]) -> (Regime, f32) {
+    if c_scores.is_empty() {
+        return (Regime::Wavelet, 0.0);
+    }
+    let active = c_scores.iter().filter(|&&s| s > ACTIVE_FLOOR).count();
+    let density = active as f32 / c_scores.len() as f32;
+    let regime = if density > 0.5 {
+        Regime::Wave
+    } else if density < 0.05 {
+        Regime::Particle
+    } else {
+        Regime::Wavelet
+    };
+    (regime, density)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dense_layer_is_wave() {
+        // 80% active
+        let scores: Vec<f32> = (0..10).map(|i| if i < 8 { 0.5 } else { 0.0 }).collect();
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wave);
+        assert!((density - 0.8).abs() < 1e-5);
+    }
+
+    #[test]
+    fn sparse_layer_is_particle() {
+        // 2% active
+        let mut scores = vec![0.0f32; 100];
+        scores[0] = 0.5;
+        scores[1] = 0.5;
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Particle);
+        assert!((density - 0.02).abs() < 1e-5);
+    }
+
+    #[test]
+    fn mid_density_is_wavelet() {
+        // 20% active
+        let mut scores = vec![0.0f32; 10];
+        for i in 0..2 { scores[i] = 0.5; }
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet);
+        assert!((density - 0.2).abs() < 1e-5);
+    }
+
+    #[test]
+    fn empty_layer_is_wavelet_density_zero() {
+        let (regime, density) = classify_layer_regime(&[]);
+        assert_eq!(regime, Regime::Wavelet);
+        assert_eq!(density, 0.0);
+    }
+
+    #[test]
+    fn boundary_at_0_5_is_wave() {
+        // density == 0.5, NOT > 0.5, so Wavelet
+        let scores: Vec<f32> = (0..10).map(|i| if i < 5 { 0.5 } else { 0.0 }).collect();
+        let (regime, _) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet, "density=0.5 is not > 0.5, should be Wavelet");
+    }
+
+    #[test]
+    fn boundary_at_0_05_is_wavelet() {
+        // density = 0.05, NOT < 0.05, so Wavelet
+        let mut scores = vec![0.0f32; 20];
+        scores[0] = 0.5; // 1/20 = 0.05
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet, "density=0.05 is not < 0.05, should be Wavelet");
+        assert!((density - 0.05).abs() < 1e-5);
+    }
+}

--- a/crates/larql-vindex/src/canonical/types.rs
+++ b/crates/larql-vindex/src/canonical/types.rs
@@ -1,0 +1,125 @@
+use serde::{Deserialize, Serialize};
+
+/// Wave/Particle/Wavelet activation regime for a transformer layer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Regime {
+    /// Dense activations — many weak gates fire (e.g., early syntax layers).
+    Wave,
+    /// Sparse activations — few strong gates fire (e.g., MoE knowledge layers).
+    Particle,
+    /// Mixed — multi-resolution, some wave structure, some particle selectivity.
+    Wavelet,
+}
+
+/// Per-layer canonical metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerCanonicalInfo {
+    pub layer: usize,
+    pub regime: Regime,
+    /// Number of features that pass the on-shell filter (top 15% by c_score).
+    pub on_shell_count: usize,
+    /// Total features at this layer.
+    pub total_features: usize,
+    /// Fraction of features with c_score > 0.1 (activation density proxy).
+    pub mean_density: f32,
+}
+
+/// Root canonical metadata written to `canonical_meta.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalMeta {
+    /// Format version; increment when the schema changes.
+    pub version: u32,
+    pub model: String,
+    pub family: String,
+    pub num_layers: usize,
+    pub hidden_size: usize,
+    /// Number of embedding rows sampled to estimate G.
+    pub covariance_sample_size: usize,
+    /// embed_scale used when computing G.
+    pub embed_scale: f32,
+    /// Cholesky factor L packed row-major lower-triangle:
+    /// indices (i,j) with j<=i stored as L[i*(i+1)/2 + j].
+    /// Length = hidden_size * (hidden_size + 1) / 2. Values are f64.
+    pub cholesky_l_packed: Vec<f64>,
+    /// Per-layer info.
+    pub layers: Vec<LayerCanonicalInfo>,
+}
+
+impl CanonicalMeta {
+    /// Unpack the lower-triangular Cholesky factor into a dense d×d matrix.
+    pub fn unpack_cholesky_l(&self) -> ndarray::Array2<f64> {
+        let d = self.hidden_size;
+        let mut l = ndarray::Array2::<f64>::zeros((d, d));
+        for i in 0..d {
+            for j in 0..=i {
+                l[[i, j]] = self.cholesky_l_packed[i * (i + 1) / 2 + j];
+            }
+        }
+        l
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regime_serialises_as_snake_case() {
+        assert_eq!(serde_json::to_string(&Regime::Wave).unwrap(), "\"wave\"");
+        assert_eq!(serde_json::to_string(&Regime::Particle).unwrap(), "\"particle\"");
+        assert_eq!(serde_json::to_string(&Regime::Wavelet).unwrap(), "\"wavelet\"");
+    }
+
+    #[test]
+    fn canonical_meta_round_trips_through_json() {
+        let meta = CanonicalMeta {
+            version: 1,
+            model: "test/model".into(),
+            family: "llama".into(),
+            num_layers: 2,
+            hidden_size: 4,
+            covariance_sample_size: 32,
+            embed_scale: 1.0,
+            // 4×4 lower triangle: 10 values
+            cholesky_l_packed: vec![1.0, 0.0, 2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0],
+            layers: vec![
+                LayerCanonicalInfo {
+                    layer: 0, regime: Regime::Wave,
+                    on_shell_count: 1, total_features: 4, mean_density: 0.75,
+                },
+                LayerCanonicalInfo {
+                    layer: 1, regime: Regime::Particle,
+                    on_shell_count: 1, total_features: 4, mean_density: 0.02,
+                },
+            ],
+        };
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        let back: CanonicalMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.family, "llama");
+        assert_eq!(back.layers[0].regime, Regime::Wave);
+        assert_eq!(back.layers[1].regime, Regime::Particle);
+        assert_eq!(back.cholesky_l_packed.len(), 10);
+    }
+
+    #[test]
+    fn unpack_cholesky_l_recovers_diagonal() {
+        // Packed lower-triangle of 3×3: [L00, L10, L11, L20, L21, L22]
+        let meta = CanonicalMeta {
+            version: 1, model: "x".into(), family: "y".into(),
+            num_layers: 1, hidden_size: 3,
+            covariance_sample_size: 8, embed_scale: 1.0,
+            cholesky_l_packed: vec![2.0, 1.0, 3.0, 4.0, 5.0, 6.0],
+            layers: vec![],
+        };
+        let l = meta.unpack_cholesky_l();
+        assert_eq!(l[[0, 0]], 2.0);
+        assert_eq!(l[[1, 0]], 1.0);
+        assert_eq!(l[[1, 1]], 3.0);
+        assert_eq!(l[[2, 0]], 4.0);
+        assert_eq!(l[[2, 1]], 5.0);
+        assert_eq!(l[[2, 2]], 6.0);
+        assert_eq!(l[[0, 1]], 0.0);
+        assert_eq!(l[[0, 2]], 0.0);
+    }
+}

--- a/crates/larql-vindex/src/canonical/types.rs
+++ b/crates/larql-vindex/src/canonical/types.rs
@@ -73,6 +73,32 @@ impl CanonicalMeta {
     }
 }
 
+/// Per-head Hilbertian residual: how close head `query_head`'s query/key
+/// coupling is to complex-linear w.r.t. the split-half complex structure.
+/// `residual` ∈ [0, 2]; 0 = exactly complex-linear (an upper bound on the
+/// optimal-J residual).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeadHilbertianInfo {
+    pub layer: usize,
+    pub query_head: usize,
+    pub kv_head: usize,
+    pub residual: f64,
+}
+
+/// Root metadata written to `hilbertian_meta.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HilbertianMeta {
+    pub version: u32,
+    pub model: String,
+    pub hidden_size: usize,
+    pub head_dim: usize,
+    pub num_q_heads: usize,
+    pub num_kv_heads: usize,
+    /// The fixed complex-structure convention used (currently always "split_half").
+    pub complex_structure: String,
+    pub heads: Vec<HeadHilbertianInfo>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -148,5 +174,29 @@ mod tests {
         };
         assert!(meta.unpack_cholesky_l().is_err(),
             "truncated packing must Err, not panic");
+    }
+
+    #[test]
+    fn hilbertian_meta_round_trips_through_json() {
+        let meta = HilbertianMeta {
+            version: 1,
+            model: "test/model".into(),
+            hidden_size: 4,
+            head_dim: 2,
+            num_q_heads: 2,
+            num_kv_heads: 1,
+            complex_structure: "split_half".into(),
+            heads: vec![
+                HeadHilbertianInfo { layer: 0, query_head: 0, kv_head: 0, residual: 0.0 },
+                HeadHilbertianInfo { layer: 0, query_head: 1, kv_head: 0, residual: 1.25 },
+            ],
+        };
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        let back: HilbertianMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.model, "test/model");
+        assert_eq!(back.heads.len(), 2);
+        assert_eq!(back.heads[1].query_head, 1);
+        assert!((back.heads[1].residual - 1.25).abs() < 1e-15);
+        assert_eq!(back.complex_structure, "split_half");
     }
 }

--- a/crates/larql-vindex/src/canonical/types.rs
+++ b/crates/larql-vindex/src/canonical/types.rs
@@ -48,15 +48,28 @@ pub struct CanonicalMeta {
 
 impl CanonicalMeta {
     /// Unpack the lower-triangular Cholesky factor into a dense d×d matrix.
-    pub fn unpack_cholesky_l(&self) -> ndarray::Array2<f64> {
+    ///
+    /// Returns `Err` if `cholesky_l_packed` is not exactly `d·(d+1)/2` long
+    /// (e.g. a truncated or mismatched `canonical_meta.json`), rather than
+    /// panicking on an out-of-bounds index.
+    pub fn unpack_cholesky_l(&self) -> Result<ndarray::Array2<f64>, String> {
         let d = self.hidden_size;
+        let expected = d * (d + 1) / 2;
+        if self.cholesky_l_packed.len() != expected {
+            return Err(format!(
+                "cholesky_l_packed length {} does not match hidden_size {} (expected {})",
+                self.cholesky_l_packed.len(),
+                d,
+                expected
+            ));
+        }
         let mut l = ndarray::Array2::<f64>::zeros((d, d));
         for i in 0..d {
             for j in 0..=i {
                 l[[i, j]] = self.cholesky_l_packed[i * (i + 1) / 2 + j];
             }
         }
-        l
+        Ok(l)
     }
 }
 
@@ -112,7 +125,7 @@ mod tests {
             cholesky_l_packed: vec![2.0, 1.0, 3.0, 4.0, 5.0, 6.0],
             layers: vec![],
         };
-        let l = meta.unpack_cholesky_l();
+        let l = meta.unpack_cholesky_l().unwrap();
         assert_eq!(l[[0, 0]], 2.0);
         assert_eq!(l[[1, 0]], 1.0);
         assert_eq!(l[[1, 1]], 3.0);
@@ -121,5 +134,19 @@ mod tests {
         assert_eq!(l[[2, 2]], 6.0);
         assert_eq!(l[[0, 1]], 0.0);
         assert_eq!(l[[0, 2]], 0.0);
+    }
+
+    #[test]
+    fn unpack_cholesky_l_rejects_malformed_packing() {
+        // hidden_size=3 expects 6 packed entries; supply only 5.
+        let meta = CanonicalMeta {
+            version: 1, model: "x".into(), family: "y".into(),
+            num_layers: 1, hidden_size: 3,
+            covariance_sample_size: 8, embed_scale: 1.0,
+            cholesky_l_packed: vec![2.0, 1.0, 3.0, 4.0, 5.0],
+            layers: vec![],
+        };
+        assert!(meta.unpack_cholesky_l().is_err(),
+            "truncated packing must Err, not panic");
     }
 }

--- a/crates/larql-vindex/src/canonical/whitening.rs
+++ b/crates/larql-vindex/src/canonical/whitening.rs
@@ -1,0 +1,120 @@
+use ndarray::Array2;
+
+use larql_compute::cholesky;
+pub use larql_compute::{back_solve_lt, compute_l_inv_t};
+
+const DEFAULT_RIDGE: f64 = 1e-5;
+
+/// Cholesky whitening data computed from a covariance matrix G.
+pub struct WhiteningData {
+    /// Lower triangular Cholesky factor L such that G ≈ L L^T (with ridge).
+    pub l: Array2<f64>,
+    /// Packed lower triangle: entry (i,j) with j<=i at index i*(i+1)/2 + j.
+    pub l_packed: Vec<f64>,
+}
+
+/// Compute the Cholesky factor of G and pack it for storage.
+pub fn compute_whitening(g: &Array2<f64>) -> Result<WhiteningData, String> {
+    let l = cholesky(g, DEFAULT_RIDGE)?;
+    let d = l.shape()[0];
+    let mut l_packed = Vec::with_capacity(d * (d + 1) / 2);
+    for i in 0..d {
+        for j in 0..=i {
+            l_packed.push(l[[i, j]]);
+        }
+    }
+    Ok(WhiteningData { l, l_packed })
+}
+
+/// Unpack a lower-triangle-packed Cholesky factor to a dense d×d matrix.
+pub fn unpack_l(packed: &[f64], d: usize) -> Array2<f64> {
+    let mut l = Array2::<f64>::zeros((d, d));
+    for i in 0..d {
+        for j in 0..=i {
+            l[[i, j]] = packed[i * (i + 1) / 2 + j];
+        }
+    }
+    l
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn spd_3x3() -> Array2<f64> {
+        let data = vec![4.0_f64, 2.0, 1.0, 2.0, 5.0, 3.0, 1.0, 3.0, 6.0];
+        Array2::from_shape_vec((3, 3), data).unwrap()
+    }
+
+    #[test]
+    fn cholesky_recovers_g() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        let reconstructed = wd.l.dot(&wd.l.t());
+        for i in 0..3 {
+            for j in 0..3 {
+                let expected = g[[i, j]] + if i == j { 1e-5 } else { 0.0 };
+                assert!((reconstructed[[i, j]] - expected).abs() < 1e-8,
+                    "L L^T differs from G+ridge at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn l_is_lower_triangular() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        for i in 0..3 {
+            for j in (i + 1)..3 {
+                assert_eq!(wd.l[[i, j]], 0.0, "upper triangle not zero at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn l_packed_length_is_triangular_number() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        assert_eq!(wd.l_packed.len(), 3 * 4 / 2); // 6
+    }
+
+    #[test]
+    fn unpack_roundtrips_packed() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        let l2 = unpack_l(&wd.l_packed, 3);
+        for i in 0..3 {
+            for j in 0..3 {
+                assert!((l2[[i, j]] - wd.l[[i, j]]).abs() < 1e-14,
+                    "unpack mismatch at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn whitening_makes_mahalanobis_a_dot_product() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        // L^{-T} is what we get; transpose to get L^{-1}
+        let l_inv_t = compute_l_inv_t(&wd.l);
+        let l_inv = l_inv_t.t().to_owned();
+
+        let g_vec = Array2::from_shape_vec((3, 1), vec![1.0f64, 2.0, 3.0]).unwrap();
+        let h_vec = Array2::from_shape_vec((3, 1), vec![4.0f64, 5.0, 6.0]).unwrap();
+
+        let g_tilde = l_inv.dot(&g_vec);
+        let h_tilde = l_inv.dot(&h_vec);
+
+        let dot_whitened: f64 = (0..3).map(|i| g_tilde[[i, 0]] * h_tilde[[i, 0]]).sum();
+
+        let g_inv = larql_compute::cholesky_inverse(&wd.l);
+        let mahal: f64 = {
+            let tmp = g_inv.dot(&h_vec);
+            (0..3).map(|i| g_vec[[i, 0]] * tmp[[i, 0]]).sum()
+        };
+
+        assert!((dot_whitened - mahal).abs() < 1e-8,
+            "whitened dot={dot_whitened} mahal={mahal}");
+    }
+}

--- a/crates/larql-vindex/src/canonical/whitening.rs
+++ b/crates/larql-vindex/src/canonical/whitening.rs
@@ -27,7 +27,17 @@ pub fn compute_whitening(g: &Array2<f64>) -> Result<WhiteningData, String> {
 }
 
 /// Unpack a lower-triangle-packed Cholesky factor to a dense d×d matrix.
+///
+/// Panics with a clear message (rather than a cryptic out-of-bounds index) if
+/// `packed.len()` is not exactly `d·(d+1)/2`.
 pub fn unpack_l(packed: &[f64], d: usize) -> Array2<f64> {
+    assert_eq!(
+        packed.len(),
+        d * (d + 1) / 2,
+        "unpack_l: packed length {} does not match d={d} (expected {})",
+        packed.len(),
+        d * (d + 1) / 2
+    );
     let mut l = Array2::<f64>::zeros((d, d));
     for i in 0..d {
         for j in 0..=i {

--- a/crates/larql-vindex/src/format/attn_load.rs
+++ b/crates/larql-vindex/src/format/attn_load.rs
@@ -81,6 +81,12 @@ fn read_entry(bin: &[u8], e: &ManifestEntry) -> Result<Array2<f32>, VindexError>
     if n == 0 {
         return Err(VindexError::Parse(format!("entry {} is empty", e.key)));
     }
+    if !e.length.is_multiple_of(n) {
+        return Err(VindexError::Parse(format!(
+            "entry {} byte length {} is not a multiple of element count {n}",
+            e.key, e.length
+        )));
+    }
     let dtype = match e.length / n {
         4 => StorageDtype::F32,
         2 => StorageDtype::F16,
@@ -91,7 +97,9 @@ fn read_entry(bin: &[u8], e: &ManifestEntry) -> Result<Array2<f32>, VindexError>
             )))
         }
     };
-    let end = e.offset + e.length;
+    let end = e.offset.checked_add(e.length).ok_or_else(|| {
+        VindexError::Parse(format!("entry {} offset+length overflows usize", e.key))
+    })?;
     if end > bin.len() {
         return Err(VindexError::Parse(format!(
             "entry {} range {}..{end} exceeds {ATTN_WEIGHTS_BIN} ({} bytes)",

--- a/crates/larql-vindex/src/format/attn_load.rs
+++ b/crates/larql-vindex/src/format/attn_load.rs
@@ -1,0 +1,158 @@
+//! Manifest-driven reader for per-layer attention Q/K weight matrices.
+//!
+//! `attn_weights.bin` is a header-less concatenation of tensors; offsets and
+//! shapes come from `weight_manifest.json` (a top-level JSON array). We read
+//! only the `q_proj` / `k_proj` tensors — no tokenizer, no forward pass, and
+//! no full-model load.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use ndarray::Array2;
+use serde::Deserialize;
+
+use crate::config::dtype::{decode_floats, StorageDtype};
+use crate::error::VindexError;
+use crate::format::filenames::{ATTN_WEIGHTS_BIN, WEIGHT_MANIFEST_JSON};
+
+#[derive(Deserialize)]
+struct ManifestEntry {
+    key: String,
+    shape: Vec<usize>,
+    offset: usize,
+    length: usize,
+    file: String,
+}
+
+/// A `(W_Q, W_K)` pair for one transformer layer.
+pub type QkPair = (Array2<f32>, Array2<f32>);
+
+/// Load per-layer `(W_Q, W_K)` from `attn_weights.bin`.
+/// `W_Q` is `[num_q_heads*head_dim, hidden]`, `W_K` is `[num_kv_heads*head_dim, hidden]`,
+/// both as `f32` (decoded from on-disk f16/f32). Index in the returned Vec is the layer.
+pub fn load_attention_qk(
+    dir: &Path,
+    num_layers: usize,
+) -> Result<Vec<QkPair>, VindexError> {
+    let manifest_bytes = std::fs::read(dir.join(WEIGHT_MANIFEST_JSON))?;
+    let entries: Vec<ManifestEntry> = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| VindexError::Parse(format!("weight_manifest.json: {e}")))?;
+    let by_key: HashMap<&str, &ManifestEntry> =
+        entries.iter().map(|e| (e.key.as_str(), e)).collect();
+
+    let bin = std::fs::read(dir.join(ATTN_WEIGHTS_BIN))?;
+
+    let mut out = Vec::with_capacity(num_layers);
+    for layer in 0..num_layers {
+        let q_key = format!("layers.{layer}.self_attn.q_proj.weight");
+        let k_key = format!("layers.{layer}.self_attn.k_proj.weight");
+        let wq = read_entry(&bin, lookup(&by_key, &q_key)?)?;
+        let wk = read_entry(&bin, lookup(&by_key, &k_key)?)?;
+        out.push((wq, wk));
+    }
+    Ok(out)
+}
+
+fn lookup<'a>(
+    by_key: &HashMap<&str, &'a ManifestEntry>,
+    key: &str,
+) -> Result<&'a ManifestEntry, VindexError> {
+    by_key
+        .get(key)
+        .copied()
+        .ok_or_else(|| VindexError::Parse(format!("weight_manifest.json missing key {key}")))
+}
+
+fn read_entry(bin: &[u8], e: &ManifestEntry) -> Result<Array2<f32>, VindexError> {
+    if e.file != ATTN_WEIGHTS_BIN {
+        return Err(VindexError::Parse(format!(
+            "entry {} is in {}, expected {ATTN_WEIGHTS_BIN}",
+            e.key, e.file
+        )));
+    }
+    if e.shape.len() != 2 {
+        return Err(VindexError::Parse(format!(
+            "entry {} has non-2D shape {:?}",
+            e.key, e.shape
+        )));
+    }
+    let (rows, cols) = (e.shape[0], e.shape[1]);
+    let n = rows * cols;
+    if n == 0 {
+        return Err(VindexError::Parse(format!("entry {} is empty", e.key)));
+    }
+    let dtype = match e.length / n {
+        4 => StorageDtype::F32,
+        2 => StorageDtype::F16,
+        other => {
+            return Err(VindexError::Parse(format!(
+                "entry {} has {other} bytes/elem (expected 2 or 4)",
+                e.key
+            )))
+        }
+    };
+    let end = e.offset + e.length;
+    if end > bin.len() {
+        return Err(VindexError::Parse(format!(
+            "entry {} range {}..{end} exceeds {ATTN_WEIGHTS_BIN} ({} bytes)",
+            e.key,
+            e.offset,
+            bin.len()
+        )));
+    }
+    let floats = decode_floats(&bin[e.offset..end], dtype);
+    Array2::from_shape_vec((rows, cols), floats)
+        .map_err(|e| VindexError::Parse(format!("reshape attention weight: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_qk_from_a_synthetic_vindex() {
+        let dir = tempfile::tempdir().unwrap();
+        // Two f32 tensors: q_proj [2,2] then k_proj [2,2], concatenated.
+        let q: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
+        let k: [f32; 4] = [5.0, 6.0, 7.0, 8.0];
+        let mut bin = Vec::new();
+        for v in q.iter().chain(k.iter()) {
+            bin.extend_from_slice(&v.to_le_bytes());
+        }
+        std::fs::write(dir.path().join(ATTN_WEIGHTS_BIN), &bin).unwrap();
+
+        let manifest = serde_json::json!([
+            {"key": "layers.0.self_attn.q_proj.weight", "shape": [2, 2],
+             "offset": 0, "length": 16, "file": ATTN_WEIGHTS_BIN},
+            {"key": "layers.0.self_attn.k_proj.weight", "shape": [2, 2],
+             "offset": 16, "length": 16, "file": ATTN_WEIGHTS_BIN}
+        ]);
+        std::fs::write(
+            dir.path().join(WEIGHT_MANIFEST_JSON),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let qk = load_attention_qk(dir.path(), 1).unwrap();
+        assert_eq!(qk.len(), 1);
+        let (wq, wk) = &qk[0];
+        assert_eq!(wq.shape(), [2, 2]);
+        assert_eq!(wk.shape(), [2, 2]);
+        assert_eq!(wq[[0, 0]], 1.0);
+        assert_eq!(wq[[1, 1]], 4.0);
+        assert_eq!(wk[[0, 0]], 5.0);
+        assert_eq!(wk[[1, 1]], 8.0);
+    }
+
+    #[test]
+    fn missing_key_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(ATTN_WEIGHTS_BIN), [0u8; 16]).unwrap();
+        std::fs::write(
+            dir.path().join(WEIGHT_MANIFEST_JSON),
+            serde_json::to_vec(&serde_json::json!([])).unwrap(),
+        )
+        .unwrap();
+        assert!(load_attention_qk(dir.path(), 1).is_err());
+    }
+}

--- a/crates/larql-vindex/src/format/down_meta.rs
+++ b/crates/larql-vindex/src/format/down_meta.rs
@@ -220,6 +220,8 @@ pub fn read_cscores_binary(dir: &Path) -> Result<Vec<Vec<f32>>, VindexError> {
     // top_k_count × (u32 token_id + f32 logit) = top_k_count × 8 bytes
     let skip_per_feature = top_k_count * (U32_BYTES + F32_BYTES);
 
+    // Reused across every feature; `skip_per_feature` is constant.
+    let mut skip_buf = vec![0u8; skip_per_feature];
     let mut result = Vec::with_capacity(num_layers);
     for _ in 0..num_layers {
         let num_features = read_u32(&mut r)? as usize;
@@ -233,7 +235,6 @@ pub fn read_cscores_binary(dir: &Path) -> Result<Vec<Vec<f32>>, VindexError> {
             let c_score = read_f32(&mut r)?;
             cscores.push(c_score);
             // Skip the top_k entries
-            let mut skip_buf = vec![0u8; skip_per_feature];
             r.read_exact(&mut skip_buf)?;
         }
         result.push(cscores);

--- a/crates/larql-vindex/src/format/down_meta.rs
+++ b/crates/larql-vindex/src/format/down_meta.rs
@@ -195,6 +195,52 @@ pub fn read_binary(
     Ok((down_meta, total))
 }
 
+/// Read only c_scores from down_meta.bin — no tokenizer needed.
+/// Returns one Vec<f32> per layer; layers with no features yield an empty Vec.
+pub fn read_cscores_binary(dir: &Path) -> Result<Vec<Vec<f32>>, VindexError> {
+    let path = dir.join(DOWN_META_BIN);
+    let file = std::fs::File::open(&path)?;
+    let mut r = BufReader::new(file);
+
+    let magic = read_u32(&mut r)?;
+    if magic != MAGIC && magic != LEGACY_LITERAL_MAGIC {
+        return Err(VindexError::Parse(format!(
+            "invalid down_meta.bin magic: 0x{magic:08X}"
+        )));
+    }
+    let version = read_u32(&mut r)?;
+    if version != FORMAT_VERSION {
+        return Err(VindexError::Parse(format!(
+            "unsupported down_meta.bin version: {version}"
+        )));
+    }
+    let num_layers = read_u32(&mut r)? as usize;
+    let top_k_count = read_u32(&mut r)? as usize;
+    // Bytes to skip per feature after reading top_token_id + c_score:
+    // top_k_count × (u32 token_id + f32 logit) = top_k_count × 8 bytes
+    let skip_per_feature = top_k_count * (U32_BYTES + F32_BYTES);
+
+    let mut result = Vec::with_capacity(num_layers);
+    for _ in 0..num_layers {
+        let num_features = read_u32(&mut r)? as usize;
+        if num_features == 0 {
+            result.push(Vec::new());
+            continue;
+        }
+        let mut cscores = Vec::with_capacity(num_features);
+        for _ in 0..num_features {
+            let _top_token_id = read_u32(&mut r)?;
+            let c_score = read_f32(&mut r)?;
+            cscores.push(c_score);
+            // Skip the top_k entries
+            let mut skip_buf = vec![0u8; skip_per_feature];
+            r.read_exact(&mut skip_buf)?;
+        }
+        result.push(cscores);
+    }
+    Ok(result)
+}
+
 /// Check if a binary down_meta.bin exists in the directory.
 pub fn has_binary(dir: &Path) -> bool {
     dir.join(DOWN_META_BIN).exists()
@@ -285,4 +331,40 @@ fn read_f32<R: Read>(r: &mut R) -> Result<f32, VindexError> {
     let mut buf = [0u8; 4];
     r.read_exact(&mut buf)?;
     Ok(f32::from_le_bytes(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_cscores_binary_matches_full_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta: Vec<Option<Vec<Option<FeatureMeta>>>> = vec![
+            Some(vec![
+                Some(FeatureMeta {
+                    top_token: "hello".into(),
+                    top_token_id: 1,
+                    c_score: 3.5,
+                    top_k: vec![larql_models::TopKEntry {
+                        token: "hello".into(), token_id: 1, logit: 3.5,
+                    }],
+                }),
+                Some(FeatureMeta {
+                    top_token: "world".into(),
+                    top_token_id: 2,
+                    c_score: 1.2,
+                    top_k: vec![larql_models::TopKEntry {
+                        token: "world".into(), token_id: 2, logit: 1.2,
+                    }],
+                }),
+            ]),
+            None,
+        ];
+        write_binary(dir.path(), &meta, 1).unwrap();
+        let cscores = read_cscores_binary(dir.path()).unwrap();
+        assert_eq!(cscores.len(), 2);
+        assert_eq!(cscores[0], vec![3.5f32, 1.2f32]);
+        assert!(cscores[1].is_empty(), "None layer should give empty vec");
+    }
 }

--- a/crates/larql-vindex/src/format/filenames.rs
+++ b/crates/larql-vindex/src/format/filenames.rs
@@ -22,6 +22,7 @@ pub const MODEL_WEIGHTS_BIN: &str = "model_weights.bin";
 
 // ── Canonical form sidecar ──────────────────────────────────────────────
 pub const CANONICAL_META_JSON: &str = "canonical_meta.json";
+pub const HILBERTIAN_META_JSON: &str = "hilbertian_meta.json";
 
 // ── Labels / clustering sidecars ───────────────────────────────────────
 pub const RELATION_CLUSTERS_JSON: &str = "relation_clusters.json";
@@ -295,6 +296,7 @@ mod tests {
             KNN_STORE_BIN,
             MODEL_WEIGHTS_BIN,
             CANONICAL_META_JSON,
+            HILBERTIAN_META_JSON,
             RELATION_CLUSTERS_JSON,
             FEATURE_CLUSTERS_JSONL,
             FEATURE_LABELS_JSON,
@@ -522,5 +524,11 @@ mod tests {
                 "CANONICAL_META_JSON collides with {name}");
         }
         assert_eq!(CANONICAL_META_JSON, "canonical_meta.json");
+    }
+
+    #[test]
+    fn hilbertian_meta_json_is_distinct_from_canonical() {
+        assert_ne!(HILBERTIAN_META_JSON, CANONICAL_META_JSON);
+        assert_eq!(HILBERTIAN_META_JSON, "hilbertian_meta.json");
     }
 }

--- a/crates/larql-vindex/src/format/filenames.rs
+++ b/crates/larql-vindex/src/format/filenames.rs
@@ -20,6 +20,9 @@ pub const WEIGHT_MANIFEST_JSON: &str = "weight_manifest.json";
 pub const KNN_STORE_BIN: &str = "knn_store.bin";
 pub const MODEL_WEIGHTS_BIN: &str = "model_weights.bin";
 
+// ── Canonical form sidecar ──────────────────────────────────────────────
+pub const CANONICAL_META_JSON: &str = "canonical_meta.json";
+
 // ── Labels / clustering sidecars ───────────────────────────────────────
 pub const RELATION_CLUSTERS_JSON: &str = "relation_clusters.json";
 pub const FEATURE_CLUSTERS_JSONL: &str = "feature_clusters.jsonl";
@@ -291,6 +294,7 @@ mod tests {
             WEIGHT_MANIFEST_JSON,
             KNN_STORE_BIN,
             MODEL_WEIGHTS_BIN,
+            CANONICAL_META_JSON,
             RELATION_CLUSTERS_JSON,
             FEATURE_CLUSTERS_JSONL,
             FEATURE_LABELS_JSON,
@@ -505,5 +509,18 @@ mod tests {
         std::fs::remove_file(dir.path().join(LEGACY_DOWN_FEATURES_Q4K_BIN)).unwrap();
         std::fs::write(dir.path().join(DOWN_FEATURES_KQUANT_BIN), b"x").unwrap();
         assert!(has_kquant_down_features(dir.path()));
+    }
+
+    #[test]
+    fn canonical_meta_json_is_unique() {
+        let existing = [
+            INDEX_JSON, TOKENIZER_JSON, TOKENIZER_CONFIG_JSON, GENERATION_CONFIG_JSON,
+            WEIGHT_MANIFEST_JSON, EMBEDDINGS_BIN, NORMS_BIN, GATE_VECTORS_BIN, DOWN_META_BIN,
+        ];
+        for name in existing {
+            assert_ne!(CANONICAL_META_JSON, name,
+                "CANONICAL_META_JSON collides with {name}");
+        }
+        assert_eq!(CANONICAL_META_JSON, "canonical_meta.json");
     }
 }

--- a/crates/larql-vindex/src/format/mod.rs
+++ b/crates/larql-vindex/src/format/mod.rs
@@ -1,6 +1,7 @@
 //! File format I/O — vindex loading, saving, checksums, HuggingFace.
 //! Model loading (safetensors/GGUF) is in larql-models.
 
+pub mod attn_load;
 pub mod checksums;
 pub mod down_meta;
 pub mod filenames;

--- a/crates/larql-vindex/src/lib.rs
+++ b/crates/larql-vindex/src/lib.rs
@@ -54,7 +54,9 @@ pub use tokenizers;
 // ── Re-export essentials at crate root ──
 
 // Canonical
-pub use canonical::{CanonicalMeta, LayerCanonicalInfo, Regime};
+pub use canonical::{
+    CanonicalMeta, HeadHilbertianInfo, HilbertianMeta, LayerCanonicalInfo, Regime,
+};
 
 // Config
 pub use config::dtype::StorageDtype;

--- a/crates/larql-vindex/src/lib.rs
+++ b/crates/larql-vindex/src/lib.rs
@@ -25,6 +25,7 @@
 // BLAS provided by larql-compute dependency (no direct blas_src needed)
 
 // ── Module structure ──
+pub mod canonical;
 pub mod clustering;
 pub mod config;
 pub mod describe;
@@ -51,6 +52,9 @@ pub use ndarray;
 pub use tokenizers;
 
 // ── Re-export essentials at crate root ──
+
+// Canonical
+pub use canonical::{CanonicalMeta, LayerCanonicalInfo, Regime};
 
 // Config
 pub use config::dtype::StorageDtype;

--- a/docs/QLM-ROADMAP.md
+++ b/docs/QLM-ROADMAP.md
@@ -1,0 +1,167 @@
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+Copyright © 2026 Ian Douglas Lawrence Norman McLean.
+Licensed under the Creative Commons Attribution-ShareAlike 4.0 International
+License (CC BY-SA 4.0): https://creativecommons.org/licenses/by-sa/4.0/
+
+This is the QLM (Quantum Language Model) roadmap. It is a SEPARATE work from the
+LARQL project roadmap (`ROADMAP.md`), which has its own authorship and license
+and is left unmodified.
+-->
+
+# QLM Roadmap — Quantum Language Models for LARQL
+
+> **Copyright © 2026 Ian Douglas Lawrence Norman McLean · CC BY-SA 4.0.**
+> Distinct from the upstream `ROADMAP.md` (unmodified). Per-phase code lives in
+> the `larql-hilbert` crate and is cross-referenced to its PRs/issues below.
+
+This roadmap tracks the **quantum language model** line: the Hilbert-space
+formalization of language models, the minimal canonical quantum LM, and the
+classical-vs-quantum compressibility programme — built as the pure-Rust leaf
+crate `larql-hilbert` (deps: `ndarray` + `num-complex`; no BLAS), kept portable
+toward the `wasm32v1-none` minimal-LM target.
+
+---
+
+## Purpose (load-bearing — read first)
+
+A **vindex** is a queryable weight database (the object language / the data); an
+**LQL** operation is a process over it (the metalanguage / the query). The QLM
+line asks what these become at the Hilbert-space limit:
+
+- **State** = a (projective) Hilbert-space point — a qubit on the Bloch sphere
+  (`ℂP¹`) at the minimal scale.
+- **Readout** = the Born rule — a *measurement*, which (per the constructive
+  reading) is the **elimination rule** of the linear, no-cloning fragment, not a
+  new primitive.
+- **Evolution** = unitary (SU(2)/SU(2ⁿ)) gates — norm-preserving, the
+  conservative idealization of the residual-stream update.
+- **Canonical form** = the gauge-fixed representative (the dagger/metric, then
+  the projective quotient) — the same canonicalization the `larql canonicalize`
+  pipeline performs, at minimal scale.
+
+The minimal quantum LM is the **single qubit**; the place classical structure
+fails is the **Bell point** (two qubits stop factoring, `A⊗B ≠ A×B`); the
+asymptotic regime is **GHZ / W** (3+ qubits). The unifying claim is that the
+**classical/quantum compressibility gap of a vindex is denominated in ebits**,
+with **superdense coding** as the operational unit and the **entanglement
+entropy** as the measured quantity.
+
+## Theoretical frame (the four pillars)
+
+1. **Categorical quantum mechanics / the dagger.** Canonicalization is choosing
+   the dagger (the inner product), lifting `FdVect → FdHilb`; it reduces the
+   gauge group `GL(n) → U(n)/O(n)` (why cross-model alignment is Procrustes).
+   The token vocabulary is the classical structure; the hidden space is the
+   basis-free quantum object. (Baez & Stay, *Rosetta Stone*; Abramsky & Coecke.)
+2. **Zizzi quantum metalanguage.** Assertions carry **complex assertion degrees**
+   (amplitudes); Sambin's reflection turns metalinguistic bonds into the
+   object-language **superposition connective** (logic `Lq`). Maps onto
+   LQL (metalanguage) / vindex (object language); the single-qubit LM is an
+   operational model of `Lq`; entanglement is the non-factorizing bond.
+   (Zizzi, arXiv:1003.5976.)
+3. **Rosko admissibility.** Admissible measurement = finite extraction ⊆
+   **Σ⁰₁ ∪ Π⁰₂** (Δ₀-decidable core), via realizability over Heyting Arithmetic.
+   This is the *finiteness filter on Zizzi's metalanguage* — the
+   `admissibility` module (Δ₀/Σ⁰₁/Π⁰₂) is its implementation; the ⊥ outcome
+   (`project → None`, `score → −∞`) is the degree-0 / uninhabited assertion.
+   (Rosko, arXiv:2511.21296.)
+4. **Superdense coding & compressibility.** One ebit ↔ the 2-bit dense-coding
+   gain; the classical/quantum vindex compressibility ratio is set by the
+   entanglement entropy in ebits. Weight-matrix spectra are heavy-tailed
+   (Martin–Mahoney HTSR), which is why *lossy ≫ lossless* and the on-shell Zipf
+   head carries the function. (Bennett–Wiesner; Schumacher.)
+
+---
+
+## Phases (critical path)
+
+Status legend: ✅ done (PR open in `metavacua/larql-to-sparql`), 🔄 in progress,
+⬜ planned, 🔬 research.
+
+### Phase 0 — Hilbert-space foundation ✅ (PR #137)
+Complex structure `J` (`J²=−I`), commutator residual, the unifying theorem
+`commutator_residual = 2·antilinear_fraction`, the real↔complex (`realify` /
+`complex_parts`) bridge, and the **Hilbertian residual** — a per-attention-head,
+weights-only score of complex-linearity. *Result:* on SmolLM2, residuals
+0.45–1.46 (discriminating); the metric doubles as a **quantum-compressibility
+meter** (residual 0 ⇒ 2× complex-compressible). Built on the canonical pipeline
+(PR #133).
+
+### Phase 1 — Single-qubit Bloch LM ✅ (PR #138)
+`Qubit` + Bloch coordinates (`ℂP¹`), SU(2) gates, Born readout, `SingleQubitLM`
+(2-token vocab, collapse-then-unitary, autoregressive `score`/`generate`).
+With projective collapse it reduces to a first-order Markov chain — the boundary
+where quantum = classical, hence the right *minimal* object.
+
+### Phase 2 — Constructive measurement + admissibility ✅ (PR #139)
+`measurement::project` (elimination rule; `None` = ⊥), `LinearQubit` (no-cloning
+via Rust move semantics), and `admissibility` (Δ₀ `is_realizable`, Σ⁰₁
+`exists_continuation`, Π⁰₂ `uniformly_stable`). Implements the Rosko filter on
+the Zizzi metalanguage; the integration test pins `⊥ ≅ −∞`.
+
+### Phase 3 — Two-qubit LM + Bell ✅ (PR #140)
+`TwoQubit` (ℂ⁴), tensor product, `is_product` (entanglement = nonzero 2×2
+determinant), partial measurement, 4×4 gate algebra, `cnot`, `bell` (Φ⁺), and
+`TwoQubitLM`. *Result:* the Bell-init LM forbids the anti-correlated tokens
+01/10 (`−∞`) — the place the single-qubit Markov reduction provably breaks.
+
+### Phase 4 — Entanglement-entropy / compressibility meter 🔄 (branch `feat/entanglement-entropy`)
+`spectral_entropy(&[f64])` (quantum compressibility in ebits) ✅. Next:
+`entanglement_entropy(&Array2<f64>)` via a pure-Rust cyclic-Jacobi symmetric
+eigensolver (plan: `docs/superpowers/plans/2026-06-11-matrix-entanglement-entropy.md`).
+Turns `is_product` (yes/no) into "how many ebits."
+
+### Phase 5 — GHZ / W (3+ qubits) ⬜
+`ℂ^{2ⁿ}` states, n-qubit gate algebra, the GHZ and W entangling operations,
+multi-cut entanglement. The asymptotic regime where the classical/quantum size
+ratio (`Vⁿ` vs bond dimension `χ ≈ 2^S`) is a real, growing gap.
+
+### Phase 6 — Superdense coding + quantum LQL ⬜
+Superdense coding as a protocol on the Bell machinery (Pauli-gated Bell states +
+Bell-basis readout) — the first *protocol* (not just state) and the literal
+quantum factor-of-2. Then `MEASURE` (Born) and `STEP` (collapse+unitary) as
+quantum LQL operations under a linear/affine resource discipline (no-cloning at
+the type level). Generation ↔ communication as dual readouts.
+
+### Phase 7 — Vindex compressibility analysis 🔬 (depends on Phase 4)
+A CLI/analysis running `entanglement_entropy` over weight matrices: **on-shell
+vs full**, **canonical vs raw**, **von Neumann (complex) vs Shannon (real)**
+coherence defect, and a **Zipfian/HTSR** power-law check. Tests the conjecture:
+*the quantum compressibility advantage is concentrated in the canonicalized
+on-shell subspace and invisible in the raw syntactic whole.* (Prior from the
+Hilbertian data: small in the raw basis — the open question is whether
+canonicalization recovers it.)
+
+### Phase 8 — `wasm32v1-none` minimal quantum metalanguage 🔬 (epic #132)
+The constructively-admissible (Zizzi ∩ Rosko) fragment — finitely-extractable,
+computable-amplitude, sub-Turing (`¬L ∧ ¬M`) — is the minimal LM. The
+larql-hilbert primitives are the certification target: alloc-free / no_std /
+bounded-stack versions of the kernels (the Hilbertian 64×64 kernel first).
+Numerical-backend portability tracked in #135.
+
+---
+
+## Cross-references
+
+- **PR stack** (all in `metavacua/larql-to-sparql`, merge in order): #133
+  canonical → #137 hilbertian → #138 qlm-hilbert → #139 constructive-measurement
+  → #140 two-qubit-bell → (Phase 4) entanglement-entropy.
+- **Issues:** #132 (wasm32v1-none minimal LM), #134 (regime-classifier finding),
+  #135 (numerical-backend portability / BLAS-free), #136 (hilbertian
+  refinements).
+- **Plans:** `docs/superpowers/plans/` — `2026-06-10-canonical-extraction-pipeline`,
+  `2026-06-11-attention-hilbertian-residual`, `2026-06-11-qlm-hilbert-foundation`,
+  `2026-06-11-constructive-measurement-layer`, `2026-06-11-two-qubit-bell`,
+  `2026-06-11-matrix-entanglement-entropy`.
+
+## Bibliography
+
+- P. Zizzi, *From Quantum Metalanguage to the Logic of Qubits*, arXiv:1003.5976 (2010).
+- M. Rosko, *A Constructive Fragment of Physical Propositions*, arXiv:2511.21296 (2025).
+- J. Baez & M. Stay, *Physics, Topology, Logic and Computation: A Rosetta Stone* (2009).
+- S. Abramsky & B. Coecke, *Categorical Quantum Mechanics*.
+- *Towards a Computational Quantum Logic* (the `Lᶜ` calculus), arXiv:2504.07609 (2025).
+- C. Bennett & S. Wiesner, *Communication via one- and two-particle operators on EPR states* (1992) — superdense coding.
+- B. Schumacher, *Quantum coding* (1995) — quantum data compression.
+- C. Martin & M. Mahoney, *Heavy-Tailed Self-Regularization in Deep Neural Networks* — weight-spectrum power laws.

--- a/docs/adr/0011-qlm-quantum-language-models.md
+++ b/docs/adr/0011-qlm-quantum-language-models.md
@@ -1,0 +1,80 @@
+# ADR 0011 — QLM: Quantum Language Models as a Pure-Rust Leaf Crate
+
+**Status:** Accepted
+**Date:** 2026-06-11
+**Depends on:** `larql-hilbert` (new), `larql-vindex` (canonical pipeline)
+
+---
+
+## Context
+
+The QLM line (see `docs/QLM-ROADMAP.md`) formalizes language models as
+Hilbert-space objects: qubit states, unitary evolution, Born-rule readout, and
+the classical-vs-quantum compressibility programme. It is built as a new crate,
+`larql-hilbert`, across PRs #137–#140 (+ the entanglement-entropy work). Several
+non-obvious architectural choices were made that are not legible from the code
+alone; this ADR records them and their rationale.
+
+## Decision
+
+1. **`larql-hilbert` is a pure-Rust leaf crate.** Its only dependencies are
+   `ndarray` (real matrices) and `num-complex` (the qubit `Complex64` algebra).
+   It depends on **no other `larql-*` crate** and links **no BLAS/LAPACK**.
+
+2. **Measurement is an elimination rule, not a new primitive.** Projective
+   measurement is `project(&Qubit, outcome) -> Option<Qubit>`, with `None` the
+   uninhabited outcome ⊥ (coinciding with `SingleQubitLM::score` returning −∞).
+   The no-cloning discipline is enforced by the type system: `LinearQubit` is
+   `!Copy`/`!Clone`, so `measure(self, …)` consumes it (Rust move semantics =
+   linear-logic's prohibition on contraction).
+
+3. **Admissibility is a first-class layer.** Bounded extraction over the LM is
+   classified by arithmetical fragment — `is_realizable` (Δ₀), `exists_continuation`
+   (Σ⁰₁), `uniformly_stable` (Π⁰₂) — implementing Rosko's finite-extraction
+   criterion (admissible measurement ⊆ Σ⁰₁ ∪ Π⁰₂) as the quantifier shape of
+   bounded procedures.
+
+4. **Numerics are hand-written and BLAS-free.** Single/two-qubit gates are
+   fixed-size (`[[Complex64;2];2]`, `[[Complex64;4];4]`) with hand-written
+   `mat_mul`/`dagger`/`apply`; the entanglement-entropy meter uses a pure-Rust
+   cyclic-Jacobi symmetric eigensolver, not `ndarray-linalg`/LAPACK.
+
+5. **Born readout presupposes the dagger installed by canonicalization.** The
+   Born rule `|⟨t|ψ⟩|²` is only well-defined given an inner product; the
+   `larql canonicalize` whitening *is* the act of choosing that dagger/metric.
+   The QLM is therefore conceptually downstream of the canonical pipeline.
+
+## Rationale
+
+- **Portability toward `wasm32v1-none` (#132) and BLAS-free numerics (#135).**
+  A leaf crate with no native linkage and alloc-light, fixed-size kernels is the
+  certification target for the minimal-LM epic. Linking BLAS would make the
+  crate impossible on the bare wasm target; depending on `larql-compute` would
+  drag the whole inference stack.
+- **Constructive/categorical correctness.** Measurement-as-elimination and
+  no-cloning-as-move follow the Curry-Howard-Lambek / categorical-quantum-
+  mechanics reading; encoding linearity in the type system makes the no-cloning
+  theorem mechanical rather than a runtime convention.
+- **Isolation for an exploratory subproject.** The QLM is a research line with
+  its own roadmap and (separate) authorship/licence; keeping it a leaf avoids
+  coupling the main vindex/inference path to in-flux quantum-LM code.
+
+## Consequences
+
+- **Positive:** the crate builds anywhere `ndarray` + `num-complex` build; it is
+  the natural no_std/wasm certification target; the type system enforces the
+  linear discipline; the qubit core is small and auditable.
+- **Negative / accepted cost:** some numerics are reimplemented rather than
+  reused (a symmetric eigensolver, fixed-size complex matmul) — justified by the
+  no-BLAS constraint; a future shared math crate could consolidate (see #135).
+- **Reuse is deliberately forgone:** an entropy helper already exists in
+  `larql-cli` (`ov_rd/metrics.rs`), but reusing it would invert the dependency
+  hierarchy onto a leaf crate; the re-implementation is intentional (`/simplify`
+  review confirmed this is the right call).
+
+## Cross-references
+
+PRs #133 (canonical), #137 (hilbertian residual), #138 (single-qubit LM), #139
+(constructive measurement + admissibility), #140 (two-qubit/Bell). Issues #132
+(wasm32v1-none minimal LM), #135 (numerical-backend portability). Roadmap:
+`docs/QLM-ROADMAP.md`.

--- a/docs/lql-guide.md
+++ b/docs/lql-guide.md
@@ -114,6 +114,12 @@ INFER "The capital of Atlantis is" ROUTE VERIFY TOP 3;
 -- non-stored entity it can confident-wrong like the legacy gate — use FALLBACK
 -- only for queries known to be aliases of stored entities.
 INFER "The capital of Persia is" ROUTE VERIFY FALLBACK TOPK 8 TOP 3;
+
+-- EXIT: retrieval-augmented early exit. When the verified hit fires, the forward
+-- short-circuits at the resolved layer — the stored target is emitted and the
+-- remaining layers + lm_head are skipped (parity-exact, ~1.4× faster on
+-- fact-lookup answer tokens). Verified-only; ignored with FALLBACK.
+INFER "The capital of Atlantis is" ROUTE VERIFY EXIT TOP 3;
 ```
 
 With no `ROUTE` clause, INFER inherits the global default from the `LARQL_KNN_*`

--- a/docs/superpowers/plans/2026-06-10-canonical-extraction-pipeline.md
+++ b/docs/superpowers/plans/2026-06-10-canonical-extraction-pipeline.md
@@ -1,0 +1,1435 @@
+# Canonical Extraction Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `larql canonicalize <vindex-path>` — a command that computes the flat-canonical (single G constant across all layers, semi-intrinsic W_E calibration) form of a vindex and writes `canonical_meta.json` into the vindex directory.
+
+**Architecture:** A new `canonical` module in `larql-vindex` implements four pure algorithms: covariance estimation from the token embedding matrix, Cholesky whitening factor computation, on-shell feature scoring via c_score percentile, and regime classification per layer from the existing layer bands and activation density. The `larql-cli` gets a `Canonicalize` subcommand that opens a vindex directory, runs the pipeline, and writes `canonical_meta.json`. The existing vindex files are left untouched — canonicalize is purely additive.
+
+**Tech Stack:** Rust 2021, ndarray 0.16, existing `larql_compute::cpu::ops::linalg` (Cholesky, cholesky_inverse), `larql-vindex` format loaders (embeddings.bin, down_meta.bin, gate_vectors.bin, index.json), serde_json, clap.
+
+---
+
+## Scope note: three separate plans
+
+This synthesis document covers three independent subsystems. This plan covers **Plan 1 only**:
+
+- **Plan 1 (this):** Canonical extraction pipeline — `larql canonicalize`. The load-bearing missing piece. No prerequisites.
+- **Plan 2 (separate):** Knowledge graph integration — INSERT ops importer + entity→QID alignment. Depends on Plan 1 canonical_meta.json for Class A label addressing.
+- **Plan 3 (separate):** Cross-model Procrustes alignment CLI — `larql align`. Depends on Plan 1 whitening factor.
+
+---
+
+## Key domain concepts
+
+- **G (activation covariance):** `G = (1/N) Σ_v (embed_scale · W_E[v])^T (embed_scale · W_E[v])` where W_E is the token embedding matrix. Shape [hidden_size, hidden_size]. The flat-canonical choice uses a single G for all layers (semi-intrinsic, computed from model weights alone, no external corpus needed).
+- **Cholesky whitening:** `G = L L^T`. The whitened gate vector is `g̃_f = L^{-T} g_f` (back-solve `L^T g̃_f = g_f`). Two whitened vectors have Mahalanobis inner product = ordinary dot product.
+- **c_score:** the logit of the feature's top down-projected token (already in `down_meta.bin`). High c_score = feature strongly predicts a specific token = factual/on-shell.
+- **On-shell filter:** the top 15% features by c_score within each layer. These are the "detail wavelets" (factual subspace). Features below the 85th percentile are structural ("dark space").
+- **Regime per layer:** Wave (mean_density > 0.5), Particle (mean_density < 0.05), Wavelet (otherwise). `mean_density` = fraction of layer features with c_score above a low floor (c_score > 0.1 indicates the feature fires for at least some inputs).
+
+## File structure
+
+**New files:**
+- `crates/larql-compute/src/cpu/ops/linalg.rs` — add `back_solve_lt`, `compute_l_inv_t` functions
+- `crates/larql-vindex/src/canonical/mod.rs`
+- `crates/larql-vindex/src/canonical/types.rs` — `Regime`, `LayerCanonicalInfo`, `CanonicalMeta`
+- `crates/larql-vindex/src/canonical/covariance.rs` — `estimate_covariance`
+- `crates/larql-vindex/src/canonical/whitening.rs` — `WhiteningData`, `compute_whitening`
+- `crates/larql-vindex/src/canonical/onshell.rs` — `compute_onshell_mask`
+- `crates/larql-vindex/src/canonical/regime.rs` — `classify_layer_regime`
+- `crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs`
+
+**Modified files:**
+- `crates/larql-compute/src/cpu/ops/linalg.rs` — add two functions
+- `crates/larql-vindex/src/format/down_meta.rs` — add `read_cscores_binary` (no tokenizer needed)
+- `crates/larql-vindex/src/format/filenames.rs` — add `CANONICAL_META_JSON` constant
+- `crates/larql-vindex/src/lib.rs` — add `pub mod canonical;` and re-export types
+- `crates/larql-cli/src/commands/extraction/mod.rs` — add `pub mod canonicalize_cmd;`
+- `crates/larql-cli/src/main.rs` — add `Canonicalize` variant to `Commands`
+
+---
+
+## Task 1: `back_solve_lt` and `compute_l_inv_t` in linalg.rs
+
+These are the only new numerical primitives needed. Everything else uses existing Cholesky.
+
+**Files:**
+- Modify: `crates/larql-compute/src/cpu/ops/linalg.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the bottom of `crates/larql-compute/src/cpu/ops/linalg.rs`:
+
+```rust
+#[cfg(test)]
+mod canonical_linalg_tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn lower_3x3() -> Array2<f64> {
+        // L = [[2,0,0],[1,3,0],[4,5,6]]
+        let mut l = Array2::<f64>::zeros((3, 3));
+        l[[0,0]] = 2.0; l[[1,0]] = 1.0; l[[1,1]] = 3.0;
+        l[[2,0]] = 4.0; l[[2,1]] = 5.0; l[[2,2]] = 6.0;
+        l
+    }
+
+    #[test]
+    fn back_solve_lt_recovers_rhs() {
+        // L^T z = b, check L^T (back_solve_lt(L, b)) == b
+        let l = lower_3x3();
+        let b = Array2::from_shape_vec((3, 2), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        let z = back_solve_lt(&l, &b);
+        // Verify L^T z == b
+        let lt = l.t().to_owned();
+        for col in 0..2 {
+            for row in 0..3 {
+                let dot: f64 = (0..3).map(|k| lt[[row, k]] * z[[k, col]]).sum();
+                assert!((dot - b[[row, col]]).abs() < 1e-10, "row={row} col={col} dot={dot} expected={}", b[[row,col]]);
+            }
+        }
+    }
+
+    #[test]
+    fn compute_l_inv_t_times_l_t_is_identity() {
+        let l = lower_3x3();
+        let l_inv_t = compute_l_inv_t(&l);
+        // l_inv_t @ l^T should == I
+        let lt = l.t().to_owned();
+        let product = l_inv_t.dot(&lt);
+        for i in 0..3 {
+            for j in 0..3 {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!((product[[i,j]] - expected).abs() < 1e-10,
+                    "product[{i},{j}]={} expected={expected}", product[[i,j]]);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+cargo test -p larql-compute canonical_linalg_tests 2>&1 | tail -5
+```
+Expected: FAIL — `back_solve_lt` and `compute_l_inv_t` not defined.
+
+- [ ] **Step 3: Implement `back_solve_lt` and `compute_l_inv_t`**
+
+Add to `crates/larql-compute/src/cpu/ops/linalg.rs` before the `#[cfg(test)]` block:
+
+```rust
+/// Back-substitution: solve L^T X = B where L is lower-triangular.
+/// L^T is upper-triangular, so we iterate from bottom row to top.
+/// Returns X of the same shape as B.
+pub fn back_solve_lt(l: &Array2<f64>, b: &Array2<f64>) -> Array2<f64> {
+    let n = l.shape()[0];
+    let m = b.shape()[1];
+    let mut x = Array2::<f64>::zeros((n, m));
+    // L^T[i,j] = L[j,i]. Upper-triangular back-substitution:
+    for i in (0..n).rev() {
+        for col in 0..m {
+            let mut sum = b[[i, col]];
+            for k in (i + 1)..n {
+                sum -= l[[k, i]] * x[[k, col]]; // L^T[i,k] = L[k,i]
+            }
+            x[[i, col]] = sum / l[[i, i]];
+        }
+    }
+    x
+}
+
+/// Compute L^{-T} explicitly: the d×d matrix such that L^{-T} @ L^T = I.
+/// Equivalent to: for each unit column e_j, solve L^T x = e_j via back_solve_lt.
+/// Returns a d×d array — the whitening matrix for gate vectors.
+pub fn compute_l_inv_t(l: &Array2<f64>) -> Array2<f64> {
+    let n = l.shape()[0];
+    let identity = Array2::<f64>::eye(n);
+    back_solve_lt(l, &identity)
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```
+cargo test -p larql-compute canonical_linalg_tests 2>&1 | tail -5
+```
+Expected: `test result: ok. 2 passed`
+
+- [ ] **Step 5: Run full larql-compute tests to verify no regression**
+
+```
+cargo test -p larql-compute 2>&1 | tail -5
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/larql-compute/src/cpu/ops/linalg.rs
+git commit -m "feat(linalg): add back_solve_lt and compute_l_inv_t for canonical whitening"
+```
+
+---
+
+## Task 2: `CANONICAL_META_JSON` filename constant
+
+**Files:**
+- Modify: `crates/larql-vindex/src/format/filenames.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/larql-vindex/src/format/filenames.rs`, inside `mod tests`, add:
+
+```rust
+#[test]
+fn canonical_meta_json_is_unique() {
+    // CANONICAL_META_JSON must not collide with any existing constant.
+    let existing = [
+        INDEX_JSON, TOKENIZER_JSON, TOKENIZER_CONFIG_JSON, GENERATION_CONFIG_JSON,
+        WEIGHT_MANIFEST_JSON, EMBEDDINGS_BIN, NORMS_BIN, GATE_VECTORS_BIN, DOWN_META_BIN,
+    ];
+    for name in existing {
+        assert_ne!(CANONICAL_META_JSON, name,
+            "CANONICAL_META_JSON collides with {name}");
+    }
+    assert_eq!(CANONICAL_META_JSON, "canonical_meta.json");
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```
+cargo test -p larql-vindex canonical_meta_json_is_unique 2>&1 | tail -5
+```
+Expected: FAIL — constant not defined.
+
+- [ ] **Step 3: Add the constant**
+
+In `crates/larql-vindex/src/format/filenames.rs`, after the `INDEX_JSON` group (around line 22), add:
+
+```rust
+// ── Canonical form sidecar ──────────────────────────────────────────────
+pub const CANONICAL_META_JSON: &str = "canonical_meta.json";
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+```
+cargo test -p larql-vindex canonical_meta_json_is_unique 2>&1 | tail -5
+```
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/larql-vindex/src/format/filenames.rs
+git commit -m "feat(filenames): add CANONICAL_META_JSON constant"
+```
+
+---
+
+## Task 3: Canonical types
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/types.rs`
+- Create: `crates/larql-vindex/src/canonical/mod.rs`
+- Modify: `crates/larql-vindex/src/lib.rs`
+
+- [ ] **Step 1: Write failing tests (in types.rs, will fail until the file exists)**
+
+Create `crates/larql-vindex/src/canonical/types.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+/// Wave/Particle/Wavelet activation regime for a transformer layer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Regime {
+    /// Dense activations — many weak gates fire (e.g., early syntax layers).
+    Wave,
+    /// Sparse activations — few strong gates fire (e.g., MoE knowledge layers).
+    Particle,
+    /// Mixed — multi-resolution, some wave structure, some particle selectivity.
+    Wavelet,
+}
+
+/// Per-layer canonical metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerCanonicalInfo {
+    pub layer: usize,
+    pub regime: Regime,
+    /// Number of features that pass the on-shell filter (top 15% by c_score).
+    pub on_shell_count: usize,
+    /// Total features at this layer.
+    pub total_features: usize,
+    /// Fraction of features with c_score > 0.1 (activation density proxy).
+    pub mean_density: f32,
+}
+
+/// Root canonical metadata written to `canonical_meta.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalMeta {
+    /// Format version; increment when the schema changes.
+    pub version: u32,
+    pub model: String,
+    pub family: String,
+    pub num_layers: usize,
+    pub hidden_size: usize,
+    /// Number of embedding rows sampled to estimate G.
+    pub covariance_sample_size: usize,
+    /// embed_scale used when computing G.
+    pub embed_scale: f32,
+    /// Cholesky factor L packed row-major lower-triangle:
+    /// indices (i,j) with j<=i stored as L[i*(i+1)/2 + j].
+    /// Length = hidden_size * (hidden_size + 1) / 2. Values are f64.
+    pub cholesky_l_packed: Vec<f64>,
+    /// Per-layer info.
+    pub layers: Vec<LayerCanonicalInfo>,
+}
+
+impl CanonicalMeta {
+    /// Unpack the lower-triangular Cholesky factor into a dense d×d matrix.
+    pub fn unpack_cholesky_l(&self) -> ndarray::Array2<f64> {
+        let d = self.hidden_size;
+        let mut l = ndarray::Array2::<f64>::zeros((d, d));
+        for i in 0..d {
+            for j in 0..=i {
+                l[[i, j]] = self.cholesky_l_packed[i * (i + 1) / 2 + j];
+            }
+        }
+        l
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regime_serialises_as_snake_case() {
+        assert_eq!(serde_json::to_string(&Regime::Wave).unwrap(), "\"wave\"");
+        assert_eq!(serde_json::to_string(&Regime::Particle).unwrap(), "\"particle\"");
+        assert_eq!(serde_json::to_string(&Regime::Wavelet).unwrap(), "\"wavelet\"");
+    }
+
+    #[test]
+    fn canonical_meta_round_trips_through_json() {
+        let meta = CanonicalMeta {
+            version: 1,
+            model: "test/model".into(),
+            family: "llama".into(),
+            num_layers: 2,
+            hidden_size: 4,
+            covariance_sample_size: 32,
+            embed_scale: 1.0,
+            // 4×4 lower triangle: 10 values (indices 0..9)
+            cholesky_l_packed: vec![1.0, 0.0, 2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0],
+            layers: vec![
+                LayerCanonicalInfo {
+                    layer: 0, regime: Regime::Wave,
+                    on_shell_count: 1, total_features: 4, mean_density: 0.75,
+                },
+                LayerCanonicalInfo {
+                    layer: 1, regime: Regime::Particle,
+                    on_shell_count: 1, total_features: 4, mean_density: 0.02,
+                },
+            ],
+        };
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        let back: CanonicalMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.family, "llama");
+        assert_eq!(back.layers[0].regime, Regime::Wave);
+        assert_eq!(back.layers[1].regime, Regime::Particle);
+        assert_eq!(back.cholesky_l_packed.len(), 10);
+    }
+
+    #[test]
+    fn unpack_cholesky_l_recovers_diagonal() {
+        // Packed lower-triangle of 3×3: [L00, L10, L11, L20, L21, L22]
+        let meta = CanonicalMeta {
+            version: 1, model: "x".into(), family: "y".into(),
+            num_layers: 1, hidden_size: 3,
+            covariance_sample_size: 8, embed_scale: 1.0,
+            cholesky_l_packed: vec![2.0, 1.0, 3.0, 4.0, 5.0, 6.0],
+            layers: vec![],
+        };
+        let l = meta.unpack_cholesky_l();
+        assert_eq!(l[[0, 0]], 2.0);
+        assert_eq!(l[[1, 0]], 1.0);
+        assert_eq!(l[[1, 1]], 3.0);
+        assert_eq!(l[[2, 0]], 4.0);
+        assert_eq!(l[[2, 1]], 5.0);
+        assert_eq!(l[[2, 2]], 6.0);
+        // Upper triangle must be zero
+        assert_eq!(l[[0, 1]], 0.0);
+        assert_eq!(l[[0, 2]], 0.0);
+    }
+}
+```
+
+- [ ] **Step 2: Create `crates/larql-vindex/src/canonical/mod.rs`**
+
+```rust
+pub mod types;
+pub use types::{CanonicalMeta, LayerCanonicalInfo, Regime};
+```
+
+- [ ] **Step 3: Add `pub mod canonical;` to `crates/larql-vindex/src/lib.rs`**
+
+In `crates/larql-vindex/src/lib.rs`, after `pub mod config;`, add:
+
+```rust
+pub mod canonical;
+```
+
+Also add re-exports after the existing `// Re-export essentials at crate root` section:
+
+```rust
+// Canonical
+pub use canonical::{CanonicalMeta, LayerCanonicalInfo, Regime};
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+cargo test -p larql-vindex canonical::types 2>&1 | tail -5
+```
+Expected: `test result: ok. 3 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/larql-vindex/src/canonical/ crates/larql-vindex/src/lib.rs
+git commit -m "feat(canonical): add CanonicalMeta, LayerCanonicalInfo, Regime types"
+```
+
+---
+
+## Task 4: C-score-only reader for down_meta
+
+We need to read `down_meta.bin` without constructing token strings (no tokenizer dependency).
+
+**Files:**
+- Modify: `crates/larql-vindex/src/format/down_meta.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/larql-vindex/src/format/down_meta.rs`, inside the existing `#[cfg(test)]` block, add:
+
+```rust
+#[test]
+fn read_cscores_binary_matches_full_read() {
+    // Build a tiny down_meta.bin with known c_scores, then verify
+    // read_cscores_binary extracts them correctly.
+    let dir = tempfile::tempdir().unwrap();
+    let meta: Vec<Option<Vec<Option<FeatureMeta>>>> = vec![
+        Some(vec![
+            Some(FeatureMeta {
+                top_token: "hello".into(),
+                top_token_id: 1,
+                c_score: 3.5,
+                top_k: vec![larql_models::TopKEntry {
+                    token: "hello".into(), token_id: 1, logit: 3.5,
+                }],
+            }),
+            Some(FeatureMeta {
+                top_token: "world".into(),
+                top_token_id: 2,
+                c_score: 1.2,
+                top_k: vec![larql_models::TopKEntry {
+                    token: "world".into(), token_id: 2, logit: 1.2,
+                }],
+            }),
+        ]),
+        None,
+    ];
+    write_binary(dir.path(), &meta, 1).unwrap();
+    let cscores = read_cscores_binary(dir.path()).unwrap();
+    assert_eq!(cscores.len(), 2);
+    assert_eq!(cscores[0], vec![3.5f32, 1.2f32]);
+    assert!(cscores[1].is_empty(), "None layer should give empty vec");
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```
+cargo test -p larql-vindex read_cscores_binary_matches_full_read 2>&1 | tail -5
+```
+Expected: FAIL — `read_cscores_binary` not defined.
+
+- [ ] **Step 3: Implement `read_cscores_binary`**
+
+Add to `crates/larql-vindex/src/format/down_meta.rs` after the `read_binary` function:
+
+```rust
+/// Read only c_scores from down_meta.bin — no tokenizer needed.
+/// Returns a Vec (per layer) of Vec<f32> (per feature).
+/// Layers with no features (None in the full format) yield an empty Vec.
+pub fn read_cscores_binary(dir: &Path) -> Result<Vec<Vec<f32>>, VindexError> {
+    let path = dir.join(DOWN_META_BIN);
+    let file = std::fs::File::open(&path)?;
+    let mut r = BufReader::new(file);
+
+    let magic = read_u32(&mut r)?;
+    if magic != MAGIC && magic != LEGACY_LITERAL_MAGIC {
+        return Err(VindexError::Parse(format!(
+            "invalid down_meta.bin magic: 0x{magic:08X}"
+        )));
+    }
+    let version = read_u32(&mut r)?;
+    if version != FORMAT_VERSION {
+        return Err(VindexError::Parse(format!(
+            "unsupported down_meta.bin version: {version}"
+        )));
+    }
+    let num_layers = read_u32(&mut r)? as usize;
+    let top_k_count = read_u32(&mut r)? as usize;
+    // Bytes to skip per feature after reading c_score:
+    // top_k_count × (u32 token_id + f32 logit) = top_k_count × 8 bytes
+    let skip_per_feature = top_k_count * (U32_BYTES + F32_BYTES);
+
+    let mut result = Vec::with_capacity(num_layers);
+    for _ in 0..num_layers {
+        let num_features = read_u32(&mut r)? as usize;
+        if num_features == 0 {
+            result.push(Vec::new());
+            continue;
+        }
+        let mut cscores = Vec::with_capacity(num_features);
+        for _ in 0..num_features {
+            let _top_token_id = read_u32(&mut r)?;
+            let c_score = read_f32(&mut r)?;
+            cscores.push(c_score);
+            // Skip top_k entries
+            let mut skip_buf = vec![0u8; skip_per_feature];
+            r.read_exact(&mut skip_buf)?;
+        }
+        result.push(cscores);
+    }
+    Ok(result)
+}
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+```
+cargo test -p larql-vindex read_cscores_binary_matches_full_read 2>&1 | tail -5
+```
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 5: Run full larql-vindex tests**
+
+```
+cargo test -p larql-vindex 2>&1 | tail -8
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/larql-vindex/src/format/down_meta.rs
+git commit -m "feat(down_meta): add read_cscores_binary (no tokenizer dependency)"
+```
+
+---
+
+## Task 5: Covariance estimation
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/covariance.rs`
+- Modify: `crates/larql-vindex/src/canonical/mod.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/larql-vindex/src/canonical/covariance.rs`:
+
+```rust
+use ndarray::{Array2, s};
+
+/// Estimate the activation covariance G = (1/N) Σ (s·W_E[v])^T (s·W_E[v])
+/// using at most `max_samples` rows from the embedding matrix.
+/// Rows are subsampled deterministically (every stride-th row).
+/// Returns a [hidden_size, hidden_size] f64 matrix.
+pub fn estimate_covariance(
+    embed: &Array2<f32>,
+    embed_scale: f32,
+    max_samples: usize,
+) -> Array2<f64> {
+    let (vocab, d) = (embed.shape()[0], embed.shape()[1]);
+    let stride = (vocab / max_samples).max(1);
+    let indices: Vec<usize> = (0..vocab).step_by(stride).collect();
+    let n = indices.len();
+
+    let mut g = Array2::<f64>::zeros((d, d));
+    let scale = embed_scale as f64;
+
+    for &v in &indices {
+        let row = embed.slice(s![v, ..]);
+        for i in 0..d {
+            let xi = row[i] as f64 * scale;
+            for j in 0..=i {
+                let xj = row[j] as f64 * scale;
+                g[[i, j]] += xi * xj;
+                if i != j {
+                    g[[j, i]] += xi * xj;
+                }
+            }
+        }
+    }
+
+    let norm = n as f64;
+    g.mapv_inplace(|v| v / norm);
+    g
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn identity_embed(d: usize) -> Array2<f32> {
+        // Each row is a basis vector — G should be I/d * d = I (after normalization).
+        // Actually G = (1/d) I·I^T = I (diagonal 1.0) when embed = I_d.
+        Array2::<f32>::eye(d)
+    }
+
+    #[test]
+    fn covariance_of_identity_is_identity_scaled() {
+        // embed = 4×4 identity, embed_scale = 1.0, max_samples = 4
+        let embed = identity_embed(4);
+        let g = estimate_covariance(&embed, 1.0, 4);
+        // G = (1/4) Σ_v e_v e_v^T = (1/4) I. Diagonal = 0.25, off-diag = 0.
+        for i in 0..4 {
+            for j in 0..4 {
+                let expected = if i == j { 0.25 } else { 0.0 };
+                assert!(
+                    (g[[i, j]] - expected).abs() < 1e-10,
+                    "G[{i},{j}]={} expected={expected}", g[[i, j]]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn covariance_is_positive_semidefinite() {
+        // A PSD matrix has non-negative diagonal and the off-diagonal satisfies
+        // G[i,j]^2 <= G[i,i] * G[j,j] (Cauchy-Schwarz).
+        let embed = Array2::from_shape_fn((8, 4), |(v, d)| (v as f32 + 1.0) * (d as f32 + 1.0));
+        let g = estimate_covariance(&embed, 0.5, 8);
+        for i in 0..4 {
+            assert!(g[[i, i]] >= 0.0, "diagonal must be non-negative");
+            for j in 0..4 {
+                assert!(
+                    g[[i, j]] * g[[i, j]] <= g[[i, i]] * g[[j, j]] + 1e-10,
+                    "Cauchy-Schwarz violated at ({i},{j})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn covariance_is_symmetric() {
+        let embed = Array2::from_shape_fn((16, 4), |(v, d)| (v * d) as f32 * 0.1 + 0.01);
+        let g = estimate_covariance(&embed, 1.0, 16);
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!((g[[i, j]] - g[[j, i]]).abs() < 1e-10,
+                    "G not symmetric at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn embed_scale_squares_into_covariance() {
+        let embed = identity_embed(4);
+        let g1 = estimate_covariance(&embed, 1.0, 4);
+        let g2 = estimate_covariance(&embed, 2.0, 4);
+        // Scaling by s multiplies G by s^2
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!((g2[[i, j]] - 4.0 * g1[[i, j]]).abs() < 1e-10,
+                    "scale^2 law violated at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn subsampling_reduces_sample_count_not_shape() {
+        let embed = Array2::from_shape_fn((100, 4), |(v, _)| v as f32);
+        let g = estimate_covariance(&embed, 1.0, 10);
+        assert_eq!(g.shape(), [4, 4]);
+    }
+}
+```
+
+- [ ] **Step 2: Add to `mod.rs`**
+
+In `crates/larql-vindex/src/canonical/mod.rs`, add:
+
+```rust
+pub mod covariance;
+pub use covariance::estimate_covariance;
+```
+
+- [ ] **Step 3: Run tests to confirm they fail first**
+
+```
+cargo test -p larql-vindex canonical::covariance 2>&1 | tail -5
+```
+Expected: compile error — module doesn't exist yet (you just created the file, so this should compile but tests should pass; if the impl is in the file you wrote, they should pass immediately).
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```
+cargo test -p larql-vindex canonical::covariance 2>&1 | tail -5
+```
+Expected: `test result: ok. 5 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/larql-vindex/src/canonical/covariance.rs crates/larql-vindex/src/canonical/mod.rs
+git commit -m "feat(canonical): add estimate_covariance from token embeddings"
+```
+
+---
+
+## Task 6: Cholesky whitening
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/whitening.rs`
+- Modify: `crates/larql-vindex/src/canonical/mod.rs`
+
+- [ ] **Step 1: Write the failing tests and implementation together**
+
+Create `crates/larql-vindex/src/canonical/whitening.rs`:
+
+```rust
+use ndarray::Array2;
+
+use larql_compute::cholesky;
+// back_solve_lt and compute_l_inv_t are re-exported from larql_compute
+pub use larql_compute::{back_solve_lt, compute_l_inv_t};
+
+/// Ridge regularisation added to G diagonal before Cholesky decomposition.
+/// Prevents failure on near-singular covariance (small hidden dims in tests).
+const DEFAULT_RIDGE: f64 = 1e-5;
+
+/// The Cholesky whitening data computed from a covariance matrix G.
+pub struct WhiteningData {
+    /// Lower triangular Cholesky factor L such that G = L L^T.
+    pub l: Array2<f64>,
+    /// Packed lower triangle of L for storage in canonical_meta.json.
+    /// Entry (i,j) with j<=i is at index i*(i+1)/2 + j.
+    pub l_packed: Vec<f64>,
+}
+
+/// Compute the Cholesky factor of the covariance matrix G.
+/// Returns `WhiteningData` containing L and its packed form.
+pub fn compute_whitening(g: &Array2<f64>) -> Result<WhiteningData, String> {
+    let l = cholesky(g, DEFAULT_RIDGE)?;
+    let d = l.shape()[0];
+    let mut l_packed = Vec::with_capacity(d * (d + 1) / 2);
+    for i in 0..d {
+        for j in 0..=i {
+            l_packed.push(l[[i, j]]);
+        }
+    }
+    Ok(WhiteningData { l, l_packed })
+}
+
+/// Unpack a lower-triangle-packed Cholesky factor back to a dense d×d matrix.
+pub fn unpack_l(packed: &[f64], d: usize) -> Array2<f64> {
+    let mut l = Array2::<f64>::zeros((d, d));
+    for i in 0..d {
+        for j in 0..=i {
+            l[[i, j]] = packed[i * (i + 1) / 2 + j];
+        }
+    }
+    l
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    fn spd_3x3() -> Array2<f64> {
+        // G = [[4,2,1],[2,5,3],[1,3,6]] (symmetric positive definite)
+        let data = vec![4.0_f64, 2.0, 1.0, 2.0, 5.0, 3.0, 1.0, 3.0, 6.0];
+        Array2::from_shape_vec((3, 3), data).unwrap()
+    }
+
+    #[test]
+    fn cholesky_recovers_g() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        let reconstructed = wd.l.dot(&wd.l.t());
+        // With ridge=1e-5, G_reconstructed ≈ G + 1e-5 * I
+        for i in 0..3 {
+            for j in 0..3 {
+                let expected = g[[i, j]] + if i == j { 1e-5 } else { 0.0 };
+                assert!((reconstructed[[i, j]] - expected).abs() < 1e-8,
+                    "L L^T differs from G+ridge at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn l_is_lower_triangular() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        for i in 0..3 {
+            for j in (i + 1)..3 {
+                assert_eq!(wd.l[[i, j]], 0.0, "upper triangle not zero at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn l_packed_length_is_triangular_number() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        assert_eq!(wd.l_packed.len(), 3 * 4 / 2); // 6
+    }
+
+    #[test]
+    fn unpack_roundtrips_packed() {
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        let l2 = unpack_l(&wd.l_packed, 3);
+        for i in 0..3 {
+            for j in 0..3 {
+                assert!((l2[[i, j]] - wd.l[[i, j]]).abs() < 1e-14,
+                    "unpack mismatch at ({i},{j})");
+            }
+        }
+    }
+
+    #[test]
+    fn whitening_makes_mahalanobis_a_dot_product() {
+        // After whitening g̃ = L^{-T} g, the Mahalanobis score g^T G^{-1} h
+        // equals the ordinary dot product g̃ · h̃.
+        let g = spd_3x3();
+        let wd = compute_whitening(&g).unwrap();
+        let l_inv_t = compute_l_inv_t(&wd.l);
+
+        // Two test vectors
+        let g_vec = Array2::from_shape_vec((3, 1), vec![1.0f64, 2.0, 3.0]).unwrap();
+        let h_vec = Array2::from_shape_vec((3, 1), vec![4.0f64, 5.0, 6.0]).unwrap();
+
+        // Whitened vectors
+        let g_tilde = l_inv_t.dot(&g_vec); // L^{-T} g
+        let h_tilde = l_inv_t.dot(&h_vec); // L^{-T} h
+
+        // Mahalanobis: g^T G^{-1} h = g^T L^{-T} L^{-1} h = g̃^T h̃
+        let dot_whitened: f64 = (0..3).map(|i| g_tilde[[i, 0]] * h_tilde[[i, 0]]).sum();
+
+        // Direct Mahalanobis using cholesky_inverse
+        let l_inv = larql_compute::cholesky_inverse(&wd.l);
+        let g_inv = l_inv.t().dot(&l_inv);
+        let mahal: f64 = {
+            let tmp = g_inv.dot(&h_vec);
+            (0..3).map(|i| g_vec[[i, 0]] * tmp[[i, 0]]).sum()
+        };
+
+        assert!((dot_whitened - mahal).abs() < 1e-8,
+            "whitened dot={dot_whitened} mahal={mahal}");
+    }
+}
+```
+
+- [ ] **Step 2: Expose `back_solve_lt` and `compute_l_inv_t` from `larql-compute`**
+
+In `crates/larql-compute/src/lib.rs`, add to the existing public exports:
+
+```rust
+pub use cpu::ops::linalg::{back_solve_lt, cholesky, cholesky_inverse, cholesky_solve,
+    compute_l_inv_t, ridge_decomposition_solve};
+```
+
+(Find the existing `pub use cpu::ops::linalg::{cholesky, ...}` line and extend it.)
+
+- [ ] **Step 3: Add `larql-compute` dependency to `larql-vindex/Cargo.toml` if not already present**
+
+Check:
+```
+grep "larql-compute" crates/larql-vindex/Cargo.toml
+```
+If absent, add under `[dependencies]`:
+```toml
+larql-compute = { path = "../larql-compute" }
+```
+
+- [ ] **Step 4: Add to `canonical/mod.rs`**
+
+```rust
+pub mod whitening;
+pub use whitening::{compute_whitening, unpack_l, WhiteningData};
+```
+
+- [ ] **Step 5: Run tests**
+
+```
+cargo test -p larql-vindex canonical::whitening 2>&1 | tail -5
+```
+Expected: `test result: ok. 5 passed`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/larql-vindex/src/canonical/whitening.rs \
+        crates/larql-vindex/src/canonical/mod.rs \
+        crates/larql-compute/src/lib.rs \
+        crates/larql-vindex/Cargo.toml
+git commit -m "feat(canonical): add Cholesky whitening (compute_whitening, unpack_l)"
+```
+
+---
+
+## Task 7: On-shell filter
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/onshell.rs`
+- Modify: `crates/larql-vindex/src/canonical/mod.rs`
+
+- [ ] **Step 1: Write the failing tests and implementation**
+
+Create `crates/larql-vindex/src/canonical/onshell.rs`:
+
+```rust
+/// Compute a boolean on-shell mask for features in one layer.
+/// Features whose c_score ranks in the top `top_fraction` are on-shell.
+/// `top_fraction = 0.15` reproduces the "15% factual subspace" from the synthesis.
+///
+/// Returns a Vec<bool> of length equal to `c_scores`.
+/// Empty input returns an empty Vec.
+pub fn compute_onshell_mask(c_scores: &[f32], top_fraction: f32) -> Vec<bool> {
+    if c_scores.is_empty() {
+        return Vec::new();
+    }
+    let n = c_scores.len();
+    // Number of on-shell features (at least 1 if any features exist)
+    let k = ((n as f32 * top_fraction).ceil() as usize).max(1).min(n);
+    // Find the k-th largest c_score (threshold)
+    let mut sorted: Vec<f32> = c_scores.to_vec();
+    sorted.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    let threshold = sorted[k - 1];
+    // Mark as on-shell all features with c_score >= threshold.
+    // Ties are included (may yield slightly more than k on-shell features).
+    c_scores.iter().map(|&s| s >= threshold).collect()
+}
+
+/// Count on-shell features across all layers and return (on_shell_count, total).
+pub fn onshell_stats(c_scores_per_layer: &[Vec<f32>], top_fraction: f32) -> Vec<(usize, usize)> {
+    c_scores_per_layer
+        .iter()
+        .map(|cscores| {
+            let mask = compute_onshell_mask(cscores, top_fraction);
+            let on_shell = mask.iter().filter(|&&b| b).count();
+            (on_shell, cscores.len())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_15pct_of_10_is_2() {
+        // 15% of 10 = 1.5 → ceil = 2
+        let scores: Vec<f32> = (0..10).map(|i| i as f32).collect(); // 0..9
+        let mask = compute_onshell_mask(&scores, 0.15);
+        // Top 2 = scores 8 and 9
+        let on_shell_indices: Vec<usize> =
+            mask.iter().enumerate().filter(|(_, &b)| b).map(|(i, _)| i).collect();
+        assert_eq!(on_shell_indices.len(), 2);
+        assert!(on_shell_indices.contains(&8));
+        assert!(on_shell_indices.contains(&9));
+    }
+
+    #[test]
+    fn empty_scores_returns_empty_mask() {
+        assert!(compute_onshell_mask(&[], 0.15).is_empty());
+    }
+
+    #[test]
+    fn single_feature_always_on_shell() {
+        let mask = compute_onshell_mask(&[0.5], 0.15);
+        assert_eq!(mask, vec![true]);
+    }
+
+    #[test]
+    fn mask_length_matches_input() {
+        let scores: Vec<f32> = (0..100).map(|i| i as f32 * 0.01).collect();
+        let mask = compute_onshell_mask(&scores, 0.15);
+        assert_eq!(mask.len(), 100);
+    }
+
+    #[test]
+    fn on_shell_count_is_at_least_top_fraction() {
+        let scores: Vec<f32> = (0..20).map(|i| i as f32).collect();
+        let mask = compute_onshell_mask(&scores, 0.15);
+        let count = mask.iter().filter(|&&b| b).count();
+        // 15% of 20 = 3 → expect exactly 3
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn all_same_scores_all_on_shell() {
+        // When all c_scores are equal, all features tie at the threshold.
+        let scores = vec![1.0f32; 10];
+        let mask = compute_onshell_mask(&scores, 0.15);
+        // All values >= threshold (which is 1.0), so all are on-shell.
+        assert!(mask.iter().all(|&b| b));
+    }
+
+    #[test]
+    fn onshell_stats_counts_per_layer() {
+        let layers = vec![
+            vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+            vec![],
+        ];
+        let stats = onshell_stats(&layers, 0.15);
+        assert_eq!(stats.len(), 2);
+        let (on, total) = stats[0];
+        assert_eq!(total, 10);
+        assert_eq!(on, 2); // top 15% of 10 = 2
+        let (on2, total2) = stats[1];
+        assert_eq!(total2, 0);
+        assert_eq!(on2, 0);
+    }
+}
+```
+
+- [ ] **Step 2: Add to `canonical/mod.rs`**
+
+```rust
+pub mod onshell;
+pub use onshell::{compute_onshell_mask, onshell_stats};
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cargo test -p larql-vindex canonical::onshell 2>&1 | tail -5
+```
+Expected: `test result: ok. 7 passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/larql-vindex/src/canonical/onshell.rs crates/larql-vindex/src/canonical/mod.rs
+git commit -m "feat(canonical): add on-shell feature filter (top 15% by c_score)"
+```
+
+---
+
+## Task 8: Regime classifier
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/regime.rs`
+- Modify: `crates/larql-vindex/src/canonical/mod.rs`
+
+- [ ] **Step 1: Write the failing tests and implementation**
+
+Create `crates/larql-vindex/src/canonical/regime.rs`:
+
+```rust
+use crate::canonical::types::Regime;
+
+/// Activation density floor: features with c_score above this are "active".
+const ACTIVE_FLOOR: f32 = 0.1;
+
+/// Classify the regime for a single layer.
+/// `c_scores`: c_score for each feature in this layer.
+/// `mean_density` = fraction of features with c_score > ACTIVE_FLOOR.
+///   - mean_density > 0.5  → Wave
+///   - mean_density < 0.05 → Particle
+///   - otherwise           → Wavelet
+pub fn classify_layer_regime(c_scores: &[f32]) -> (Regime, f32) {
+    if c_scores.is_empty() {
+        return (Regime::Wavelet, 0.0);
+    }
+    let active = c_scores.iter().filter(|&&s| s > ACTIVE_FLOOR).count();
+    let density = active as f32 / c_scores.len() as f32;
+    let regime = if density > 0.5 {
+        Regime::Wave
+    } else if density < 0.05 {
+        Regime::Particle
+    } else {
+        Regime::Wavelet
+    };
+    (regime, density)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dense_layer_is_wave() {
+        // 80% of features active
+        let scores: Vec<f32> = (0..10).map(|i| if i < 8 { 0.5 } else { 0.0 }).collect();
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wave);
+        assert!((density - 0.8).abs() < 1e-5);
+    }
+
+    #[test]
+    fn sparse_layer_is_particle() {
+        // 2% of features active
+        let mut scores = vec![0.0f32; 100];
+        scores[0] = 0.5;
+        scores[1] = 0.5;
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Particle);
+        assert!((density - 0.02).abs() < 1e-5);
+    }
+
+    #[test]
+    fn mid_density_is_wavelet() {
+        // 20% of features active
+        let mut scores = vec![0.0f32; 10];
+        for i in 0..2 {
+            scores[i] = 0.5;
+        }
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet);
+        assert!((density - 0.2).abs() < 1e-5);
+    }
+
+    #[test]
+    fn empty_layer_is_wavelet_density_zero() {
+        let (regime, density) = classify_layer_regime(&[]);
+        assert_eq!(regime, Regime::Wavelet);
+        assert_eq!(density, 0.0);
+    }
+
+    #[test]
+    fn boundary_at_0_5_is_wave() {
+        // Exactly 50% active (density == 0.5, > 0.5 is false, so Wavelet)
+        let scores: Vec<f32> = (0..10).map(|i| if i < 5 { 0.5 } else { 0.0 }).collect();
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet, "density=0.5 is not > 0.5, should be Wavelet");
+        assert!((density - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn boundary_at_0_05_is_wavelet() {
+        // density = 0.05, which is NOT < 0.05, so Wavelet
+        let mut scores = vec![0.0f32; 20];
+        scores[0] = 0.5; // 1/20 = 0.05
+        let (regime, density) = classify_layer_regime(&scores);
+        assert_eq!(regime, Regime::Wavelet, "density=0.05 is not < 0.05, should be Wavelet");
+        assert!((density - 0.05).abs() < 1e-5);
+    }
+}
+```
+
+- [ ] **Step 2: Add to `canonical/mod.rs`**
+
+```rust
+pub mod regime;
+pub use regime::classify_layer_regime;
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cargo test -p larql-vindex canonical::regime 2>&1 | tail -5
+```
+Expected: `test result: ok. 6 passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/larql-vindex/src/canonical/regime.rs crates/larql-vindex/src/canonical/mod.rs
+git commit -m "feat(canonical): add per-layer regime classifier (Wave/Particle/Wavelet)"
+```
+
+---
+
+## Task 9: `larql canonicalize` command
+
+This wires all the pieces together into a usable CLI command.
+
+**Files:**
+- Create: `crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs`
+- Modify: `crates/larql-cli/src/commands/extraction/mod.rs`
+- Modify: `crates/larql-cli/src/main.rs`
+
+- [ ] **Step 1: Implement `canonicalize_cmd.rs`**
+
+Create `crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs`:
+
+```rust
+use std::path::PathBuf;
+use std::time::Instant;
+
+use clap::Args;
+use larql_vindex::{
+    canonical::{
+        classify_layer_regime, compute_onshell_mask, compute_whitening, estimate_covariance,
+        CanonicalMeta, LayerCanonicalInfo,
+    },
+    format::{
+        down_meta::read_cscores_binary,
+        filenames::CANONICAL_META_JSON,
+        load::{load_vindex_config, load_vindex_embeddings},
+    },
+};
+
+/// Number of embedding rows to subsample for covariance estimation.
+const COVARIANCE_SAMPLES: usize = 4096;
+/// Fraction of features per layer that are considered "on-shell" (factual subspace).
+const ONSHELL_FRACTION: f32 = 0.15;
+
+#[derive(Args)]
+pub struct CanonicalizeArgs {
+    /// Path to the .vindex directory to canonicalize.
+    vindex: PathBuf,
+
+    /// Override the on-shell fraction (default 0.15 = top 15% by c_score).
+    #[arg(long, default_value = "0.15")]
+    onshell_fraction: f32,
+
+    /// Override the covariance sample size (default 4096 embedding rows).
+    #[arg(long, default_value = "4096")]
+    covariance_samples: usize,
+}
+
+pub fn run(args: CanonicalizeArgs) -> anyhow::Result<()> {
+    let vindex_dir = &args.vindex;
+    let onshell_fraction = args.onshell_fraction;
+    let covariance_samples = args.covariance_samples;
+
+    println!("Canonicalizing vindex at {}", vindex_dir.display());
+
+    // ── 1. Load index.json ──────────────────────────────────────────────
+    let t0 = Instant::now();
+    let config = load_vindex_config(vindex_dir)?;
+    println!(
+        "  model: {} ({}), {} layers, hidden={}, vocab={}",
+        config.model, config.family, config.num_layers, config.hidden_size, config.vocab_size
+    );
+
+    // ── 2. Load embeddings.bin ──────────────────────────────────────────
+    print!("  loading embeddings.bin ... ");
+    let (embed, embed_scale) = load_vindex_embeddings(vindex_dir)?;
+    println!(
+        "{}×{} ({:.1}ms)",
+        embed.shape()[0], embed.shape()[1],
+        t0.elapsed().as_secs_f64() * 1000.0
+    );
+
+    // ── 3. Estimate covariance G ────────────────────────────────────────
+    let t1 = Instant::now();
+    print!("  estimating G ({covariance_samples} samples) ... ");
+    let g = estimate_covariance(&embed, embed_scale, covariance_samples);
+    println!("{:.1}ms", t1.elapsed().as_secs_f64() * 1000.0);
+
+    // ── 4. Cholesky whitening ───────────────────────────────────────────
+    let t2 = Instant::now();
+    print!("  Cholesky decomposition ... ");
+    let whitening = compute_whitening(&g).map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!("{:.1}ms", t2.elapsed().as_secs_f64() * 1000.0);
+
+    // ── 5. Read c_scores from down_meta.bin ────────────────────────────
+    let t3 = Instant::now();
+    print!("  reading c_scores from down_meta.bin ... ");
+    let cscores_per_layer = read_cscores_binary(vindex_dir)?;
+    println!(
+        "{} layers, {:.1}ms",
+        cscores_per_layer.len(),
+        t3.elapsed().as_secs_f64() * 1000.0
+    );
+
+    // ── 6. Per-layer: regime + on-shell ────────────────────────────────
+    let mut layers_info: Vec<LayerCanonicalInfo> = Vec::with_capacity(config.num_layers);
+    for layer in 0..config.num_layers {
+        let cscores = cscores_per_layer
+            .get(layer)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+        let (regime, mean_density) = classify_layer_regime(cscores);
+        let mask = compute_onshell_mask(cscores, onshell_fraction);
+        let on_shell_count = mask.iter().filter(|&&b| b).count();
+        layers_info.push(LayerCanonicalInfo {
+            layer,
+            regime,
+            on_shell_count,
+            total_features: cscores.len(),
+            mean_density,
+        });
+    }
+
+    // ── 7. Build and write canonical_meta.json ─────────────────────────
+    let meta = CanonicalMeta {
+        version: 1,
+        model: config.model.clone(),
+        family: config.family.clone(),
+        num_layers: config.num_layers,
+        hidden_size: config.hidden_size,
+        covariance_sample_size: covariance_samples,
+        embed_scale,
+        cholesky_l_packed: whitening.l_packed,
+        layers: layers_info,
+    };
+
+    let out_path = vindex_dir.join(CANONICAL_META_JSON);
+    let json = serde_json::to_string_pretty(&meta)?;
+    std::fs::write(&out_path, &json)?;
+
+    let total_on_shell: usize = meta.layers.iter().map(|l| l.on_shell_count).sum();
+    let total_features: usize = meta.layers.iter().map(|l| l.total_features).sum();
+    let pct = if total_features > 0 {
+        100.0 * total_on_shell as f32 / total_features as f32
+    } else {
+        0.0
+    };
+
+    println!("  on-shell features: {total_on_shell}/{total_features} ({pct:.1}%)");
+    println!("  wrote {}", out_path.display());
+    println!("  total: {:.1}ms", t0.elapsed().as_secs_f64() * 1000.0);
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Register module in `mod.rs`**
+
+In `crates/larql-cli/src/commands/extraction/mod.rs`, add:
+
+```rust
+pub mod canonicalize_cmd;
+```
+
+- [ ] **Step 3: Add `Canonicalize` variant to `Commands` in `main.rs`**
+
+Note: `load_vindex_config` and `load_vindex_embeddings` are already `pub` in `larql_vindex::format::load` — no visibility changes needed.
+
+In `crates/larql-cli/src/main.rs`, inside the `Commands` enum, after the `Compile` variant, add:
+
+```rust
+    #[command(next_help_heading = "Build")]
+    /// Compute canonical form metadata for a vindex (writes canonical_meta.json).
+    Canonicalize(canonicalize_cmd::CanonicalizeArgs),
+```
+
+Also add `use commands::extraction::canonicalize_cmd;` to the imports if needed (the existing wildcard `use commands::extraction::*;` may not cover it — check and add explicitly if so).
+
+In the `match` arm that dispatches commands (look for the large `match cli.command {` block), add:
+
+```rust
+    Commands::Canonicalize(args) => canonicalize_cmd::run(args)?,
+```
+
+- [ ] **Step 4: Compile check**
+
+```
+cargo build -p larql-cli 2>&1 | tail -20
+```
+Expected: compiles without errors.
+
+- [ ] **Step 5: Smoke test against the SmolLM2-360M vindex**
+
+```
+cargo run -p larql-cli -- canonicalize /home/metavacua/larql-vindexes/smollm2-360m.vindex 2>&1
+```
+Expected output: something like:
+```
+Canonicalizing vindex at /home/metavacua/larql-vindexes/smollm2-360m.vindex
+  model: output/smollm2-360m-src (llama), 32 layers, hidden=960, vocab=49152
+  loading embeddings.bin ... 49152×960 (...)ms
+  estimating G (4096 samples) ... ...ms
+  Cholesky decomposition ... ...ms
+  reading c_scores from down_meta.bin ... 32 layers, ...ms
+  on-shell features: .../... (~15%)
+  wrote /home/metavacua/larql-vindexes/smollm2-360m.vindex/canonical_meta.json
+  total: ...ms
+```
+
+- [ ] **Step 6: Verify canonical_meta.json structure**
+
+```
+python3 -c "
+import json
+with open('/home/metavacua/larql-vindexes/smollm2-360m.vindex/canonical_meta.json') as f:
+    m = json.load(f)
+print('version:', m['version'])
+print('hidden_size:', m['hidden_size'])
+print('cholesky_l_packed length:', len(m['cholesky_l_packed']))
+expected_packed = m['hidden_size'] * (m['hidden_size'] + 1) // 2
+print('expected packed length:', expected_packed)
+assert len(m['cholesky_l_packed']) == expected_packed
+print('layers:', len(m['layers']))
+for l in m['layers'][:3]:
+    print(f\"  layer {l['layer']}: regime={l['regime']}, on_shell={l['on_shell_count']}/{l['total_features']}, density={l['mean_density']:.3f}\")
+print('OK')
+"
+```
+Expected: no assertion error, cholesky_l_packed length = 960*961/2 = 461280.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/larql-cli/src/commands/extraction/canonicalize_cmd.rs \
+        crates/larql-cli/src/commands/extraction/mod.rs \
+        crates/larql-cli/src/main.rs
+git commit -m "feat(cli): add larql canonicalize command"
+```
+
+---
+
+## Task 10: Full test suite pass
+
+- [ ] **Step 1: Run all tests**
+
+```
+cargo test --workspace 2>&1 | tail -20
+```
+Expected: all tests pass, no regressions.
+
+- [ ] **Step 2: If any tests fail, diagnose and fix**
+
+Read the failing test output carefully. Common failure modes:
+- Visibility errors on `load_config`/`load_embeddings` — fix by promoting to `pub`
+- Missing `use` in `whitening.rs` — add `use larql_compute::{back_solve_lt, cholesky, cholesky_inverse, compute_l_inv_t};`
+- `cholesky_l_packed` assertion on SmolLM2 — verify `960 * 961 / 2 = 461280`
+
+- [ ] **Step 3: Final commit if any fixup patches were needed**
+
+```bash
+git add -p  # stage only the fixup changes
+git commit -m "fix(canonical): resolve visibility and import issues after integration"
+```
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- [x] G_l covariance computation — Task 5 (`estimate_covariance`)
+- [x] Gate vector whitening — Task 6 (`compute_whitening`, `back_solve_lt`, `compute_l_inv_t`)
+- [x] On-shell projection filter — Task 7 (`compute_onshell_mask` via c_score percentile)
+- [x] Regime classifier — Task 8 (`classify_layer_regime`)
+- [x] `larql canonicalize` command — Task 9
+- [ ] **Not in this plan:** Writing whitened gate vectors to `gate_vectors_whitened.bin` — the canonical form stores the Cholesky factor; applying it to gate vectors is Plan 3 prerequisite
+- [ ] **Not in this plan:** Knowledge graph integration (Plan 2)
+- [ ] **Not in this plan:** Cross-model Procrustes alignment (Plan 3)
+
+**Type consistency:**
+- `back_solve_lt` defined in Task 1, used in Task 6 (`whitening.rs`) and re-exported via `larql_compute`
+- `compute_l_inv_t` defined in Task 1, used in whitening test (`Task 6 Step 1`)
+- `CanonicalMeta.cholesky_l_packed` field name matches in types.rs (Task 3), whitening.rs (Task 6), and canonicalize_cmd.rs (Task 9)
+- `read_cscores_binary` defined in Task 4, called in Task 9
+- `LayerCanonicalInfo` fields in types.rs (Task 3) match construction in canonicalize_cmd.rs (Task 9)
+
+**No placeholders confirmed.**

--- a/docs/superpowers/plans/2026-06-11-attention-hilbertian-residual.md
+++ b/docs/superpowers/plans/2026-06-11-attention-hilbertian-residual.md
@@ -1,0 +1,895 @@
+# Attention Hilbertian Residual Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `larql hilbertian <vindex>` — a weights-only command that scores, per attention head, how close that head's query/key coupling is to being genuinely complex-linear (i.e. the real part of a complex Hermitian form), and writes the per-head scores to `hilbertian_meta.json`.
+
+**Architecture:** A new pure-linear-algebra module `canonical/hilbertian.rs` builds the split-half complex structure `J` (`J²=−I`) and computes the relative commutator residual `‖[C,J]‖_F / ‖C‖_F` of a head's coupling matrix `C`. A manifest-driven loader `format/attn_load.rs` reads per-layer `W_Q`/`W_K` from `attn_weights.bin`. A new `larql-cli` subcommand assembles per-head couplings, scores them, and writes a JSON sidecar. Everything is intrinsic (a pure function of the weights), requires no corpus and no forward pass, and leaves all existing vindex files untouched.
+
+**Tech Stack:** Rust 2021, ndarray 0.16 (no BLAS feature — keep matrices small), serde / serde_json, clap, existing `larql-vindex` format helpers (`decode_floats`, `load_vindex_config`, filename constants).
+
+---
+
+## Domain background (read once)
+
+For an attention head, the query/key projections are `W_Q^{(h)}` and `W_K^{(g)}` (shape `[d_head, hidden]`, PyTorch `[out, in]` orientation). Their **coupling matrix** is
+
+```
+C_h = W_Q^{(h)} · (W_K^{(g)})ᵀ        # shape [d_head, d_head]
+```
+
+A complex structure on `ℝ^{d_head}` is a linear map `J` with `J² = −I`. The **split-half** convention (the one RoPE uses in this codebase — `crates/larql-compute/src/attention/rope.rs` pairs coordinate `i` with `i + d_head/2`) is:
+
+```
+J e_i        =  e_{i+half}      for i in [0, half)
+J e_{i+half} = −e_i             where half = d_head/2
+```
+
+`C_h` is the **real part of a complex Hermitian form** (it is "complex-linear" w.r.t. `J`) **iff** `C_h` commutes with `J`: `C_h J = J C_h`. We therefore score each head by the **relative commutator residual**
+
+```
+r_h = ‖C_h J − J C_h‖_F / ‖C_h‖_F        ∈ [0, 2]
+```
+
+`r_h = 0` ⟺ the head's coupling is genuinely complex-linear w.r.t. the split-half `J` (the realification of a complex `(d_head/2)×(d_head/2)` matrix). Larger `r_h` ⟺ more irreducibly real. Because `J` is orthogonal, `‖C_h J‖_F = ‖J C_h‖_F = ‖C_h‖_F`, so `r_h ≤ 2`.
+
+**Scope of this v1 (documented choices, refinements deferred to a follow-up issue in Task 6):**
+- Uses the **fixed** split-half `J`, not the *optimal* `J` minimised over all complex structures. The fixed-`J` residual is an **upper bound** on the optimal-`J` residual (the fixed `J` is one admissible choice, so the minimum can only be smaller). A small `r_h` therefore *proves* the head is near-complex-linear; a large `r_h` is inconclusive until the optimal-`J` fit (deferred) is done.
+- Analyses the `d_head×d_head` coupling `C_h` (cheap, RoPE-faithful `J`), not the `hidden×hidden` residual-space QK form (expensive without BLAS; deferred).
+- Computed in the model's native basis, not the canonical whitened basis (deferred — makes `r_h` a function of the canonical form).
+
+## Verified codebase facts (do not re-derive)
+
+- `attn_weights.bin` has **no header**: a raw concatenation of tensors. Per-tensor `{key, shape:[rows,cols], offset, length, file}` lives in `weight_manifest.json`, which is a **top-level JSON array**.
+- Keys: `"layers.{L}.self_attn.q_proj.weight"` (`[hidden, hidden]`) and `"layers.{L}.self_attn.k_proj.weight"` (`[num_kv_heads*head_dim, hidden]`). Orientation `[out, in]`, row-major.
+- dtype is per-tensor and detectable: `bytes_per_elem = length / (rows*cols)` → `2 = f16`, `4 = f32`. Decode with `larql_vindex::config::dtype::decode_floats(&[u8], StorageDtype) -> Vec<f32>`. `StorageDtype` is re-exported at `larql_vindex::StorageDtype`. (Confirm the variant names — likely `F16`/`F32` — by reading `crates/larql-vindex/src/config/dtype.rs` lines 12–42 in Task 4 Step 1.)
+- Head config: `VindexConfig.model_config: Option<VindexModelConfig>` with fields `num_q_heads: usize`, `num_kv_heads: usize`, `head_dim: usize` (`crates/larql-vindex/src/config/model.rs`). `hidden_size = num_q_heads * head_dim`.
+- GQA: query head `h` uses KV head `h / (num_q_heads / num_kv_heads)`. SmolLM2-360M: 15 Q-heads, 5 KV-heads (group size 3), `head_dim = 64`, `hidden_size = 960`, 32 layers, dtype f16, `quant: none`.
+- `VindexError::Io(#[from] std::io::Error)` exists (so `?` on `std::fs` works) and `VindexError::Parse(String)` exists.
+- Filename constants live in `crates/larql-vindex/src/format/filenames.rs`; `ATTN_WEIGHTS_BIN` and `WEIGHT_MANIFEST_JSON` already exist there.
+- CLI command pattern: see the existing `Canonicalize` variant (`crates/larql-cli/src/main.rs`) and `canonicalize_cmd.rs` — runners return `Result<(), Box<dyn std::error::Error>>`; the dispatch `match` arm returns the `Result` directly (no `?`).
+
+## File structure
+
+**New files:**
+- `crates/larql-vindex/src/canonical/hilbertian.rs` — `complex_structure_split_half`, `commutator_residual`, `head_block`, `head_coupling`, `kv_head_for_query`, `head_hilbertian_residual`
+- `crates/larql-vindex/src/format/attn_load.rs` — `load_attention_qk`
+- `crates/larql-cli/src/commands/extraction/hilbertian_cmd.rs` — `HilbertianArgs`, `run`
+
+**Modified files:**
+- `crates/larql-vindex/src/canonical/types.rs` — add `HeadHilbertianInfo`, `HilbertianMeta`
+- `crates/larql-vindex/src/canonical/mod.rs` — wire `hilbertian` module + re-exports
+- `crates/larql-vindex/src/format/filenames.rs` — add `HILBERTIAN_META_JSON`
+- `crates/larql-vindex/src/format/mod.rs` — add `pub mod attn_load;`
+- `crates/larql-cli/src/commands/extraction/mod.rs` — add `pub mod hilbertian_cmd;`
+- `crates/larql-cli/src/main.rs` — add `Hilbertian` variant + dispatch arm
+
+---
+
+## Task 1: Complex structure `J` and commutator residual
+
+**Files:**
+- Create: `crates/larql-vindex/src/canonical/hilbertian.rs`
+- Modify: `crates/larql-vindex/src/canonical/mod.rs`
+
+- [ ] **Step 1: Create the file with implementation + failing tests**
+
+Create `crates/larql-vindex/src/canonical/hilbertian.rs`:
+
+```rust
+//! Per-head "Hilbertian" residual: how close an attention head's query/key
+//! coupling is to being complex-linear w.r.t. the split-half complex
+//! structure J (J² = −I) that RoPE uses. See the plan doc for the math.
+
+use ndarray::{s, Array2};
+
+/// Build the split-half complex structure J on R^n (n must be even):
+///   J e_i        =  e_{i+half}     for i in [0, half)
+///   J e_{i+half} = −e_i
+/// so that J·J = −I. Panics if n is odd.
+pub fn complex_structure_split_half(n: usize) -> Array2<f64> {
+    assert!(n % 2 == 0, "complex structure requires even dimension, got {n}");
+    let half = n / 2;
+    let mut j = Array2::<f64>::zeros((n, n));
+    for i in 0..half {
+        j[[half + i, i]] = 1.0; // J e_i = e_{i+half}
+        j[[i, half + i]] = -1.0; // J e_{i+half} = -e_i
+    }
+    j
+}
+
+fn frob_norm(a: &Array2<f64>) -> f64 {
+    a.iter().map(|&x| x * x).sum::<f64>().sqrt()
+}
+
+/// Relative commutator residual ‖M J − J M‖_F / ‖M‖_F ∈ [0, 2].
+/// 0 ⟺ M commutes with J ⟺ M is complex-linear w.r.t. J.
+/// Returns 0.0 for the zero matrix (no division by zero).
+pub fn commutator_residual(m: &Array2<f64>, j: &Array2<f64>) -> f64 {
+    let comm = &m.dot(j) - &j.dot(m);
+    let den = frob_norm(m);
+    if den == 0.0 {
+        0.0
+    } else {
+        frob_norm(&comm) / den
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn j_squares_to_negative_identity() {
+        let j = complex_structure_split_half(4);
+        let jj = j.dot(&j);
+        let neg_i = -Array2::<f64>::eye(4);
+        for i in 0..4 {
+            for k in 0..4 {
+                assert!((jj[[i, k]] - neg_i[[i, k]]).abs() < 1e-12,
+                    "J^2 != -I at ({i},{k})");
+            }
+        }
+    }
+
+    #[test]
+    fn realified_complex_matrix_has_zero_residual() {
+        // M = [[A, -B], [B, A]] (2x2 blocks) commutes with split-half J on R^4.
+        let a = array![[1.0, 2.0], [3.0, 4.0]];
+        let b = array![[5.0, 6.0], [7.0, 8.0]];
+        let mut m = Array2::<f64>::zeros((4, 4));
+        m.slice_mut(s![0..2, 0..2]).assign(&a);
+        m.slice_mut(s![0..2, 2..4]).assign(&(-&b));
+        m.slice_mut(s![2..4, 0..2]).assign(&b);
+        m.slice_mut(s![2..4, 2..4]).assign(&a);
+        let j = complex_structure_split_half(4);
+        assert!(commutator_residual(&m, &j) < 1e-12);
+    }
+
+    #[test]
+    fn diagonal_matrix_has_positive_residual() {
+        // diag(1,2,3,4) does not commute with J (it mixes paired coords).
+        let m = Array2::from_diag(&array![1.0, 2.0, 3.0, 4.0]);
+        let j = complex_structure_split_half(4);
+        assert!(commutator_residual(&m, &j) > 0.1);
+    }
+
+    #[test]
+    fn identity_has_zero_residual() {
+        let m = Array2::<f64>::eye(4);
+        let j = complex_structure_split_half(4);
+        assert!(commutator_residual(&m, &j) < 1e-12);
+    }
+
+    #[test]
+    fn zero_matrix_has_zero_residual_not_nan() {
+        let m = Array2::<f64>::zeros((4, 4));
+        let j = complex_structure_split_half(4);
+        let r = commutator_residual(&m, &j);
+        assert_eq!(r, 0.0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn odd_dimension_panics() {
+        let _ = complex_structure_split_half(3);
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module into `canonical/mod.rs`**
+
+Append to the end of `crates/larql-vindex/src/canonical/mod.rs`:
+
+```rust
+pub mod hilbertian;
+pub use hilbertian::{commutator_residual, complex_structure_split_half};
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cd /home/metavacua/larql && cargo test -p larql-vindex canonical::hilbertian 2>&1 | tail -10`
+Expected: `test result: ok. 6 passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-vindex/src/canonical/hilbertian.rs crates/larql-vindex/src/canonical/mod.rs
+git commit -m "feat(canonical): add split-half complex structure J + commutator residual"
+```
+
+---
+
+## Task 2: Per-head coupling, head slicing, and GQA mapping
+
+**Files:**
+- Modify: `crates/larql-vindex/src/canonical/hilbertian.rs`
+
+- [ ] **Step 1: Add the failing tests**
+
+In `crates/larql-vindex/src/canonical/hilbertian.rs`, inside `mod tests`, add:
+
+```rust
+    #[test]
+    fn kv_head_for_query_maps_gqa_groups() {
+        // 15 query heads, 5 kv heads -> group size 3.
+        assert_eq!(kv_head_for_query(0, 15, 5), 0);
+        assert_eq!(kv_head_for_query(2, 15, 5), 0);
+        assert_eq!(kv_head_for_query(3, 15, 5), 1);
+        assert_eq!(kv_head_for_query(14, 15, 5), 4);
+        // No GQA (num_kv == num_q): identity.
+        assert_eq!(kv_head_for_query(2, 4, 4), 2);
+        // Single kv head: everything maps to 0.
+        assert_eq!(kv_head_for_query(7, 8, 1), 0);
+    }
+
+    #[test]
+    fn head_block_extracts_rows() {
+        // proj is [4, 3] = 2 heads of head_dim 2.
+        let proj = array![
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+            [10.0, 11.0, 12.0],
+        ];
+        let h0 = head_block(&proj, 0, 2);
+        let h1 = head_block(&proj, 1, 2);
+        assert_eq!(h0, array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        assert_eq!(h1, array![[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]);
+    }
+
+    #[test]
+    fn head_coupling_is_wq_times_wk_transpose() {
+        // wq, wk are [d_head=2, hidden=3]; C = wq · wkᵀ is [2,2].
+        let wq = array![[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        let wk = array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+        let c = head_coupling(&wq, &wk);
+        // row0·wkᵀ = [1,4]; row1·wkᵀ = [2,5]
+        assert_eq!(c, array![[1.0, 4.0], [2.0, 5.0]]);
+    }
+
+    #[test]
+    fn head_hilbertian_residual_matches_manual_composition() {
+        let wq = array![[1.0, 2.0, 0.0, 0.0], [0.0, 1.0, 1.0, 0.0]];
+        let wk = array![[0.0, 1.0, 2.0, 0.0], [1.0, 0.0, 0.0, 3.0]];
+        let j = complex_structure_split_half(2); // d_head = 2
+        let direct = head_hilbertian_residual(&wq, &wk, &j);
+        let manual = commutator_residual(&head_coupling(&wq, &wk), &j);
+        assert!((direct - manual).abs() < 1e-15);
+    }
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `cd /home/metavacua/larql && cargo test -p larql-vindex canonical::hilbertian 2>&1 | tail -10`
+Expected: compile error — `kv_head_for_query`, `head_block`, `head_coupling`, `head_hilbertian_residual` not defined.
+
+- [ ] **Step 3: Add the implementations**
+
+In `crates/larql-vindex/src/canonical/hilbertian.rs`, add before the `#[cfg(test)]` block:
+
+```rust
+/// Map a query-head index to its KV-head index under grouped-query attention.
+/// `num_q_heads` must be a multiple of `num_kv_heads`.
+pub fn kv_head_for_query(query_head: usize, num_q_heads: usize, num_kv_heads: usize) -> usize {
+    let group = num_q_heads / num_kv_heads;
+    query_head / group.max(1)
+}
+
+/// Extract head `head`'s `[head_dim, hidden]` block from a stacked projection
+/// matrix `[n*head_dim, hidden]` (PyTorch `[out, in]` orientation).
+pub fn head_block(proj: &Array2<f64>, head: usize, head_dim: usize) -> Array2<f64> {
+    proj.slice(s![head * head_dim..(head + 1) * head_dim, ..]).to_owned()
+}
+
+/// Per-head query/key coupling C = W_Q · W_Kᵀ, shape `[head_dim, head_dim]`.
+/// `wq_head` and `wk_head` are both `[head_dim, hidden]`.
+pub fn head_coupling(wq_head: &Array2<f64>, wk_head: &Array2<f64>) -> Array2<f64> {
+    wq_head.dot(&wk_head.t())
+}
+
+/// Hilbertian residual for one head: ‖[C, J]‖_F / ‖C‖_F where C = W_Q W_Kᵀ.
+/// `j` must be the split-half complex structure of dimension `head_dim`.
+pub fn head_hilbertian_residual(
+    wq_head: &Array2<f64>,
+    wk_head: &Array2<f64>,
+    j: &Array2<f64>,
+) -> f64 {
+    let c = head_coupling(wq_head, wk_head);
+    commutator_residual(&c, j)
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `cd /home/metavacua/larql && cargo test -p larql-vindex canonical::hilbertian 2>&1 | tail -10`
+Expected: `test result: ok. 10 passed`
+
+- [ ] **Step 5: Update re-exports in `canonical/mod.rs`**
+
+In `crates/larql-vindex/src/canonical/mod.rs`, change the hilbertian re-export line to:
+
+```rust
+pub use hilbertian::{
+    commutator_residual, complex_structure_split_half, head_block, head_coupling,
+    head_hilbertian_residual, kv_head_for_query,
+};
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-vindex/src/canonical/hilbertian.rs crates/larql-vindex/src/canonical/mod.rs
+git commit -m "feat(canonical): add per-head coupling, head slicing, GQA mapping, head residual"
+```
+
+---
+
+## Task 3: Result types and the `hilbertian_meta.json` filename constant
+
+**Files:**
+- Modify: `crates/larql-vindex/src/canonical/types.rs`
+- Modify: `crates/larql-vindex/src/canonical/mod.rs`
+- Modify: `crates/larql-vindex/src/format/filenames.rs`
+
+- [ ] **Step 1: Add the failing tests for the types**
+
+In `crates/larql-vindex/src/canonical/types.rs`, inside `mod tests`, add:
+
+```rust
+    #[test]
+    fn hilbertian_meta_round_trips_through_json() {
+        let meta = HilbertianMeta {
+            version: 1,
+            model: "test/model".into(),
+            hidden_size: 4,
+            head_dim: 2,
+            num_q_heads: 2,
+            num_kv_heads: 1,
+            complex_structure: "split_half".into(),
+            heads: vec![
+                HeadHilbertianInfo { layer: 0, query_head: 0, kv_head: 0, residual: 0.0 },
+                HeadHilbertianInfo { layer: 0, query_head: 1, kv_head: 0, residual: 1.25 },
+            ],
+        };
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        let back: HilbertianMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.model, "test/model");
+        assert_eq!(back.heads.len(), 2);
+        assert_eq!(back.heads[1].query_head, 1);
+        assert!((back.heads[1].residual - 1.25).abs() < 1e-15);
+        assert_eq!(back.complex_structure, "split_half");
+    }
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+Run: `cd /home/metavacua/larql && cargo test -p larql-vindex canonical::types::tests::hilbertian_meta_round_trips_through_json 2>&1 | tail -10`
+Expected: compile error — `HilbertianMeta` / `HeadHilbertianInfo` not defined.
+
+- [ ] **Step 3: Add the types**
+
+In `crates/larql-vindex/src/canonical/types.rs`, after the `CanonicalMeta` impl block (before `#[cfg(test)]`), add:
+
+```rust
+/// Per-head Hilbertian residual: how close head `query_head`'s query/key
+/// coupling is to complex-linear w.r.t. the split-half complex structure.
+/// `residual` ∈ [0, 2]; 0 = exactly complex-linear (an upper bound on the
+/// optimal-J residual).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeadHilbertianInfo {
+    pub layer: usize,
+    pub query_head: usize,
+    pub kv_head: usize,
+    pub residual: f64,
+}
+
+/// Root metadata written to `hilbertian_meta.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HilbertianMeta {
+    pub version: u32,
+    pub model: String,
+    pub hidden_size: usize,
+    pub head_dim: usize,
+    pub num_q_heads: usize,
+    pub num_kv_heads: usize,
+    /// The fixed complex-structure convention used (currently always "split_half").
+    pub complex_structure: String,
+    pub heads: Vec<HeadHilbertianInfo>,
+}
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+Run: `cd /home/metavacua/larql && cargo test -p larql-vindex canonical::types::tests::hilbertian_meta_round_trips_through_json 2>&1 | tail -5`
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 5: Re-export the types in `canonical/mod.rs`**
+
+In `crates/larql-vindex/src/canonical/mod.rs`, change the `types` re-export line so it also exports the new types. The current line is:
+
+```rust
+pub use types::{CanonicalMeta, LayerCanonicalInfo, Regime};
+```
+
+Replace it with:
+
+```rust
+pub use types::{
+    CanonicalMeta, HeadHilbertianInfo, HilbertianMeta, LayerCanonicalInfo, Regime,
+};
+```
+
+- [ ] **Step 6: Add the filename constant + its uniqueness test**
+
+In `crates/larql-vindex/src/format/filenames.rs`, in the "Canonical form sidecar" section (right after `CANONICAL_META_JSON`), add:
+
+```rust
+pub const HILBERTIAN_META_JSON: &str = "hilbertian_meta.json";
+```
+
+Then add `HILBERTIAN_META_JSON` to the `names` array in the `all_filenames_unique` test (so future additions can't collide with it), and add this test inside `mod tests`:
+
+```rust
+    #[test]
+    fn hilbertian_meta_json_is_distinct_from_canonical() {
+        assert_ne!(HILBERTIAN_META_JSON, CANONICAL_META_JSON);
+        assert_eq!(HILBERTIAN_META_JSON, "hilbertian_meta.json");
+    }
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `cd /home/metavacua/larql && cargo test -p larql-vindex format::filenames canonical::types 2>&1 | tail -10`
+Expected: all pass (including `all_filenames_unique` and the two new tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-vindex/src/canonical/types.rs \
+        crates/larql-vindex/src/canonical/mod.rs \
+        crates/larql-vindex/src/format/filenames.rs
+git commit -m "feat(canonical): add HilbertianMeta types + hilbertian_meta.json constant"
+```
+
+---
+
+## Task 4: Manifest-driven attention Q/K loader
+
+**Files:**
+- Create: `crates/larql-vindex/src/format/attn_load.rs`
+- Modify: `crates/larql-vindex/src/format/mod.rs`
+
+- [ ] **Step 1: Confirm the `StorageDtype` variant names**
+
+Run: `cd /home/metavacua/larql && sed -n '12,42p' crates/larql-vindex/src/config/dtype.rs`
+Note the exact variant names for f32 and f16 (the code below assumes `StorageDtype::F32` and `StorageDtype::F16`). If they differ (e.g. `Float32`), use the actual names in Step 3.
+
+- [ ] **Step 2: Create the file with implementation + a hermetic test**
+
+Create `crates/larql-vindex/src/format/attn_load.rs`:
+
+```rust
+//! Manifest-driven reader for per-layer attention Q/K weight matrices.
+//!
+//! `attn_weights.bin` is a header-less concatenation of tensors; offsets and
+//! shapes come from `weight_manifest.json` (a top-level JSON array). We read
+//! only the `q_proj` / `k_proj` tensors — no tokenizer, no forward pass, and
+//! no full-model load.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use ndarray::Array2;
+use serde::Deserialize;
+
+use crate::config::dtype::{decode_floats, StorageDtype};
+use crate::error::VindexError;
+use crate::format::filenames::{ATTN_WEIGHTS_BIN, WEIGHT_MANIFEST_JSON};
+
+#[derive(Deserialize)]
+struct ManifestEntry {
+    key: String,
+    shape: Vec<usize>,
+    offset: usize,
+    length: usize,
+    file: String,
+}
+
+/// Load per-layer `(W_Q, W_K)` from `attn_weights.bin`.
+/// `W_Q` is `[num_q_heads*head_dim, hidden]`, `W_K` is `[num_kv_heads*head_dim, hidden]`,
+/// both as `f32` (decoded from on-disk f16/f32). Index in the returned Vec is the layer.
+pub fn load_attention_qk(
+    dir: &Path,
+    num_layers: usize,
+) -> Result<Vec<(Array2<f32>, Array2<f32>)>, VindexError> {
+    let manifest_bytes = std::fs::read(dir.join(WEIGHT_MANIFEST_JSON))?;
+    let entries: Vec<ManifestEntry> = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| VindexError::Parse(format!("weight_manifest.json: {e}")))?;
+    let by_key: HashMap<&str, &ManifestEntry> =
+        entries.iter().map(|e| (e.key.as_str(), e)).collect();
+
+    let bin = std::fs::read(dir.join(ATTN_WEIGHTS_BIN))?;
+
+    let mut out = Vec::with_capacity(num_layers);
+    for layer in 0..num_layers {
+        let q_key = format!("layers.{layer}.self_attn.q_proj.weight");
+        let k_key = format!("layers.{layer}.self_attn.k_proj.weight");
+        let wq = read_entry(&bin, lookup(&by_key, &q_key)?)?;
+        let wk = read_entry(&bin, lookup(&by_key, &k_key)?)?;
+        out.push((wq, wk));
+    }
+    Ok(out)
+}
+
+fn lookup<'a>(
+    by_key: &HashMap<&str, &'a ManifestEntry>,
+    key: &str,
+) -> Result<&'a ManifestEntry, VindexError> {
+    by_key
+        .get(key)
+        .copied()
+        .ok_or_else(|| VindexError::Parse(format!("weight_manifest.json missing key {key}")))
+}
+
+fn read_entry(bin: &[u8], e: &ManifestEntry) -> Result<Array2<f32>, VindexError> {
+    if e.file != ATTN_WEIGHTS_BIN {
+        return Err(VindexError::Parse(format!(
+            "entry {} is in {}, expected {ATTN_WEIGHTS_BIN}",
+            e.key, e.file
+        )));
+    }
+    if e.shape.len() != 2 {
+        return Err(VindexError::Parse(format!(
+            "entry {} has non-2D shape {:?}",
+            e.key, e.shape
+        )));
+    }
+    let (rows, cols) = (e.shape[0], e.shape[1]);
+    let n = rows * cols;
+    if n == 0 {
+        return Err(VindexError::Parse(format!("entry {} is empty", e.key)));
+    }
+    let dtype = match e.length / n {
+        4 => StorageDtype::F32,
+        2 => StorageDtype::F16,
+        other => {
+            return Err(VindexError::Parse(format!(
+                "entry {} has {other} bytes/elem (expected 2 or 4)",
+                e.key
+            )))
+        }
+    };
+    let end = e.offset + e.length;
+    if end > bin.len() {
+        return Err(VindexError::Parse(format!(
+            "entry {} range {}..{end} exceeds {ATTN_WEIGHTS_BIN} ({} bytes)",
+            e.key,
+            e.offset,
+            bin.len()
+        )));
+    }
+    let floats = decode_floats(&bin[e.offset..end], dtype);
+    Array2::from_shape_vec((rows, cols), floats)
+        .map_err(|e| VindexError::Parse(format!("reshape attention weight: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_qk_from_a_synthetic_vindex() {
+        let dir = tempfile::tempdir().unwrap();
+        // Two f32 tensors: q_proj [2,2] then k_proj [2,2], concatenated.
+        let q: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
+        let k: [f32; 4] = [5.0, 6.0, 7.0, 8.0];
+        let mut bin = Vec::new();
+        for v in q.iter().chain(k.iter()) {
+            bin.extend_from_slice(&v.to_le_bytes());
+        }
+        std::fs::write(dir.path().join(ATTN_WEIGHTS_BIN), &bin).unwrap();
+
+        let manifest = serde_json::json!([
+            {"key": "layers.0.self_attn.q_proj.weight", "shape": [2, 2],
+             "offset": 0, "length": 16, "file": ATTN_WEIGHTS_BIN},
+            {"key": "layers.0.self_attn.k_proj.weight", "shape": [2, 2],
+             "offset": 16, "length": 16, "file": ATTN_WEIGHTS_BIN}
+        ]);
+        std::fs::write(
+            dir.path().join(WEIGHT_MANIFEST_JSON),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let qk = load_attention_qk(dir.path(), 1).unwrap();
+        assert_eq!(qk.len(), 1);
+        let (wq, wk) = &qk[0];
+        assert_eq!(wq.shape(), [2, 2]);
+        assert_eq!(wk.shape(), [2, 2]);
+        assert_eq!(wq[[0, 0]], 1.0);
+        assert_eq!(wq[[1, 1]], 4.0);
+        assert_eq!(wk[[0, 0]], 5.0);
+        assert_eq!(wk[[1, 1]], 8.0);
+    }
+
+    #[test]
+    fn missing_key_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(ATTN_WEIGHTS_BIN), [0u8; 16]).unwrap();
+        std::fs::write(
+            dir.path().join(WEIGHT_MANIFEST_JSON),
+            serde_json::to_vec(&serde_json::json!([])).unwrap(),
+        )
+        .unwrap();
+        assert!(load_attention_qk(dir.path(), 1).is_err());
+    }
+}
+```
+
+- [ ] **Step 3: Adjust dtype variant names if needed**
+
+If Step 1 showed the variants are not `F32` / `F16`, edit the `match e.length / n` arms in `read_entry` accordingly.
+
+- [ ] **Step 4: Wire the module into `format/mod.rs`**
+
+In `crates/larql-vindex/src/format/mod.rs`, add (next to the other `pub mod` lines, alphabetically near `attn_*` or at the top of the module list):
+
+```rust
+pub mod attn_load;
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /home/metavacua/larql && cargo test -p larql-vindex format::attn_load 2>&1 | tail -10`
+Expected: `test result: ok. 2 passed`
+
+- [ ] **Step 6: Confirm `tempfile` is available for the test**
+
+`tempfile` is already used by `format::filenames` tests, so it is a dev-dependency. If the build complains it is missing, run `cargo add --dev tempfile -p larql-vindex` and re-run Step 5.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-vindex/src/format/attn_load.rs crates/larql-vindex/src/format/mod.rs
+git commit -m "feat(format): add manifest-driven attention Q/K loader"
+```
+
+---
+
+## Task 5: `larql hilbertian` CLI command
+
+**Files:**
+- Create: `crates/larql-cli/src/commands/extraction/hilbertian_cmd.rs`
+- Modify: `crates/larql-cli/src/commands/extraction/mod.rs`
+- Modify: `crates/larql-cli/src/main.rs`
+
+- [ ] **Step 1: Create the command file**
+
+Create `crates/larql-cli/src/commands/extraction/hilbertian_cmd.rs`:
+
+```rust
+use std::path::PathBuf;
+use std::time::Instant;
+
+use clap::Args;
+use larql_vindex::{
+    canonical::{
+        complex_structure_split_half, head_block, head_hilbertian_residual, kv_head_for_query,
+        HeadHilbertianInfo, HilbertianMeta,
+    },
+    format::{attn_load::load_attention_qk, filenames::HILBERTIAN_META_JSON, load::load_vindex_config},
+};
+
+#[derive(Args)]
+pub struct HilbertianArgs {
+    /// Path to the .vindex directory to analyse.
+    vindex: PathBuf,
+}
+
+pub fn run(args: HilbertianArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = &args.vindex;
+    let t0 = Instant::now();
+    println!("Hilbertian residual for vindex at {}", dir.display());
+
+    let config = load_vindex_config(dir)?;
+    let mc = config
+        .model_config
+        .as_ref()
+        .ok_or("hilbertian: index.json has no model_config (need head_dim / head counts)")?;
+    let (num_q, num_kv, head_dim, hidden) =
+        (mc.num_q_heads, mc.num_kv_heads, mc.head_dim, config.hidden_size);
+    println!(
+        "  model: {} ({}), {} layers, hidden={hidden}, q_heads={num_q}, kv_heads={num_kv}, head_dim={head_dim}",
+        config.model, config.family, config.num_layers
+    );
+
+    let j = complex_structure_split_half(head_dim);
+
+    print!("  loading attention Q/K ... ");
+    let qk = load_attention_qk(dir, config.num_layers)?;
+    println!("{} layers ({:.1}ms)", qk.len(), t0.elapsed().as_secs_f64() * 1000.0);
+
+    let mut heads: Vec<HeadHilbertianInfo> = Vec::with_capacity(config.num_layers * num_q);
+    for (layer, (wq, wk)) in qk.iter().enumerate() {
+        let wq64 = wq.mapv(|v| v as f64);
+        let wk64 = wk.mapv(|v| v as f64);
+        for h in 0..num_q {
+            let g = kv_head_for_query(h, num_q, num_kv);
+            let wq_h = head_block(&wq64, h, head_dim);
+            let wk_g = head_block(&wk64, g, head_dim);
+            let residual = head_hilbertian_residual(&wq_h, &wk_g, &j);
+            heads.push(HeadHilbertianInfo { layer, query_head: h, kv_head: g, residual });
+        }
+    }
+
+    let meta = HilbertianMeta {
+        version: 1,
+        model: config.model.clone(),
+        hidden_size: hidden,
+        head_dim,
+        num_q_heads: num_q,
+        num_kv_heads: num_kv,
+        complex_structure: "split_half".into(),
+        heads,
+    };
+
+    let out = dir.join(HILBERTIAN_META_JSON);
+    std::fs::write(&out, serde_json::to_string_pretty(&meta)?)?;
+
+    let rs: Vec<f64> = meta.heads.iter().map(|h| h.residual).collect();
+    let mean = rs.iter().sum::<f64>() / rs.len() as f64;
+    let min = rs.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = rs.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    println!(
+        "  residual over {} heads: mean {:.4}, min {:.4}, max {:.4}",
+        rs.len(),
+        mean,
+        min,
+        max
+    );
+    println!("  wrote {}", out.display());
+    println!("  total: {:.1}ms", t0.elapsed().as_secs_f64() * 1000.0);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `crates/larql-cli/src/commands/extraction/mod.rs`, add (alphabetically, after `pub mod hf_cmd;`):
+
+```rust
+pub mod hilbertian_cmd;
+```
+
+- [ ] **Step 3: Add the `Hilbertian` variant to the `Commands` enum**
+
+In `crates/larql-cli/src/main.rs`, in the "Build / extract" section of `enum Commands` (after the `Canonicalize` variant), add:
+
+```rust
+    #[command(next_help_heading = "Build")]
+    /// Score per-head complex-linearity (Hilbertian residual); writes hilbertian_meta.json.
+    Hilbertian(hilbertian_cmd::HilbertianArgs),
+```
+
+- [ ] **Step 4: Add the dispatch arm**
+
+In `crates/larql-cli/src/main.rs`, in the `let result = match cli.command {` block, in the `// ── Build / extract ──` section (right after the `Commands::Canonicalize(args) => ...` arm), add:
+
+```rust
+        Commands::Hilbertian(args) => hilbertian_cmd::run(args),
+```
+
+- [ ] **Step 5: Build**
+
+Run: `cd /home/metavacua/larql && cargo build -p larql-cli 2>&1 | tail -20`
+Expected: compiles without errors. If `model_config` field access fails, confirm field names with `sed -n '10,30p' crates/larql-vindex/src/config/model.rs` and adjust.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-cli/src/commands/extraction/hilbertian_cmd.rs \
+        crates/larql-cli/src/commands/extraction/mod.rs \
+        crates/larql-cli/src/main.rs
+git commit -m "feat(cli): add larql hilbertian command"
+```
+
+---
+
+## Task 6: Integration smoke test, discrimination check, full suite
+
+**Files:** none modified unless a fixup is needed.
+
+- [ ] **Step 1: Run the full workspace tests for the touched crates**
+
+Run: `cd /home/metavacua/larql && cargo test -p larql-vindex --lib 2>&1 | tail -8`
+Expected: all pass. (Note: the pre-existing integration test `vector_extractor_ffn_down_byte_identical` in `tests/test_walker_accuracy.rs` fails on this environment independent of these changes — it is a 64↔32-bit golden-drift failure that also fails on the base commit. Use `--lib` to scope to unit tests and avoid it.)
+
+Run: `cd /home/metavacua/larql && cargo test -p larql-cli 2>&1 | tail -5`
+Expected: all pass.
+
+- [ ] **Step 2: Build release and run the smoke test on SmolLM2-360M**
+
+```
+cd /home/metavacua/larql && cargo build --release -p larql-cli 2>&1 | tail -3
+./target/release/larql hilbertian /home/metavacua/larql-vindexes/smollm2-360m.vindex 2>&1
+```
+Expected: prints `model: ... (llama), 32 layers, hidden=960, q_heads=15, kv_heads=5, head_dim=64`, then a `residual over 480 heads: mean ... min ... max ...` line, then `wrote .../hilbertian_meta.json`. Should complete in well under a minute (each commutator is 64×64).
+
+- [ ] **Step 3: Verify the JSON structure and that the metric is discriminating**
+
+```
+python3 -c "
+import json
+m = json.load(open('/home/metavacua/larql-vindexes/smollm2-360m.vindex/hilbertian_meta.json'))
+assert m['version'] == 1
+assert m['head_dim'] == 64 and m['num_q_heads'] == 15 and m['num_kv_heads'] == 5
+rs = [h['residual'] for h in m['heads']]
+assert len(rs) == 32 * 15, f'expected 480 heads, got {len(rs)}'
+lo, hi = min(rs), max(rs)
+print(f'heads={len(rs)} min={lo:.4f} max={hi:.4f} mean={sum(rs)/len(rs):.4f}')
+assert all(0.0 <= r <= 2.0 + 1e-9 for r in rs), 'residual out of [0,2]'
+# Discrimination: the metric must not be degenerate (all ~equal). If it IS
+# degenerate, that is itself a finding to record (see Step 5), not a pass.
+assert hi - lo > 1e-3, 'DEGENERATE: residuals do not vary across heads'
+print('OK — metric is well-formed and discriminating')
+"
+```
+Expected: prints the stats and `OK — metric is well-formed and discriminating`.
+
+- [ ] **Step 4: Confirm existing vindex files were not modified**
+
+```
+cd /home/metavacua/larql-vindexes/smollm2-360m.vindex && ls -la canonical_meta.json hilbertian_meta.json attn_weights.bin index.json
+```
+Expected: `hilbertian_meta.json` exists; the command only ever wrote that one file (verify by inspection that `hilbertian_cmd.rs` has exactly one `std::fs::write`, to the `HILBERTIAN_META_JSON` path).
+
+- [ ] **Step 5: If Step 3's discrimination assertion FAILS (degenerate metric)**
+
+Do not silently pass. Record the finding the way #134 was recorded: post an issue **only to `metavacua/larql-to-sparql`** (the hard remote constraint — verify with `git remote -v` that you push to `fork`, never to `origin`/chrishayuk), titled e.g. "hilbertian: split-half-J residual is degenerate on SmolLM2", describing the observed distribution, and note that the optimal-J fit (below) is the likely fix. Then continue — the implementation is still correct; the metric choice is the open question.
+
+- [ ] **Step 6: File the deferred-refinement issue**
+
+Post an issue to `metavacua/larql-to-sparql` (verify remote first) titled "hilbertian: optimal-J fit, residual-space QK form, whitened-basis" capturing the three v1 simplifications documented in this plan's "Scope" note: (a) optimal `J` minimised over complex structures instead of fixed split-half, (b) the `hidden×hidden` residual-space QK form `W_Qᵀ W_K` instead of the `d_head×d_head` coupling, (c) computing in the canonical whitened basis so the residual is a function of the canonical form. Reference this plan and the `larql hilbertian` command.
+
+- [ ] **Step 7: Commit any fixups**
+
+If Steps 1–4 required code changes, commit them:
+
+```bash
+cd /home/metavacua/larql
+git add -A
+git commit -m "fix(hilbertian): resolve integration issues found in smoke test"
+```
+
+Otherwise nothing to commit for this task.
+
+---
+
+## Self-review checklist
+
+**Spec coverage** (the "spec" is the metric design in the Domain background section):
+- [x] Split-half complex structure `J` with `J²=−I` — Task 1 (`complex_structure_split_half`)
+- [x] Relative commutator residual `‖[C,J]‖/‖C‖` — Task 1 (`commutator_residual`)
+- [x] Per-head coupling `C = W_Q W_Kᵀ` + GQA head pairing + head slicing — Task 2
+- [x] Result types + sidecar filename — Task 3
+- [x] Weights-only attention Q/K loader (no corpus, no forward pass) — Task 4
+- [x] `larql hilbertian` command writing `hilbertian_meta.json` — Task 5
+- [x] Integration + discrimination check + untouched-files check — Task 6
+- [ ] **Deferred (Task 6 Step 6 issue):** optimal-J fit, residual-space QK form, whitened-basis computation
+
+**Type consistency:**
+- `complex_structure_split_half(n) -> Array2<f64>` defined Task 1, called Task 5 with `head_dim`.
+- `head_block(proj, head, head_dim)`, `head_coupling`, `head_hilbertian_residual`, `kv_head_for_query` defined Task 2, all consumed in Task 5 with matching signatures.
+- `HeadHilbertianInfo { layer, query_head, kv_head, residual }` and `HilbertianMeta { version, model, hidden_size, head_dim, num_q_heads, num_kv_heads, complex_structure, heads }` defined Task 3, constructed identically in Task 5.
+- `load_attention_qk(dir, num_layers) -> Result<Vec<(Array2<f32>, Array2<f32>)>, VindexError>` defined Task 4, called Task 5.
+- `HILBERTIAN_META_JSON` defined Task 3, used Task 5.
+- CLI runner returns `Result<(), Box<dyn std::error::Error>>` and the dispatch arm returns it directly (no `?`) — matches the `Canonicalize` precedent.
+
+**No placeholders:** every code step contains complete code; every run step has an exact command and expected output. The two investigation steps (Task 4 Step 1 dtype variant names, Task 5 Step 5 field-name fallback) point at exact file:line ranges to read, not "figure it out."

--- a/docs/superpowers/plans/2026-06-11-constructive-measurement-layer.md
+++ b/docs/superpowers/plans/2026-06-11-constructive-measurement-layer.md
@@ -1,0 +1,576 @@
+# Constructive Measurement Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Operationalize measurement-as-elimination on the existing single-qubit QLM: a destructive (linear, no-cloning) projective measurement that consumes the state, the impossible outcome as typed falsity (⊥ ≅ `None` ≅ score −∞), and a bounded-extraction admissibility layer that tags queries by arithmetical fragment (Rosko 2025: admissible measurement = finite extraction ⊆ Σ⁰₁ ∪ Π⁰₂).
+
+**Architecture:** Two new modules in the existing `larql-hilbert` crate. `measurement.rs` adds `project` (the elimination rule) and a `LinearQubit` wrapper that is `!Copy` so Rust's move semantics enforce the no-cloning discipline. `admissibility.rs` adds the Δ₀ realizability decider, a Σ⁰₁ bounded witness search, and the Π⁰₂ uniform-stability verifier — the arithmetical hierarchy made concrete as the quantifier shape of bounded extraction procedures over the QLM. Pure Rust, no new dependencies.
+
+**Tech Stack:** Rust 2021, `num-complex` (already a dep), the existing `larql-hilbert` `Qubit` / `SingleQubitLM` / `measure_probs` API.
+
+---
+
+## Scope note: first of two sequenced plans
+
+- **This plan (A):** the constructive-measurement / admissibility layer on the *existing single qubit*. A logic/types layer — no new quantum algebra.
+- **Next plan (B), separate:** the 2-qubit LM + Bell entanglement operation, built on top of this. Partial measurement there reuses the elimination/⊥ discipline established here.
+
+## Domain background (read once)
+
+The existing `measure_probs(&Qubit) -> [f64; 2]` is *non-destructive* — it reads probabilities without consuming the state (the cartesian, free-copy reading; this is the "logit-lens" analogue). **Measurement proper is an elimination rule**: it *consumes* the state and yields a collapsed basis state, or fails if the outcome is impossible. The discriminator between the two is substructural, not lexical:
+
+- non-destructive read = **contraction allowed** (the state is copyable) — cartesian.
+- destructive measurement = **no contraction** (the state is consumed) — linear / no-cloning.
+
+In Rust, the linear discipline is exactly **move semantics on a `!Copy` type**: a value consumed by a method that takes `self` by value cannot be used again — the borrow checker *is* the no-cloning enforcer.
+
+The **impossible outcome** (`P = 0`) is the uninhabited type ⊥: `project` returns `None`, mirroring `score` returning `−∞`. A successful projection is a constructive witness that the outcome was inhabited.
+
+**Rosko (arXiv:2511.21296):** admissible physical measurement yields only *finite* observational sequences, so the physically meaningful queries are those with terminating extraction — the arithmetical fragment **Σ⁰₁ ∪ Π⁰₂**, with Δ₀ the decidable core. We make the hierarchy concrete as the quantifier structure of *bounded* procedures over the QLM:
+- **Δ₀** — "is this finite sequence realizable?" (decidable; `score` finite).
+- **Σ⁰₁** — "∃ a realizable continuation (length ≤ k) satisfying P?" (bounded witness search).
+- **Π⁰₂** — "∀ realizable prefix (length ≤ k), ∃ a valid next token?" (uniform stability).
+
+## File structure
+
+New files in `crates/larql-hilbert/`:
+- `src/measurement.rs` — `project` (elimination rule, `None` = ⊥), `LinearQubit` (`!Copy`, consumed by `measure`).
+- `src/admissibility.rs` — `ArithFragment` enum, `is_realizable` (Δ₀), `exists_continuation` (Σ⁰₁), `uniformly_stable` (Π⁰₂).
+
+Modified: `src/lib.rs` — declare the two modules + re-exports.
+
+Existing API used (do not modify): `Qubit { pub amp: [Complex64; 2] }`, `Qubit::ket0()`, `apply(&Gate)`; `unitary::{hadamard, identity, pauli_x}`; `born::measure_probs`; `qlm::SingleQubitLM { gates, init }` with `score(&[usize]) -> f64`.
+
+---
+
+## Task 1: `project` — the measurement elimination rule
+
+**Files:**
+- Create: `crates/larql-hilbert/src/measurement.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/measurement.rs`**
+
+```rust
+//! Measurement as a (linear, destructive) elimination rule.
+//!
+//! `project` is the projective-measurement eliminator: given an outcome it
+//! returns the collapsed post-measurement state, or `None` when that outcome is
+//! impossible — the uninhabited type ⊥ (mirroring `SingleQubitLM::score`
+//! returning −∞). `LinearQubit` enforces the no-cloning discipline: it is
+//! `!Copy`/`!Clone`, so measuring it *consumes* it (Rust move semantics = the
+//! linear-logic restriction on contraction).
+
+use num_complex::Complex64;
+
+use crate::qubit::Qubit;
+
+/// Projective measurement onto `|outcome⟩`: returns the normalized projection
+/// (the collapsed state), or `None` if the outcome has amplitude 0 (⊥).
+///
+/// # Panics
+/// Panics if `outcome` is ≥ 2 (the basis is `{0, 1}`).
+pub fn project(state: &Qubit, outcome: usize) -> Option<Qubit> {
+    let amp = state.amp[outcome];
+    let mag = amp.norm();
+    if mag == 0.0 {
+        return None;
+    }
+    let mut new_amp = [Complex64::new(0.0, 0.0); 2];
+    new_amp[outcome] = amp / mag;
+    Some(Qubit { amp: new_amp })
+}
+
+/// A single-use qubit. NOT `Copy`/`Clone`, so the borrow checker enforces the
+/// no-cloning theorem: `measure` takes `self` by value and consumes it.
+pub struct LinearQubit {
+    state: Qubit,
+}
+
+impl LinearQubit {
+    /// Wrap a qubit as a single-use (linear) resource.
+    pub fn new(state: Qubit) -> Self {
+        LinearQubit { state }
+    }
+
+    /// Consume this state by measuring `outcome`; returns the collapsed state,
+    /// or `None` if the outcome was impossible (⊥). After this call the
+    /// `LinearQubit` has been moved and cannot be measured (or copied) again —
+    /// enforced at compile time.
+    ///
+    /// # Panics
+    /// Panics if `outcome` is ≥ 2.
+    pub fn measure(self, outcome: usize) -> Option<Qubit> {
+        project(&self.state, outcome)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::born::measure_probs;
+    use crate::unitary::hadamard;
+
+    #[test]
+    fn project_impossible_outcome_is_bottom() {
+        // |0⟩ has zero amplitude on outcome 1 → ⊥.
+        assert!(project(&Qubit::ket0(), 1).is_none());
+    }
+
+    #[test]
+    fn project_collapses_to_the_measured_basis_state() {
+        let plus = Qubit::ket0().apply(&hadamard()); // |+⟩
+        let collapsed = project(&plus, 0).unwrap();
+        let p = measure_probs(&collapsed);
+        assert!((p[0] - 1.0).abs() < 1e-12 && p[1].abs() < 1e-12);
+    }
+
+    #[test]
+    fn linear_qubit_measure_consumes_and_collapses() {
+        let lq = LinearQubit::new(Qubit::ket0().apply(&hadamard()));
+        let collapsed = lq.measure(1).unwrap();
+        // lq has been moved here; a second `lq.measure(..)` would not compile.
+        let p = measure_probs(&collapsed);
+        assert!(p[1] > 0.999);
+    }
+
+    #[test]
+    fn linear_qubit_impossible_outcome_is_bottom() {
+        let lq = LinearQubit::new(Qubit::ket0());
+        assert!(lq.measure(1).is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Enable the module in `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod measurement;
+pub use measurement::{project, LinearQubit};
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert measurement 2>&1 | tail -8
+```
+Expected: `test result: ok. 4 passed`
+
+- [ ] **Step 4: Clippy + commit**
+
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/measurement.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): measurement elimination rule (project) + LinearQubit no-cloning"
+```
+
+## Report
+Status DONE/BLOCKED, test output last 5 lines, commit SHA.
+
+---
+
+## Task 2: admissibility — Δ₀ realizability and the `ArithFragment` tag
+
+**Files:**
+- Create: `crates/larql-hilbert/src/admissibility.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/admissibility.rs`**
+
+```rust
+//! Bounded-extraction admissibility over the single-qubit LM (Rosko 2025:
+//! admissible measurement = finite extraction ⊆ Σ⁰₁ ∪ Π⁰₂). The arithmetical
+//! hierarchy appears here as the quantifier shape of *bounded* procedures.
+
+use crate::qlm::SingleQubitLM;
+
+/// Arithmetical-hierarchy fragment of a bounded extraction query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArithFragment {
+    /// Bounded / decidable (e.g. "is this finite sequence realizable?").
+    Delta0,
+    /// ∃ a terminating witness (e.g. "does a realizable continuation satisfying
+    /// P exist within bound k?").
+    Sigma01,
+    /// ∀∃ uniform stability (e.g. "for every realizable prefix is there a valid
+    /// next token?").
+    Pi02,
+}
+
+/// Δ₀ decision: is `tokens` a physically realizable sequence (finite score)?
+/// An impossible token makes the score −∞.
+pub fn is_realizable(lm: &SingleQubitLM, tokens: &[usize]) -> bool {
+    lm.score(tokens).is_finite()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::qubit::Qubit;
+    use crate::unitary::identity;
+
+    /// gates = [I, I], init = |0⟩ → only all-zero sequences are realizable
+    /// (after observing 0 the state stays |0⟩; a subsequent 1 has probability 0).
+    fn repeat_lm() -> SingleQubitLM {
+        SingleQubitLM { gates: [identity(), identity()], init: Qubit::ket0() }
+    }
+
+    #[test]
+    fn realizable_distinguishes_possible_from_impossible() {
+        let lm = repeat_lm();
+        assert!(is_realizable(&lm, &[0, 0, 0]));
+        assert!(!is_realizable(&lm, &[0, 1]));
+        assert!(is_realizable(&lm, &[])); // empty sequence: score 0, finite
+    }
+
+    #[test]
+    fn arith_fragments_are_distinct() {
+        assert_ne!(ArithFragment::Delta0, ArithFragment::Sigma01);
+        assert_ne!(ArithFragment::Sigma01, ArithFragment::Pi02);
+        assert_ne!(ArithFragment::Delta0, ArithFragment::Pi02);
+    }
+}
+```
+
+- [ ] **Step 2: Enable the module in `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod admissibility;
+pub use admissibility::{is_realizable, ArithFragment};
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert admissibility 2>&1 | tail -8
+```
+Expected: `test result: ok. 2 passed`
+
+- [ ] **Step 4: Clippy + commit**
+
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/admissibility.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): Delta0 realizability decider + ArithFragment tag"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 3: Σ⁰₁ bounded witness search
+
+**Files:**
+- Modify: `crates/larql-hilbert/src/admissibility.rs`
+
+- [ ] **Step 1: Add the failing tests**
+
+In `crates/larql-hilbert/src/admissibility.rs`, inside `mod tests`, add:
+
+```rust
+    #[test]
+    fn sigma01_finds_a_witness_within_bound() {
+        let lm = repeat_lm();
+        // ∃ a realizable length-2 continuation of the empty prefix? Yes: [0, 0].
+        let w = exists_continuation(&lm, &[], 2, |s| s.len() == 2);
+        assert_eq!(w, Some(vec![0, 0]));
+    }
+
+    #[test]
+    fn sigma01_returns_none_when_no_witness_exists_in_bound() {
+        let lm = repeat_lm();
+        // No realizable sequence ever contains token 1 → no witness within bound.
+        let w = exists_continuation(&lm, &[], 4, |s| s.contains(&1));
+        assert!(w.is_none());
+    }
+
+    #[test]
+    fn sigma01_respects_the_prefix() {
+        let lm = repeat_lm();
+        // From prefix [0], the empty continuation [0] is already realizable.
+        let w = exists_continuation(&lm, &[0], 0, |_| true);
+        assert_eq!(w, Some(vec![0]));
+    }
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert admissibility 2>&1 | tail -8
+```
+Expected: compile error — `exists_continuation` not defined.
+
+- [ ] **Step 3: Add the function**
+
+In `crates/larql-hilbert/src/admissibility.rs`, add after `is_realizable`:
+
+```rust
+/// Σ⁰₁ bounded witness search: is there a realizable continuation of `prefix`
+/// — appending between 0 and `max_len` tokens from the alphabet `{0, 1}` — for
+/// which `pred` holds? Returns the first such full sequence (a constructive
+/// witness), or `None` if none exists within the bound. The bound guarantees
+/// termination, i.e. admissibility. `max_len` should be modest (it is an
+/// admissible finite bound, not an unbounded search).
+pub fn exists_continuation<F: Fn(&[usize]) -> bool>(
+    lm: &SingleQubitLM,
+    prefix: &[usize],
+    max_len: usize,
+    pred: F,
+) -> Option<Vec<usize>> {
+    for len in 0..=max_len {
+        for code in 0..(1usize << len) {
+            let mut seq = prefix.to_vec();
+            for bit in 0..len {
+                seq.push((code >> bit) & 1);
+            }
+            if is_realizable(lm, &seq) && pred(&seq) {
+                return Some(seq);
+            }
+        }
+    }
+    None
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert admissibility 2>&1 | tail -8
+```
+Expected: `test result: ok. 5 passed`
+
+- [ ] **Step 5: Re-export + clippy + commit**
+
+In `crates/larql-hilbert/src/lib.rs`, change the admissibility re-export line to:
+```rust
+pub use admissibility::{exists_continuation, is_realizable, ArithFragment};
+```
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/admissibility.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): Sigma01 bounded witness search over the QLM"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 4: Π⁰₂ uniform stability
+
+**Files:**
+- Modify: `crates/larql-hilbert/src/admissibility.rs`
+
+- [ ] **Step 1: Add the failing tests**
+
+In `crates/larql-hilbert/src/admissibility.rs`, inside `mod tests`, add:
+
+```rust
+    #[test]
+    fn pi02_uniform_stability_holds_for_the_repeat_lm() {
+        let lm = repeat_lm();
+        // Every realizable prefix [0]^k extends by another 0 → always stable.
+        assert!(uniformly_stable(&lm, 4));
+    }
+
+    #[test]
+    fn pi02_uniform_stability_holds_for_a_nontrivial_lm() {
+        use crate::unitary::{hadamard, pauli_x};
+        // init |+⟩, gates [X, I]: realizable sequences are [0,1,1,…] and
+        // [1,1,1,…]; every realizable prefix still has a valid next token (1).
+        let lm = SingleQubitLM {
+            gates: [pauli_x(), identity()],
+            init: Qubit::ket0().apply(&hadamard()),
+        };
+        assert!(uniformly_stable(&lm, 4));
+    }
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert admissibility 2>&1 | tail -8
+```
+Expected: compile error — `uniformly_stable` not defined.
+
+- [ ] **Step 3: Add the function**
+
+In `crates/larql-hilbert/src/admissibility.rs`, add after `exists_continuation`:
+
+```rust
+/// Π⁰₂ uniform stability: for every realizable token sequence of length ≤
+/// `max_len`, does there exist a next token keeping it realizable? Returns
+/// `false` if any realizable prefix dead-ends within the bound.
+///
+/// For a single-qubit LM this always holds (unitary evolution followed by Born
+/// collapse can never reach a state where both outcomes have probability 0), so
+/// this verifies that structural stability property within the bound.
+pub fn uniformly_stable(lm: &SingleQubitLM, max_len: usize) -> bool {
+    for len in 0..=max_len {
+        for code in 0..(1usize << len) {
+            let mut seq = Vec::with_capacity(len);
+            for bit in 0..len {
+                seq.push((code >> bit) & 1);
+            }
+            if !is_realizable(lm, &seq) {
+                continue;
+            }
+            let has_next = (0..2).any(|t| {
+                let mut ext = seq.clone();
+                ext.push(t);
+                is_realizable(lm, &ext)
+            });
+            if !has_next {
+                return false;
+            }
+        }
+    }
+    true
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert admissibility 2>&1 | tail -8
+```
+Expected: `test result: ok. 7 passed`
+
+- [ ] **Step 5: Re-export + clippy + commit**
+
+In `crates/larql-hilbert/src/lib.rs`, change the admissibility re-export line to:
+```rust
+pub use admissibility::{exists_continuation, is_realizable, uniformly_stable, ArithFragment};
+```
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/admissibility.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): Pi02 uniform-stability verifier"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 5: Integration test tying measurement, ⊥, and admissibility
+
+**Files:**
+- Create: `crates/larql-hilbert/tests/measurement_integration.rs`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `crates/larql-hilbert/tests/measurement_integration.rs`:
+
+```rust
+//! End-to-end: the measurement eliminator's ⊥ (`project` → `None`) lines up
+//! with the QLM's −∞ (`score`), and bounded extraction stays admissible.
+
+use larql_hilbert::admissibility::{exists_continuation, is_realizable, uniformly_stable};
+use larql_hilbert::measurement::project;
+use larql_hilbert::qlm::SingleQubitLM;
+use larql_hilbert::qubit::Qubit;
+use larql_hilbert::unitary::identity;
+
+fn repeat_lm() -> SingleQubitLM {
+    SingleQubitLM { gates: [identity(), identity()], init: Qubit::ket0() }
+}
+
+#[test]
+fn bottom_outcome_matches_neg_infinity_score() {
+    // From |0⟩, outcome 1 is impossible: project → None, and the single-token
+    // score([1]) on the |0⟩-initialized LM is −∞. Both witness ⊥.
+    assert!(project(&Qubit::ket0(), 1).is_none());
+    let lm = repeat_lm();
+    assert!(lm.score(&[1]).is_infinite() && lm.score(&[1]) < 0.0);
+    assert!(!is_realizable(&lm, &[1]));
+}
+
+#[test]
+fn admissible_extraction_finds_witness_and_is_stable() {
+    let lm = repeat_lm();
+    // Σ⁰₁: a realizable 3-token continuation exists (all zeros).
+    let w = exists_continuation(&lm, &[], 3, |s| s.len() == 3);
+    assert_eq!(w, Some(vec![0, 0, 0]));
+    // Π⁰₂: the model is uniformly stable within the bound.
+    assert!(uniformly_stable(&lm, 3));
+}
+```
+
+- [ ] **Step 2: Run the integration test + whole crate suite**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert --test measurement_integration 2>&1 | tail -6
+cd /home/metavacua/larql && cargo test -p larql-hilbert 2>&1 | tail -6
+```
+Expected: 2 integration tests pass; whole-crate suite passes (prior 29 + Task1 4 + Task2 2 + Task3 3 + Task4 2 + 2 integration = 42).
+
+- [ ] **Step 3: Add a doc note to `lib.rs`**
+
+In `crates/larql-hilbert/src/lib.rs`, append to the END of the top `//!` doc block (after the existing `# Roadmap` section if present, else after the last `//!` line):
+
+```rust
+//!
+//! # Measurement as elimination
+//!
+//! Measurement is not a new primitive but an elimination rule in the linear
+//! (no-cloning) fragment: `measurement::project` consumes a state to a basis
+//! outcome or `None` (⊥ ≅ `SingleQubitLM::score` returning −∞). `LinearQubit`
+//! enforces no-cloning via Rust move semantics. `admissibility` bounds
+//! extraction to the finite, decidable fragment (Δ₀) with Σ⁰₁/Π⁰₂ query shapes
+//! — Rosko 2025, arXiv:2511.21296.
+```
+
+- [ ] **Step 4: Clippy + commit**
+
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/tests/measurement_integration.rs crates/larql-hilbert/src/lib.rs
+git commit -m "test(hilbert): measurement/admissibility integration + doc"
+```
+
+## Report
+Status DONE/BLOCKED, full-crate test count, commit SHA.
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- [x] Measurement as elimination rule (`project`, `None` = ⊥) — Task 1
+- [x] No-cloning via linear move semantics (`LinearQubit`, `!Copy`, `measure` consumes) — Task 1
+- [x] Δ₀ realizability decider + `ArithFragment` — Task 2
+- [x] Σ⁰₁ bounded witness search — Task 3
+- [x] Π⁰₂ uniform stability — Task 4
+- [x] Integration: ⊥ ≅ −∞, admissibility — Task 5
+
+**Type consistency:**
+- `project(&Qubit, usize) -> Option<Qubit>` defined Task 1, used in Task 5.
+- `LinearQubit::new`/`measure(self, usize) -> Option<Qubit>` defined Task 1.
+- `is_realizable(&SingleQubitLM, &[usize]) -> bool` defined Task 2, used by `exists_continuation`/`uniformly_stable` (Tasks 3,4) and Task 5.
+- `exists_continuation<F: Fn(&[usize])->bool>(&SingleQubitLM, &[usize], usize, F) -> Option<Vec<usize>>` defined Task 3, used Task 5.
+- `uniformly_stable(&SingleQubitLM, usize) -> bool` defined Task 4, used Task 5.
+- `ArithFragment` defined Task 2, re-exported, used in its own test (not dead code).
+- `lib.rs` re-exports grow incrementally; each `pub use` references items that exist by the task adding the line.
+
+**No placeholders:** every code step is complete; every run step has an exact command + expected count.

--- a/docs/superpowers/plans/2026-06-11-matrix-entanglement-entropy.md
+++ b/docs/superpowers/plans/2026-06-11-matrix-entanglement-entropy.md
@@ -1,0 +1,403 @@
+# Matrix Entanglement-Entropy Meter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `entanglement_entropy(&Array2<f64>) -> f64` to `larql-hilbert` — the entanglement entropy (in ebits) of a real matrix viewed as a bipartite state — backed by a pure-Rust symmetric eigensolver, so the quantum-compressibility quantity can be computed for any weight matrix with no BLAS.
+
+**Architecture:** A pure-Rust cyclic-Jacobi symmetric eigensolver (`eig.rs`) returns the eigenvalues of a real symmetric matrix. `entanglement_entropy` forms the (smaller) Gram matrix `M Mᵀ` or `Mᵀ M`, takes its eigenvalues (the squared singular values), and feeds them to the existing `spectral_entropy`. Everything stays in the leaf crate (deps: `ndarray` + `num-complex` only — no BLAS, no LAPACK), so it remains portable toward the wasm/minimal-LM goals.
+
+**Tech Stack:** Rust 2021, `ndarray` 0.16 (real matrices), the existing `larql_hilbert::spectral_entropy`.
+
+---
+
+## Scope note: foundation of the compressibility investigation
+
+- **This plan:** the matrix-level entanglement-entropy meter (eigensolver + `entanglement_entropy`). Self-contained, TDD-able with synthetic matrices.
+- **Follow-on (separate plan):** a vindex-wide compressibility analysis — a CLI that runs `entanglement_entropy` over the attention/FFN weight matrices and compares **on-shell vs full**, **canonical vs raw**, and checks for **Zipfian/power-law (heavy-tailed self-regularization)** spectra. That depends on this meter plus the vindex weight loaders (`load_attention_qk`, `load_model_weights_with_opts`).
+
+## Domain background (read once)
+
+A real matrix `M` (m×n), viewed as a bipartite pure state by vectorizing, has a Schmidt decomposition whose coefficients are its singular values `σᵢ`. Its **entanglement entropy** is the spectral entropy of the normalized **squared** singular values:
+
+```
+S(M) = −Σ pᵢ log₂ pᵢ ,  pᵢ = σᵢ² / Σ σⱼ²
+```
+
+`S = 0` for a rank-1 matrix (fully compressible to one Schmidt term), `S = log₂(min(m,n))` for a flat spectrum (incompressible). One ebit (`σ² = [½, ½]`) is the superdense-coding unit.
+
+The squared singular values of `M` are the **eigenvalues of the Gram matrix** `M Mᵀ` (m×m) — equivalently `Mᵀ M` (n×n); both share the same nonzero eigenvalues, so use the smaller one. Computing eigenvalues of a real symmetric matrix without BLAS is done with the **cyclic Jacobi method**: repeatedly apply Givens rotations that zero the largest off-diagonal entries; the diagonal converges to the eigenvalues. It is simple, exact in the limit, and quadratically convergent for symmetric matrices.
+
+The existing `spectral_entropy(weights: &[f64]) -> f64` (in `entropy.rs`) already computes `−Σ pᵢ log₂ pᵢ` of a normalized non-negative weight slice. This plan supplies the weights (squared singular values) from a matrix.
+
+## File structure
+
+New file in `crates/larql-hilbert/`:
+- `src/eig.rs` — `symmetric_eigenvalues(&Array2<f64>) -> Vec<f64>` (cyclic Jacobi).
+
+Modified:
+- `src/entropy.rs` — add `entanglement_entropy(&Array2<f64>) -> f64`.
+- `src/lib.rs` — declare `eig` module + re-export `entanglement_entropy`.
+
+Existing API used (do not modify): `spectral_entropy(&[f64]) -> f64`.
+
+---
+
+## Task 1: Pure-Rust symmetric eigensolver (cyclic Jacobi)
+
+**Files:**
+- Create: `crates/larql-hilbert/src/eig.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/eig.rs` with the tests first**
+
+Write this file (implementation + tests together; the tests reference `symmetric_eigenvalues` which the implementation defines):
+
+```rust
+//! Pure-Rust symmetric eigenvalue solver (cyclic Jacobi) — no BLAS/LAPACK.
+//! Used to obtain the squared-singular spectrum for entanglement entropy.
+
+use ndarray::Array2;
+
+/// Eigenvalues of a real symmetric matrix via the cyclic Jacobi method.
+/// Returns the `n` eigenvalues (unordered). The input is assumed symmetric;
+/// only its symmetric part is meaningfully used.
+pub fn symmetric_eigenvalues(a: &Array2<f64>) -> Vec<f64> {
+    let n = a.shape()[0];
+    let mut m = a.clone();
+
+    for _sweep in 0..100 {
+        // Off-diagonal Frobenius norm; stop when negligible.
+        let mut off = 0.0;
+        for i in 0..n {
+            for j in (i + 1)..n {
+                off += m[[i, j]] * m[[i, j]];
+            }
+        }
+        if off.sqrt() < 1e-14 {
+            break;
+        }
+
+        for p in 0..n {
+            for q in (p + 1)..n {
+                let apq = m[[p, q]];
+                if apq.abs() < 1e-300 {
+                    continue;
+                }
+                let app = m[[p, p]];
+                let aqq = m[[q, q]];
+                // Stable Jacobi angle (Golub & Van Loan, sym.schur2).
+                let tau = (aqq - app) / (2.0 * apq);
+                let t = if tau >= 0.0 {
+                    1.0 / (tau + (1.0 + tau * tau).sqrt())
+                } else {
+                    -1.0 / (-tau + (1.0 + tau * tau).sqrt())
+                };
+                let c = 1.0 / (1.0 + t * t).sqrt();
+                let s = t * c;
+
+                // A <- Jᵀ A J for the (p,q) rotation: rotate columns then rows.
+                for k in 0..n {
+                    let akp = m[[k, p]];
+                    let akq = m[[k, q]];
+                    m[[k, p]] = c * akp - s * akq;
+                    m[[k, q]] = s * akp + c * akq;
+                }
+                for k in 0..n {
+                    let apk = m[[p, k]];
+                    let aqk = m[[q, k]];
+                    m[[p, k]] = c * apk - s * aqk;
+                    m[[q, k]] = s * apk + c * aqk;
+                }
+            }
+        }
+    }
+
+    (0..n).map(|i| m[[i, i]]).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    fn sorted(mut v: Vec<f64>) -> Vec<f64> {
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        v
+    }
+
+    fn close(a: &[f64], b: &[f64]) -> bool {
+        a.len() == b.len() && a.iter().zip(b).all(|(x, y)| (x - y).abs() < 1e-9)
+    }
+
+    #[test]
+    fn diagonal_matrix_returns_its_diagonal() {
+        let a = Array2::from_diag(&array![3.0, 1.0, 2.0]);
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 2.0, 3.0]));
+    }
+
+    #[test]
+    fn identity_has_all_unit_eigenvalues() {
+        let a = Array2::<f64>::eye(3);
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 1.0, 1.0]));
+    }
+
+    #[test]
+    fn two_by_two_symmetric_eigenvalues() {
+        // [[2,1],[1,2]] has eigenvalues 1 and 3.
+        let a = array![[2.0, 1.0], [1.0, 2.0]];
+        assert!(close(&sorted(symmetric_eigenvalues(&a)), &[1.0, 3.0]));
+    }
+
+    #[test]
+    fn larger_spd_matrix_eigenvalues_sum_to_trace() {
+        // Eigenvalues sum to the trace and product to the determinant —
+        // a basis-independent sanity check on a non-trivial 3×3.
+        let a = array![[4.0, 1.0, 0.0], [1.0, 3.0, 1.0], [0.0, 1.0, 2.0]];
+        let eigs = symmetric_eigenvalues(&a);
+        let sum: f64 = eigs.iter().sum();
+        assert!((sum - 9.0).abs() < 1e-9, "trace should be 9, got {sum}");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they pass**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert eig 2>&1 | tail -8
+```
+Expected: `test result: ok. 4 passed`. (The implementation is in the same file, so these go green immediately — that is acceptable here because the eigensolver is a self-contained numeric kernel verified against known spectra; the failing-first discipline is exercised at the feature boundary in Task 2.)
+
+- [ ] **Step 3: Wire the module into `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod eig;
+pub use eig::symmetric_eigenvalues;
+```
+
+- [ ] **Step 4: Clippy + commit**
+
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+If clippy flags `for i in 0..n` index loops as `needless_range_loop`, restructure the off-diagonal sum with `.enumerate()` iterators (the rotation loops genuinely need index pairs `(p,q)`/`(k,p)` and may carry `#[allow(clippy::needless_range_loop)]` on the function with a one-line comment if clippy insists — these are paired-index numeric kernels where indexing is clearer). Resolve to clean.
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/eig.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): pure-Rust symmetric eigensolver (cyclic Jacobi, no BLAS)"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 2: `entanglement_entropy(&Array2<f64>)`
+
+**Files:**
+- Modify: `crates/larql-hilbert/src/entropy.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `crates/larql-hilbert/src/entropy.rs`, inside the existing `#[cfg(test)] mod tests` block, add:
+
+```rust
+    use ndarray::array;
+
+    #[test]
+    fn rank_one_matrix_has_zero_entanglement() {
+        // [[1,2],[2,4]] = [1,2]ᵀ·[1,2], rank 1 → one nonzero singular value → 0.
+        let m = array![[1.0, 2.0], [2.0, 4.0]];
+        assert!(entanglement_entropy(&m).abs() < 1e-9);
+    }
+
+    #[test]
+    fn identity_2x2_is_one_ebit() {
+        // I₂ has singular values [1,1] → squared [1,1] → 1 ebit.
+        let m = Array2::<f64>::eye(2);
+        assert!((entanglement_entropy(&m) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn rectangular_orthonormal_rows_is_one_ebit() {
+        // 2×3 with two orthonormal rows → M Mᵀ = I₂ → 1 ebit.
+        let m = array![[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        assert!((entanglement_entropy(&m) - 1.0).abs() < 1e-9);
+    }
+```
+
+Also ensure `use ndarray::Array2;` is available to the test module — add `use ndarray::Array2;` next to the new `use ndarray::array;` if `Array2` is not already in scope in the test module.
+
+- [ ] **Step 2: Run to confirm failure**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert entropy 2>&1 | tail -8
+```
+Expected: compile error — `entanglement_entropy` not defined.
+
+- [ ] **Step 3: Add the function**
+
+In `crates/larql-hilbert/src/entropy.rs`, add the import at the top of the file (below the module doc comment):
+
+```rust
+use ndarray::Array2;
+
+use crate::eig::symmetric_eigenvalues;
+```
+
+Then add, after `spectral_entropy` (before the `#[cfg(test)]` block):
+
+```rust
+/// Entanglement entropy (in ebits) of a real matrix viewed as a bipartite
+/// state: the spectral entropy of its squared singular values. `0` for a
+/// rank-1 matrix, `log₂(min(rows, cols))` for a flat spectrum.
+///
+/// Computed from the eigenvalues of the smaller Gram matrix (`M Mᵀ` if
+/// `rows ≤ cols`, else `Mᵀ M`) — these are the squared singular values.
+/// Tiny negative eigenvalues from round-off are clamped to 0.
+pub fn entanglement_entropy(m: &Array2<f64>) -> f64 {
+    let (rows, cols) = (m.shape()[0], m.shape()[1]);
+    let gram = if rows <= cols {
+        m.dot(&m.t())
+    } else {
+        m.t().dot(m)
+    };
+    let weights: Vec<f64> = symmetric_eigenvalues(&gram)
+        .into_iter()
+        .map(|e| e.max(0.0))
+        .collect();
+    spectral_entropy(&weights)
+}
+```
+
+- [ ] **Step 4: Run to confirm the tests pass**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert entropy 2>&1 | tail -8
+```
+Expected: `test result: ok. 8 passed` (5 existing `spectral_entropy` tests + 3 new).
+
+- [ ] **Step 5: Re-export + clippy + commit**
+
+In `crates/larql-hilbert/src/lib.rs`, change the entropy re-export line (currently `pub use entropy::spectral_entropy;`) to:
+
+```rust
+pub use entropy::{entanglement_entropy, spectral_entropy};
+```
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/entropy.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): entanglement_entropy(matrix) via Gram eigenvalues"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 3: Integration test (entropy as a compressibility ordering) + doc
+
+**Files:**
+- Create: `crates/larql-hilbert/tests/entropy_integration.rs`
+- Modify: `crates/larql-hilbert/src/entropy.rs` (doc only)
+
+- [ ] **Step 1: Write the integration test**
+
+Create `crates/larql-hilbert/tests/entropy_integration.rs`:
+
+```rust
+//! End-to-end: entanglement_entropy orders matrices by compressibility —
+//! rank-1 (0 ebits, fully compressible) < skewed spectrum < flat spectrum
+//! (maximal, incompressible) — through the public crate API.
+
+use larql_hilbert::{entanglement_entropy, spectral_entropy};
+use ndarray::{array, Array2};
+
+#[test]
+fn entropy_orders_matrices_by_compressibility() {
+    // Rank-1: zero entanglement (one Schmidt term).
+    let rank1 = array![[1.0, 2.0], [2.0, 4.0]];
+    // Skewed singular values [1, 0.1] → squared [1, 0.01]: low but nonzero.
+    let skewed = Array2::from_diag(&array![1.0, 0.1]);
+    // Flat: identity, maximal entropy for 2×2 (1 ebit).
+    let flat = Array2::<f64>::eye(2);
+
+    let s_rank1 = entanglement_entropy(&rank1);
+    let s_skewed = entanglement_entropy(&skewed);
+    let s_flat = entanglement_entropy(&flat);
+
+    assert!(s_rank1 < 1e-9, "rank-1 should be ~0, got {s_rank1}");
+    assert!(s_rank1 < s_skewed, "{s_rank1} !< {s_skewed}");
+    assert!(s_skewed < s_flat, "{s_skewed} !< {s_flat}");
+    assert!((s_flat - 1.0).abs() < 1e-9, "flat 2×2 should be 1 ebit, got {s_flat}");
+}
+
+#[test]
+fn matrix_meter_agrees_with_spectral_entropy_on_squared_singular_values() {
+    // The matrix meter must equal spectral_entropy applied to the squared
+    // singular values directly. For a diagonal matrix those are the squared
+    // diagonal entries.
+    let m = Array2::from_diag(&array![2.0, 1.0]);
+    let direct = spectral_entropy(&[4.0, 1.0]); // squares of 2 and 1
+    assert!((entanglement_entropy(&m) - direct).abs() < 1e-9);
+}
+```
+
+- [ ] **Step 2: Run the integration test + whole crate suite**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert --test entropy_integration 2>&1 | tail -6
+cd /home/metavacua/larql && cargo test -p larql-hilbert 2>&1 | tail -6
+```
+Expected: 2 integration tests pass; whole-crate suite passes.
+
+- [ ] **Step 3: Add a doc note to `entropy.rs`**
+
+In `crates/larql-hilbert/src/entropy.rs`, append to the END of the top `//!` module doc block:
+
+```rust
+//!
+//! `entanglement_entropy(M)` is the quantum-compressibility meter: low entropy
+//! ⇒ few Schmidt terms ⇒ the matrix compresses to a small tensor-network bond
+//! dimension (`χ ≈ 2^S`); a flat (heavy-tailed-but-broad) spectrum is
+//! incompressible. Combined with the Hilbertian residual (complex/coherence
+//! structure), it quantifies the classical-vs-quantum compressibility gap of a
+//! vindex, denominated in ebits.
+```
+
+- [ ] **Step 4: Clippy + commit**
+
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/tests/entropy_integration.rs crates/larql-hilbert/src/entropy.rs
+git commit -m "test(hilbert): entanglement entropy orders matrices by compressibility + doc"
+```
+
+## Report
+Status DONE/BLOCKED, full-crate test count, commit SHA.
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- [x] Pure-Rust symmetric eigensolver (no BLAS) — Task 1 (`symmetric_eigenvalues`, cyclic Jacobi)
+- [x] `entanglement_entropy(&Array2<f64>)` via Gram eigenvalues → `spectral_entropy` — Task 2
+- [x] Ordering/compressibility integration + agreement with `spectral_entropy` — Task 3
+- [ ] **Deferred (separate plan):** vindex-wide analysis CLI (on-shell vs full, canonical vs raw, Zipfian/HTSR check) — depends on this meter + weight loaders.
+
+**Type consistency:**
+- `symmetric_eigenvalues(&Array2<f64>) -> Vec<f64>` defined Task 1, called by `entanglement_entropy` (Task 2).
+- `entanglement_entropy(&Array2<f64>) -> f64` defined Task 2, used in Task 3; re-exported at crate root in Task 2.
+- `spectral_entropy(&[f64]) -> f64` (pre-existing) consumed by `entanglement_entropy` and cross-checked in Task 3.
+- Gram orientation: `M Mᵀ` when `rows ≤ cols` else `Mᵀ M` — same convention named in the doc and the implementation.
+
+**No placeholders:** every code step contains complete code; every run step has an exact command + expected count. Task 1's eigensolver tests pass immediately (a verified numeric kernel against known spectra); the failing-first cycle is exercised at the feature boundary in Task 2 (`entanglement_entropy` undefined → compile error → implement).

--- a/docs/superpowers/plans/2026-06-11-qlm-hilbert-foundation.md
+++ b/docs/superpowers/plans/2026-06-11-qlm-hilbert-foundation.md
@@ -1,0 +1,1092 @@
+# Hilbert-Space Foundation + Single-Qubit Bloch QLM Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a new `larql-hilbert` crate providing (a) the shared Hilbert-space formalization — complex structures, the real↔complex (realification/complexification) bridge, and the *antilinear fraction* that re-expresses the Hilbertian residual in genuine complex terms — and (b) the minimal single-qubit Bloch-sphere language model (ℂ² state, SU(2) evolution, Born-rule readout, autoregressive generation) built on that foundation.
+
+**Architecture:** One leaf crate, pure Rust, `std` for now (no_std hardening is deferred per epic #132 / #135). The real-matrix side (`complex_structure`) uses `ndarray` `Array2<f64>` and never needs complex matmul. The qubit side (`unitary`, `qubit`, `born`, `qlm`) uses `num-complex::Complex64` with hand-written 2×2 operations (no BLAS, no ndarray-complex). The unifying theorem `commutator_residual(M, J) = 2·antilinear_fraction(M)` ties this crate's complex formalism to the existing `larql hilbertian` metric (which measures, in real ℝ^{2n} terms, exactly twice the ℂ-antilinear part of an operator under the split-half complex structure).
+
+**Tech Stack:** Rust 2021, `ndarray` 0.16 (real matrices only), `num-complex` 0.4 (2×2 qubit algebra), a tiny internal LCG for deterministic sampling (no `rand` dep).
+
+---
+
+## Scope note: one of several plans
+
+This synthesis spans a roadmap. **This plan covers only the single-qubit foundation:**
+
+- **This plan:** Hilbert-space foundation + single-qubit Bloch QLM. The load-bearing base.
+- **Future (separate plan):** 2-qubit LM — ℂ⁴ states, the tensor product, and the Bell entanglement operation (where a non-commutative, non-idempotent multiplicative/additive structure first appears, because product states no longer factor).
+- **Future (separate plan):** 3+ qubit GHZ / W entanglement operations.
+- **Deferred follow-up (separate, after PR #137 merges):** wire `larql-vindex`'s `hilbertian` command to consume this crate's `antilinear_fraction` (refinement of #136). Not in this plan to avoid conflicting with the open PR; the equivalence theorem here is the foundation that rewiring will rest on.
+
+## Domain background (read once)
+
+A **complex structure** on ℝ^n (n even) is a linear map `J` with `J² = −I`. The split-half convention (the one RoPE and the existing `hilbertian` command use): `J e_i = e_{i+half}`, `J e_{i+half} = −e_i` (half = n/2).
+
+Any real operator `M` splits into a part that **commutes** with J (ℂ-linear under the identification ℝ^{2m} ≅ ℂ^m) and a part that **anticommutes** (ℂ-antilinear / conjugate-linear):
+
+```
+P_lin(M)     = (M − J M J) / 2     # commutes with J
+P_antilin(M) = (M + J M J) / 2     # anticommutes with J
+```
+
+The **antilinear fraction** `‖P_antilin(M)‖_F / ‖M‖_F` measures how far M is from being complex-linear. **Theorem (the unifier):**
+
+```
+‖[M, J]‖_F = 2 · ‖P_antilin(M)‖_F        ⟹     commutator_residual(M, J) = 2 · antilinear_fraction(M)
+```
+
+Proof: right-multiply the commutator by J — `(MJ − JM)·J = MJ² − JMJ = −M − JMJ = −2·P_antilin(M)`. Since J is orthogonal, `‖(MJ−JM)·J‖_F = ‖MJ−JM‖_F`, giving the identity. So the `larql hilbertian` residual is literally twice the ℂ-antilinear fraction of a head's coupling under the complex structure.
+
+A real operator that commutes with split-half J has block form `[[A, −B], [B, A]]` and **is** the complex matrix `A + iB` (the realification). This is the bridge to the genuinely-complex qubit world.
+
+A **qubit** is a unit vector `|ψ⟩ = α|0⟩ + β|1⟩ ∈ ℂ²`. Its **Bloch vector** is `(2 Re(ᾱβ), 2 Im(ᾱβ), |α|² − |β|²) ∈ S²`. Measurement in the computational basis follows the **Born rule**: `P(0) = |α|²`, `P(1) = |β|²`. Evolution is by SU(2) unitaries. The Bloch sphere `S² = ℂP¹` is the canonical (global-phase-and-norm-quotiented) state space — the minimal quantum state space.
+
+The **single-qubit LM**: a 2-token vocabulary `{0, 1}`. The current state is a qubit; the next-token distribution is the Born rule; after a token `t` is observed the state collapses to `|t⟩` and a token-dependent unitary `gates[t]` is applied. This is a minimal hidden-quantum-Markov language model.
+
+## File structure
+
+New crate `crates/larql-hilbert/` with:
+- `Cargo.toml`, `src/lib.rs` — crate root, module declarations, re-exports.
+- `src/complex_structure.rs` — split-half J, commutator residual, P_antilin / antilinear_fraction, the equivalence theorem (tested), realify / complex_parts bridge.
+- `src/unitary.rs` — `Gate = [[Complex64; 2]; 2]`, Pauli/Hadamard/phase/rotation gates, `mat_mul`, `dagger`, `is_unitary`, `apply_gate`.
+- `src/qubit.rs` — `Qubit`, `ket0`/`ket1`/`from_bloch`, `norm`, `normalized`, `bloch_vector`, `apply`.
+- `src/born.rs` — `measure_probs`.
+- `src/qlm.rs` — `SingleQubitLM`, `next_distribution`, `step`, `score`, `generate`.
+
+Modified: root `Cargo.toml` (add the new crate to `[workspace] members`).
+
+---
+
+## Task 1: Scaffold the `larql-hilbert` crate
+
+**Files:**
+- Create: `crates/larql-hilbert/Cargo.toml`
+- Create: `crates/larql-hilbert/src/lib.rs`
+- Modify: root `Cargo.toml`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/Cargo.toml`**
+
+```toml
+[package]
+name = "larql-hilbert"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ndarray = "0.16"
+num-complex = "0.4"
+```
+
+- [ ] **Step 2: Create `crates/larql-hilbert/src/lib.rs`**
+
+```rust
+//! Hilbert-space formalization for larql: complex structures, the real↔complex
+//! bridge, and the minimal single-qubit Bloch-sphere language model.
+//!
+//! The real-matrix side (`complex_structure`) re-expresses the `larql hilbertian`
+//! residual in genuine complex terms via the identity
+//! `commutator_residual(M, J) = 2 · antilinear_fraction(M)`. The qubit side
+//! (`unitary`, `qubit`, `born`, `qlm`) is the first concrete model built on the
+//! same formalism — a single qubit, ℂP¹ = the Bloch sphere.
+
+pub mod born;
+pub mod complex_structure;
+pub mod qlm;
+pub mod qubit;
+pub mod unitary;
+
+pub use born::measure_probs;
+pub use complex_structure::{antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j};
+pub use qlm::SingleQubitLM;
+pub use qubit::Qubit;
+pub use unitary::Gate;
+```
+
+NOTE: the `pub use` lines reference items defined in later tasks. This file will not compile until Tasks 2–7 add them. To keep Task 1 independently green, **temporarily** comment out every `pub mod` / `pub use` line except none — i.e., for Task 1, replace the body below the doc comment with just a placeholder test module, then uncomment each module line in the task that creates it. Concretely, for Task 1 use this body:
+
+```rust
+//! (doc comment above)
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn crate_builds() {
+        assert_eq!(2 + 2, 4);
+    }
+}
+```
+
+Each later task's first step will add its own `pub mod X;` + `pub use` line to `lib.rs`.
+
+- [ ] **Step 3: Add the crate to the workspace**
+
+In the root `Cargo.toml`, in `[workspace] members`, add `"crates/larql-hilbert",` after the `"crates/larql-boundary",` line.
+
+- [ ] **Step 4: Build and test**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert 2>&1 | tail -6
+```
+Expected: `test result: ok. 1 passed` (the `crate_builds` placeholder).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/Cargo.toml crates/larql-hilbert/src/lib.rs Cargo.toml
+git commit -m "feat(hilbert): scaffold larql-hilbert crate"
+```
+
+---
+
+## Task 2: Complex structure, commutator residual, antilinear fraction + equivalence theorem
+
+**Files:**
+- Create: `crates/larql-hilbert/src/complex_structure.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/complex_structure.rs`**
+
+```rust
+//! Real-matrix complex structures and the antilinear-fraction reformulation of
+//! the `larql hilbertian` residual.
+
+use ndarray::Array2;
+
+/// Split-half complex structure J on R^n (n even): J e_i = e_{i+half},
+/// J e_{i+half} = −e_i, so J·J = −I. Panics if n is odd.
+pub fn split_half_j(n: usize) -> Array2<f64> {
+    assert!(n.is_multiple_of(2), "complex structure requires even dimension, got {n}");
+    let half = n / 2;
+    let mut j = Array2::<f64>::zeros((n, n));
+    for i in 0..half {
+        j[[half + i, i]] = 1.0;
+        j[[i, half + i]] = -1.0;
+    }
+    j
+}
+
+fn frob_norm(a: &Array2<f64>) -> f64 {
+    a.iter().map(|&x| x * x).sum::<f64>().sqrt()
+}
+
+/// Relative commutator residual ‖M J − J M‖_F / ‖M‖_F ∈ [0, 2].
+/// Returns 0.0 for the zero matrix.
+pub fn commutator_residual(m: &Array2<f64>, j: &Array2<f64>) -> f64 {
+    let comm = &m.dot(j) - &j.dot(m);
+    let den = frob_norm(m);
+    if den == 0.0 { 0.0 } else { frob_norm(&comm) / den }
+}
+
+/// The ℂ-antilinear (conjugate-linear) part of M under J: (M + J M J) / 2.
+/// This part anticommutes with J; M − this commutes with J (is ℂ-linear).
+pub fn antilinear_part(m: &Array2<f64>, j: &Array2<f64>) -> Array2<f64> {
+    let jmj = j.dot(m).dot(j);
+    (m + &jmj) * 0.5
+}
+
+/// Fraction of M that is ℂ-antilinear under J: ‖P_antilin(M)‖_F / ‖M‖_F.
+/// Returns 0.0 for the zero matrix. By construction this equals exactly half
+/// the commutator residual (see `equivalence_theorem` test).
+pub fn antilinear_fraction(m: &Array2<f64>, j: &Array2<f64>) -> f64 {
+    let den = frob_norm(m);
+    if den == 0.0 { 0.0 } else { frob_norm(&antilinear_part(m, j)) / den }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn j_squares_to_negative_identity() {
+        let j = split_half_j(4);
+        let jj = j.dot(&j);
+        let neg_i = -Array2::<f64>::eye(4);
+        for i in 0..4 {
+            for k in 0..4 {
+                assert!((jj[[i, k]] - neg_i[[i, k]]).abs() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn equivalence_theorem_residual_is_twice_antilinear_fraction() {
+        // commutator_residual(M, J) = 2 · antilinear_fraction(M) for any M.
+        let j = split_half_j(4);
+        let m = array![
+            [1.0, 2.0, 3.0, 4.0],
+            [0.5, 1.5, 2.5, 3.5],
+            [9.0, 8.0, 7.0, 6.0],
+            [0.1, 0.2, 0.3, 0.4],
+        ];
+        let r = commutator_residual(&m, &j);
+        let af = antilinear_fraction(&m, &j);
+        assert!((r - 2.0 * af).abs() < 1e-12, "r={r} 2*af={}", 2.0 * af);
+    }
+
+    #[test]
+    fn complex_linear_matrix_has_zero_antilinear_fraction() {
+        // M = [[A, -B], [B, A]] commutes with split-half J → antilinear fraction 0.
+        let a = array![[1.0, 2.0], [3.0, 4.0]];
+        let b = array![[5.0, 6.0], [7.0, 8.0]];
+        let mut m = Array2::<f64>::zeros((4, 4));
+        m.slice_mut(ndarray::s![0..2, 0..2]).assign(&a);
+        m.slice_mut(ndarray::s![0..2, 2..4]).assign(&(-&b));
+        m.slice_mut(ndarray::s![2..4, 0..2]).assign(&b);
+        m.slice_mut(ndarray::s![2..4, 2..4]).assign(&a);
+        let j = split_half_j(4);
+        assert!(antilinear_fraction(&m, &j) < 1e-12);
+    }
+
+    #[test]
+    fn zero_matrix_is_safe() {
+        let j = split_half_j(4);
+        let z = Array2::<f64>::zeros((4, 4));
+        assert_eq!(commutator_residual(&z, &j), 0.0);
+        assert_eq!(antilinear_fraction(&z, &j), 0.0);
+    }
+}
+```
+
+- [ ] **Step 2: Enable the module in `lib.rs`**
+
+In `crates/larql-hilbert/src/lib.rs`, remove the placeholder `mod tests` body and restore the real module declarations + re-exports, but only those that exist so far. After this task, `lib.rs` should contain (below the doc comment):
+
+```rust
+pub mod complex_structure;
+
+pub use complex_structure::{antilinear_fraction, commutator_residual, split_half_j};
+```
+
+(Later tasks append their own `pub mod` / `pub use` lines. The `realify` / `complex_parts` re-exports come in Task 3; the qubit-side ones in Tasks 4–7.)
+
+- [ ] **Step 3: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert complex_structure 2>&1 | tail -8
+```
+Expected: `test result: ok. 4 passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/complex_structure.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): complex structure J, commutator residual, antilinear fraction (= half residual)"
+```
+
+---
+
+## Task 3: The real↔complex bridge (realify / complex_parts)
+
+**Files:**
+- Modify: `crates/larql-hilbert/src/complex_structure.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Add the failing tests**
+
+In `crates/larql-hilbert/src/complex_structure.rs`, inside `mod tests`, add:
+
+```rust
+    #[test]
+    fn realify_builds_block_form() {
+        // realify(A, B) = [[A, -B], [B, A]].
+        let a = array![[1.0, 2.0], [3.0, 4.0]];
+        let b = array![[5.0, 6.0], [7.0, 8.0]];
+        let m = realify(&a, &b);
+        assert_eq!(m.shape(), [4, 4]);
+        assert_eq!(m[[0, 0]], 1.0);
+        assert_eq!(m[[0, 2]], -5.0); // -B
+        assert_eq!(m[[2, 0]], 5.0);  //  B
+        assert_eq!(m[[2, 2]], 1.0);  //  A
+    }
+
+    #[test]
+    fn complex_parts_inverts_realify() {
+        let a = array![[1.0, 2.0], [3.0, 4.0]];
+        let b = array![[5.0, 6.0], [7.0, 8.0]];
+        let m = realify(&a, &b);
+        let (a2, b2) = complex_parts(&m);
+        assert_eq!(a2, a);
+        assert_eq!(b2, b);
+    }
+
+    #[test]
+    fn realified_matrix_commutes_with_j() {
+        let a = array![[1.0, 2.0], [3.0, 4.0]];
+        let b = array![[5.0, 6.0], [7.0, 8.0]];
+        let m = realify(&a, &b);
+        let j = split_half_j(4);
+        assert!(commutator_residual(&m, &j) < 1e-12);
+    }
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert complex_structure 2>&1 | tail -8
+```
+Expected: compile error — `realify` / `complex_parts` not defined.
+
+- [ ] **Step 3: Add the functions**
+
+In `crates/larql-hilbert/src/complex_structure.rs`, add before the `#[cfg(test)]` block:
+
+```rust
+/// Realify a complex m×m operator given as (real, imag) parts (A, B):
+/// returns the 2m×2m real matrix [[A, −B], [B, A]] (split-half convention),
+/// which commutes with `split_half_j(2m)` and represents A + iB.
+pub fn realify(a: &Array2<f64>, b: &Array2<f64>) -> Array2<f64> {
+    let m = a.shape()[0];
+    let n = 2 * m;
+    let mut out = Array2::<f64>::zeros((n, n));
+    for i in 0..m {
+        for j in 0..m {
+            out[[i, j]] = a[[i, j]];
+            out[[i, m + j]] = -b[[i, j]];
+            out[[m + i, j]] = b[[i, j]];
+            out[[m + i, m + j]] = a[[i, j]];
+        }
+    }
+    out
+}
+
+/// Read the complex (real, imag) parts (A, B) out of the top-left and
+/// bottom-left blocks of a 2m×2m real matrix. For a matrix produced by
+/// `realify` (i.e. one that commutes with J), this recovers the original
+/// (A, B). For a general matrix it returns the (A, B) of its ℂ-linear part's
+/// canonical block representative.
+pub fn complex_parts(m: &Array2<f64>) -> (Array2<f64>, Array2<f64>) {
+    let half = m.shape()[0] / 2;
+    let a = m.slice(ndarray::s![0..half, 0..half]).to_owned();
+    let b = m.slice(ndarray::s![half.., 0..half]).to_owned();
+    (a, b)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert complex_structure 2>&1 | tail -8
+```
+Expected: `test result: ok. 7 passed`
+
+- [ ] **Step 5: Update `lib.rs` re-exports**
+
+In `crates/larql-hilbert/src/lib.rs`, change the complex_structure re-export line to:
+
+```rust
+pub use complex_structure::{
+    antilinear_fraction, commutator_residual, complex_parts, realify, split_half_j,
+};
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/complex_structure.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): real<->complex bridge (realify / complex_parts)"
+```
+
+---
+
+## Task 4: Unitary gates (Pauli, Hadamard, rotations) and 2×2 complex algebra
+
+**Files:**
+- Create: `crates/larql-hilbert/src/unitary.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/unitary.rs`**
+
+```rust
+//! Single-qubit gates as 2×2 complex matrices with hand-written algebra
+//! (no BLAS, no ndarray-complex) — keeps the qubit core minimal and portable.
+
+use num_complex::Complex64;
+
+/// A single-qubit gate: a 2×2 complex matrix, row-major `[[a, b], [c, d]]`.
+pub type Gate = [[Complex64; 2]; 2];
+/// A single-qubit state vector `[amp0, amp1]`.
+pub type State = [Complex64; 2];
+
+#[inline]
+fn c(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+/// 2×2 identity gate.
+pub fn identity() -> Gate {
+    [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(1.0, 0.0)]]
+}
+
+/// Pauli X (bit flip).
+pub fn pauli_x() -> Gate {
+    [[c(0.0, 0.0), c(1.0, 0.0)], [c(1.0, 0.0), c(0.0, 0.0)]]
+}
+
+/// Pauli Y.
+pub fn pauli_y() -> Gate {
+    [[c(0.0, 0.0), c(0.0, -1.0)], [c(0.0, 1.0), c(0.0, 0.0)]]
+}
+
+/// Pauli Z (phase flip).
+pub fn pauli_z() -> Gate {
+    [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(-1.0, 0.0)]]
+}
+
+/// Hadamard.
+pub fn hadamard() -> Gate {
+    let s = 1.0 / std::f64::consts::SQRT_2;
+    [[c(s, 0.0), c(s, 0.0)], [c(s, 0.0), c(-s, 0.0)]]
+}
+
+/// Rotation about Z by angle theta: diag(e^{-iθ/2}, e^{+iθ/2}).
+pub fn rz(theta: f64) -> Gate {
+    let h = theta / 2.0;
+    [
+        [Complex64::from_polar(1.0, -h), c(0.0, 0.0)],
+        [c(0.0, 0.0), Complex64::from_polar(1.0, h)],
+    ]
+}
+
+/// Rotation about Y by angle theta: [[cos, -sin], [sin, cos]] at θ/2 (real).
+pub fn ry(theta: f64) -> Gate {
+    let h = theta / 2.0;
+    let (co, si) = (h.cos(), h.sin());
+    [[c(co, 0.0), c(-si, 0.0)], [c(si, 0.0), c(co, 0.0)]]
+}
+
+/// Multiply two gates: returns A·B.
+pub fn mat_mul(a: &Gate, b: &Gate) -> Gate {
+    let mut out = [[c(0.0, 0.0); 2]; 2];
+    for i in 0..2 {
+        for j in 0..2 {
+            out[i][j] = a[i][0] * b[0][j] + a[i][1] * b[1][j];
+        }
+    }
+    out
+}
+
+/// Conjugate transpose (dagger) of a gate.
+pub fn dagger(a: &Gate) -> Gate {
+    [[a[0][0].conj(), a[1][0].conj()], [a[0][1].conj(), a[1][1].conj()]]
+}
+
+/// Whether a gate is unitary: U U† ≈ I within 1e-10.
+pub fn is_unitary(a: &Gate) -> bool {
+    let p = mat_mul(a, &dagger(a));
+    let id = identity();
+    for i in 0..2 {
+        for j in 0..2 {
+            if (p[i][j] - id[i][j]).norm() > 1e-10 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Apply a gate to a state: returns g·|ψ⟩.
+pub fn apply_gate(g: &Gate, s: &State) -> State {
+    [
+        g[0][0] * s[0] + g[0][1] * s[1],
+        g[1][0] * s[0] + g[1][1] * s[1],
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx_eq(a: Complex64, re: f64, im: f64) -> bool {
+        (a.re - re).abs() < 1e-12 && (a.im - im).abs() < 1e-12
+    }
+
+    #[test]
+    fn paulis_square_to_identity() {
+        for g in [pauli_x(), pauli_y(), pauli_z(), hadamard()] {
+            let sq = mat_mul(&g, &g);
+            let id = identity();
+            for i in 0..2 {
+                for j in 0..2 {
+                    assert!((sq[i][j] - id[i][j]).norm() < 1e-12);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn all_standard_gates_are_unitary() {
+        assert!(is_unitary(&identity()));
+        assert!(is_unitary(&pauli_x()));
+        assert!(is_unitary(&pauli_y()));
+        assert!(is_unitary(&pauli_z()));
+        assert!(is_unitary(&hadamard()));
+        assert!(is_unitary(&rz(0.7)));
+        assert!(is_unitary(&ry(1.3)));
+    }
+
+    #[test]
+    fn xy_equals_i_times_z() {
+        // X·Y = iZ
+        let xy = mat_mul(&pauli_x(), &pauli_y());
+        let iz = {
+            let z = pauli_z();
+            [[z[0][0] * c(0.0, 1.0), z[0][1] * c(0.0, 1.0)],
+             [z[1][0] * c(0.0, 1.0), z[1][1] * c(0.0, 1.0)]]
+        };
+        for i in 0..2 {
+            for j in 0..2 {
+                assert!((xy[i][j] - iz[i][j]).norm() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn apply_x_flips_basis() {
+        let zero: State = [c(1.0, 0.0), c(0.0, 0.0)];
+        let flipped = apply_gate(&pauli_x(), &zero);
+        assert!(approx_eq(flipped[0], 0.0, 0.0));
+        assert!(approx_eq(flipped[1], 1.0, 0.0));
+    }
+
+    #[test]
+    fn non_unitary_is_rejected() {
+        let bad: Gate = [[c(1.0, 0.0), c(1.0, 0.0)], [c(0.0, 0.0), c(1.0, 0.0)]];
+        assert!(!is_unitary(&bad));
+    }
+}
+```
+
+- [ ] **Step 2: Enable the module in `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod unitary;
+pub use unitary::Gate;
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert unitary 2>&1 | tail -8
+```
+Expected: `test result: ok. 5 passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/unitary.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): single-qubit gates (Pauli, Hadamard, rotations) + 2x2 complex algebra"
+```
+
+---
+
+## Task 5: The Qubit type and the Bloch sphere
+
+**Files:**
+- Create: `crates/larql-hilbert/src/qubit.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/qubit.rs`**
+
+```rust
+//! A single qubit: a unit vector in ℂ², with Bloch-sphere coordinates.
+//! The Bloch sphere S² = ℂP¹ is the canonical state space (global phase and
+//! norm quotiented out).
+
+use num_complex::Complex64;
+
+use crate::unitary::{apply_gate, Gate, State};
+
+#[inline]
+fn c(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+/// A single-qubit pure state. Not assumed normalized; use `normalized()`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Qubit {
+    pub amp: State,
+}
+
+impl Qubit {
+    /// |0⟩.
+    pub fn ket0() -> Qubit {
+        Qubit { amp: [c(1.0, 0.0), c(0.0, 0.0)] }
+    }
+
+    /// |1⟩.
+    pub fn ket1() -> Qubit {
+        Qubit { amp: [c(0.0, 0.0), c(1.0, 0.0)] }
+    }
+
+    /// State from Bloch angles: cos(θ/2)|0⟩ + e^{iφ} sin(θ/2)|1⟩.
+    pub fn from_bloch(theta: f64, phi: f64) -> Qubit {
+        let h = theta / 2.0;
+        Qubit { amp: [c(h.cos(), 0.0), Complex64::from_polar(h.sin(), phi)] }
+    }
+
+    /// L2 norm sqrt(|α|² + |β|²).
+    pub fn norm(&self) -> f64 {
+        (self.amp[0].norm_sqr() + self.amp[1].norm_sqr()).sqrt()
+    }
+
+    /// A normalized copy (unchanged if already unit norm; panics on the zero vector).
+    pub fn normalized(&self) -> Qubit {
+        let n = self.norm();
+        assert!(n > 0.0, "cannot normalize the zero state");
+        Qubit { amp: [self.amp[0] / n, self.amp[1] / n] }
+    }
+
+    /// Bloch vector (x, y, z) = (2 Re(ᾱβ), 2 Im(ᾱβ), |α|² − |β|²) of the
+    /// normalized state.
+    pub fn bloch_vector(&self) -> [f64; 3] {
+        let q = self.normalized();
+        let (a, b) = (q.amp[0], q.amp[1]);
+        let ab = a.conj() * b;
+        [2.0 * ab.re, 2.0 * ab.im, a.norm_sqr() - b.norm_sqr()]
+    }
+
+    /// Apply a gate, returning the new (un-normalized-if-gate-non-unitary) state.
+    pub fn apply(&self, g: &Gate) -> Qubit {
+        Qubit { amp: apply_gate(g, &self.amp) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unitary::{hadamard, pauli_x};
+
+    fn close(a: [f64; 3], b: [f64; 3]) -> bool {
+        (0..3).all(|i| (a[i] - b[i]).abs() < 1e-12)
+    }
+
+    #[test]
+    fn ket0_points_to_north_pole() {
+        assert!(close(Qubit::ket0().bloch_vector(), [0.0, 0.0, 1.0]));
+    }
+
+    #[test]
+    fn ket1_points_to_south_pole() {
+        assert!(close(Qubit::ket1().bloch_vector(), [0.0, 0.0, -1.0]));
+    }
+
+    #[test]
+    fn hadamard_zero_points_to_plus_x() {
+        let plus = Qubit::ket0().apply(&hadamard());
+        assert!(close(plus.bloch_vector(), [1.0, 0.0, 0.0]));
+    }
+
+    #[test]
+    fn from_bloch_round_trips() {
+        let theta = 0.9;
+        let phi = 1.7;
+        let q = Qubit::from_bloch(theta, phi);
+        let bv = q.bloch_vector();
+        let expected = [
+            theta.sin() * phi.cos(),
+            theta.sin() * phi.sin(),
+            theta.cos(),
+        ];
+        assert!(close(bv, expected), "got {bv:?} expected {expected:?}");
+    }
+
+    #[test]
+    fn x_gate_swaps_poles() {
+        let flipped = Qubit::ket0().apply(&pauli_x());
+        assert!(close(flipped.bloch_vector(), [0.0, 0.0, -1.0]));
+    }
+
+    #[test]
+    fn norm_of_basis_state_is_one() {
+        assert!((Qubit::ket0().norm() - 1.0).abs() < 1e-12);
+    }
+}
+```
+
+- [ ] **Step 2: Enable the module in `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod qubit;
+pub use qubit::Qubit;
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert qubit 2>&1 | tail -8
+```
+Expected: `test result: ok. 6 passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/qubit.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): Qubit type + Bloch-sphere coordinates"
+```
+
+---
+
+## Task 6: Born-rule measurement
+
+**Files:**
+- Create: `crates/larql-hilbert/src/born.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/born.rs`**
+
+```rust
+//! Born-rule measurement in the computational basis.
+
+use crate::qubit::Qubit;
+
+/// Computational-basis measurement probabilities [P(0), P(1)] = [|α|², |β|²]
+/// of the normalized state. Always sums to 1.
+pub fn measure_probs(q: &Qubit) -> [f64; 2] {
+    let qn = q.normalized();
+    [qn.amp[0].norm_sqr(), qn.amp[1].norm_sqr()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unitary::hadamard;
+
+    #[test]
+    fn ket0_measures_zero_with_certainty() {
+        let p = measure_probs(&Qubit::ket0());
+        assert!((p[0] - 1.0).abs() < 1e-12);
+        assert!(p[1].abs() < 1e-12);
+    }
+
+    #[test]
+    fn hadamard_zero_is_fair_coin() {
+        let p = measure_probs(&Qubit::ket0().apply(&hadamard()));
+        assert!((p[0] - 0.5).abs() < 1e-12);
+        assert!((p[1] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn probabilities_sum_to_one() {
+        let q = Qubit::from_bloch(0.9, 1.7);
+        let p = measure_probs(&q);
+        assert!((p[0] + p[1] - 1.0).abs() < 1e-12);
+    }
+}
+```
+
+- [ ] **Step 2: Enable the module in `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod born;
+pub use born::measure_probs;
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert born 2>&1 | tail -8
+```
+Expected: `test result: ok. 3 passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/born.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): Born-rule measurement"
+```
+
+---
+
+## Task 7: The single-qubit language model
+
+**Files:**
+- Create: `crates/larql-hilbert/src/qlm.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/qlm.rs`**
+
+```rust
+//! Minimal single-qubit language model: a 2-token vocabulary {0, 1}. The state
+//! is a qubit; the next-token distribution is the Born rule; after observing a
+//! token `t` the state collapses to |t⟩ and the token-dependent unitary
+//! `gates[t]` is applied. This is a minimal hidden-quantum-Markov LM.
+
+use crate::born::measure_probs;
+use crate::qubit::Qubit;
+use crate::unitary::Gate;
+
+/// A single-qubit autoregressive language model over the alphabet {0, 1}.
+pub struct SingleQubitLM {
+    /// `gates[t]` is applied (after collapse to |t⟩) when token `t` is observed.
+    pub gates: [Gate; 2],
+    /// Initial state before any token.
+    pub init: Qubit,
+}
+
+impl SingleQubitLM {
+    /// Next-token distribution from a state: the Born rule.
+    pub fn next_distribution(&self, state: &Qubit) -> [f64; 2] {
+        measure_probs(state)
+    }
+
+    /// State after observing token `t`: collapse to |t⟩, then apply gates[t].
+    pub fn step(&self, state_token: usize) -> Qubit {
+        let collapsed = if state_token == 0 { Qubit::ket0() } else { Qubit::ket1() };
+        collapsed.apply(&self.gates[state_token])
+    }
+
+    /// Autoregressive log-likelihood (natural log) of a token sequence.
+    /// A token with zero probability yields −∞.
+    pub fn score(&self, tokens: &[usize]) -> f64 {
+        let mut state = self.init;
+        let mut ll = 0.0;
+        for &t in tokens {
+            let p = self.next_distribution(&state);
+            ll += p[t].ln();
+            state = self.step(t);
+        }
+        ll
+    }
+
+    /// Generate `len` tokens, sampling each from the Born distribution using a
+    /// deterministic LCG seeded by `seed` (reproducible; no external rng dep).
+    pub fn generate(&self, len: usize, seed: u64) -> Vec<usize> {
+        let mut rng_state = seed ^ 0x9E37_79B9_7F4A_7C15;
+        let mut next_uniform = || {
+            // SplitMix64-style step → uniform in [0, 1).
+            rng_state = rng_state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = rng_state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^= z >> 31;
+            (z >> 11) as f64 / (1u64 << 53) as f64
+        };
+
+        let mut state = self.init;
+        let mut out = Vec::with_capacity(len);
+        for _ in 0..len {
+            let p = self.next_distribution(&state);
+            let u = next_uniform();
+            let t = if u < p[0] { 0 } else { 1 };
+            out.push(t);
+            state = self.step(t);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unitary::{hadamard, identity};
+
+    fn lm_identity_from_zero() -> SingleQubitLM {
+        SingleQubitLM { gates: [identity(), identity()], init: Qubit::ket0() }
+    }
+
+    #[test]
+    fn next_distribution_sums_to_one() {
+        let lm = lm_identity_from_zero();
+        let p = lm.next_distribution(&Qubit::from_bloch(0.6, 1.1));
+        assert!((p[0] + p[1] - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn deterministic_zero_state_scores_all_zeros_at_log_prob_zero() {
+        // init |0⟩, identity gates: state stays |0⟩ forever → P(0)=1.
+        let lm = lm_identity_from_zero();
+        assert!((lm.score(&[0, 0, 0])).abs() < 1e-12); // ln(1)+ln(1)+ln(1) = 0
+    }
+
+    #[test]
+    fn impossible_token_scores_neg_infinity() {
+        let lm = lm_identity_from_zero();
+        let s = lm.score(&[1]); // P(1)=0 from |0⟩
+        assert!(s.is_infinite() && s < 0.0);
+    }
+
+    #[test]
+    fn generate_from_certain_state_is_deterministic() {
+        // init |0⟩, identity gates: every step P(0)=1 → all zeros regardless of seed.
+        let lm = lm_identity_from_zero();
+        assert_eq!(lm.generate(5, 42), vec![0, 0, 0, 0, 0]);
+        assert_eq!(lm.generate(5, 7), vec![0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn hadamard_init_first_step_is_fair_then_collapses() {
+        // init H|0⟩ (P=[.5,.5]); identity gates. Sequence [0,0] has prob 0.5·1,
+        // sequence [0,1] has prob 0.5·0 = 0 (after observing 0, state collapses
+        // to |0⟩ and stays there).
+        let lm = SingleQubitLM {
+            gates: [identity(), identity()],
+            init: Qubit::ket0().apply(&hadamard()),
+        };
+        let s00 = lm.score(&[0, 0]);
+        assert!((s00 - 0.5_f64.ln()).abs() < 1e-12);
+        let s01 = lm.score(&[0, 1]);
+        assert!(s01.is_infinite() && s01 < 0.0);
+    }
+
+    #[test]
+    fn generate_is_reproducible_for_a_seed() {
+        // Non-trivial dynamics: X gate after observing 0 flips to |1⟩.
+        let lm = SingleQubitLM {
+            gates: [crate::unitary::pauli_x(), identity()],
+            init: Qubit::ket0().apply(&hadamard()),
+        };
+        assert_eq!(lm.generate(8, 12345), lm.generate(8, 12345));
+    }
+}
+```
+
+- [ ] **Step 2: Enable the module in `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod qlm;
+pub use qlm::SingleQubitLM;
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert qlm 2>&1 | tail -8
+```
+Expected: `test result: ok. 6 passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/qlm.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): minimal single-qubit autoregressive language model"
+```
+
+---
+
+## Task 8: Crate-level integration test, clippy, and roadmap doc
+
+**Files:**
+- Create: `crates/larql-hilbert/tests/integration.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs` (doc only)
+
+- [ ] **Step 1: Write a crate-level integration test exercising the public API end to end**
+
+Create `crates/larql-hilbert/tests/integration.rs`:
+
+```rust
+//! End-to-end: build a 2-token single-qubit LM, generate, score, and confirm
+//! the Hilbert-space bridge (a complex-linear real operator has zero antilinear
+//! fraction) all work through the public crate API.
+
+use larql_hilbert::complex_structure::{antilinear_fraction, realify, split_half_j};
+use larql_hilbert::qubit::Qubit;
+use larql_hilbert::unitary::{hadamard, identity, pauli_x};
+use larql_hilbert::SingleQubitLM;
+use ndarray::array;
+
+#[test]
+fn end_to_end_qlm_generate_and_score() {
+    let lm = SingleQubitLM {
+        gates: [pauli_x(), identity()],
+        init: Qubit::ket0().apply(&hadamard()),
+    };
+    // Generation is reproducible and in-alphabet.
+    let seq = lm.generate(16, 2026);
+    assert_eq!(seq.len(), 16);
+    assert!(seq.iter().all(|&t| t < 2));
+    // Scoring a generated-from-certainty sequence is finite when probabilities
+    // are all positive along the path; at minimum, scoring runs without panic.
+    let _ll = lm.score(&seq);
+}
+
+#[test]
+fn hilbert_bridge_complex_linear_operator_is_pure() {
+    // A realified complex operator has zero antilinear fraction (it is exactly
+    // ℂ-linear) — the foundation the larql hilbertian residual rests on.
+    let a = array![[2.0, 1.0], [0.0, 3.0]];
+    let b = array![[0.5, -1.0], [1.0, 0.5]];
+    let m = realify(&a, &b);
+    let j = split_half_j(4);
+    assert!(antilinear_fraction(&m, &j) < 1e-12);
+}
+```
+
+- [ ] **Step 2: Run the integration test**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert --test integration 2>&1 | tail -8
+```
+Expected: `test result: ok. 2 passed`
+
+- [ ] **Step 3: Run the whole crate suite and clippy**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert 2>&1 | tail -6
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -E "warning|error" | head || echo clean
+```
+Expected: all tests pass (Tasks 2–8: 4+3+5+6+3+6+2 = 29 unit/integration tests); clippy clean. Fix any clippy warnings in the touched files (do not suppress).
+
+- [ ] **Step 4: Add a roadmap note to `lib.rs`**
+
+In `crates/larql-hilbert/src/lib.rs`, append to the crate doc comment (the `//!` block at the top):
+
+```rust
+//!
+//! # Roadmap
+//!
+//! This crate is the single-qubit foundation. Next: a 2-qubit model (ℂ⁴ states,
+//! the tensor product) introduces the Bell entanglement operation — the point
+//! at which states no longer factor into single-qubit parts, so the algebra
+//! becomes non-commutative and non-idempotent. GHZ / W states generalize this
+//! to 3+ qubits. Each is a separate plan built on these primitives.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/tests/integration.rs crates/larql-hilbert/src/lib.rs
+git commit -m "test(hilbert): end-to-end integration + roadmap doc"
+```
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- [x] Shared Hilbert-space formalization: split-half J, commutator residual, antilinear fraction — Task 2
+- [x] The unifying equivalence `commutator_residual = 2·antilinear_fraction` (refines/reframes the `larql hilbertian` metric in complex terms) — Task 2 test `equivalence_theorem_residual_is_twice_antilinear_fraction`
+- [x] Real↔complex bridge (realify / complex_parts) — Task 3
+- [x] SU(2) gates + 2×2 complex algebra — Task 4
+- [x] Qubit + Bloch sphere (ℂP¹ canonical state space) — Task 5
+- [x] Born-rule measurement — Task 6
+- [x] Single-qubit autoregressive LM (Born readout, collapse+unitary evolution, generate, score) — Task 7
+- [x] End-to-end integration + roadmap toward 2-qubit/Bell/GHZ/W — Task 8
+- [ ] **Deferred (separate, post-#137):** wire `larql-vindex hilbertian` command to emit `antilinear_fraction` via this crate. Noted in the scope section; not implemented here to avoid conflicting with the open PR.
+
+**Type consistency:**
+- `Gate = [[Complex64; 2]; 2]` and `State = [Complex64; 2]` defined in Task 4 (`unitary.rs`), consumed by `qubit.rs` (Task 5) via `apply_gate`/`Gate`/`State` and by `qlm.rs` (Task 7) via `Gate`.
+- `Qubit { amp: State }` defined Task 5, used by `born.rs` (Task 6) and `qlm.rs` (Task 7).
+- `measure_probs(&Qubit) -> [f64; 2]` defined Task 6, called in `qlm.rs` Task 7.
+- `SingleQubitLM { gates: [Gate; 2], init: Qubit }` defined Task 7; `gates`/`init` field names used consistently in tests and integration.
+- `split_half_j`, `commutator_residual`, `antilinear_fraction`, `realify`, `complex_parts` defined Tasks 2–3, re-exported in `lib.rs`, used in Task 8 integration.
+- `lib.rs` re-exports are added incrementally; every `pub use` references an item that exists by the task that adds the line (Task 1 uses a placeholder body; Task 2 restores real declarations).
+
+**No placeholders:** every code step has complete code; every run step has an exact command + expected count. The only intentional staging is `lib.rs`'s incremental module enabling (Task 1 placeholder → each task appends its own line), which is spelled out explicitly rather than left as "add later".

--- a/docs/superpowers/plans/2026-06-11-two-qubit-bell.md
+++ b/docs/superpowers/plans/2026-06-11-two-qubit-bell.md
@@ -1,0 +1,840 @@
+# Two-Qubit LM + Bell Entanglement Operation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `larql-hilbert` to two qubits: ℂ⁴ states, the tensor product (with a test that entangled/Bell states do **not** factor as `A⊗B`), the CNOT and Bell entangling operations, partial (single-qubit) measurement showing the perfect Bell correlation, and a minimal two-qubit language model whose statistics encode that correlation (the impossible joint tokens score −∞).
+
+**Architecture:** Three new modules in the existing `larql-hilbert` crate. `two_qubit.rs` holds the ℂ⁴ `TwoQubit` state, the `tensor` product, the `is_product` (non-factorization) test, and partial measurement. `gate2.rs` holds the 4×4 gate algebra, the Kronecker lift of single-qubit gates, `cnot`, and `bell`. `qlm2.rs` holds a minimal two-qubit LM. Pure Rust, no new dependencies; hand-written ℂ⁴ algebra (no BLAS), consistent with the single-qubit side.
+
+**Tech Stack:** Rust 2021, `num-complex` (already a dep), the existing `larql-hilbert` `Qubit` / `unitary::{Gate, hadamard, identity}` API.
+
+---
+
+## Scope note: second of two sequenced plans
+
+- **Prior plan (A):** the constructive-measurement / admissibility layer on the single qubit (`measurement::project` / ⊥, `admissibility`). **Build this plan on top of A** — partial measurement here mirrors A's `project`/`None`=⊥ discipline at ℂ⁴.
+- **This plan (B):** the 2-qubit LM + Bell operation. The point where states stop factoring (`A⊗B ≠ A×B`), so the single-qubit-Markov reduction provably breaks.
+- **Future (separate):** GHZ / W entanglement for 3+ qubits (n-qubit `ℂ^{2ⁿ}`), generalizing these primitives.
+
+## Domain background (read once)
+
+A two-qubit pure state lives in ℂ⁴ with basis `|00⟩, |01⟩, |10⟩, |11⟩` indexed by `2·q0 + q1`. The **tensor product** of single qubits `a=(a0,a1)`, `b=(b0,b1)` is `amp[2·q0+q1] = a[q0]·b[q1]`.
+
+A state `(c0,c1,c2,c3)` **factors** (is a product `|a⟩⊗|b⟩`, i.e. *not* entangled) iff the 2×2 amplitude matrix `[[c0,c1],[c2,c3]]` has rank 1 — equivalently `c0·c3 − c1·c2 = 0` (determinant zero). This determinant is the concrete witness of entanglement: nonzero ⟺ entangled. This is the operational content of the multiplicative `⊗ ≠ ×` (the joint system is not a cartesian product).
+
+**CNOT** (control = qubit 0, target = qubit 1) maps `|00⟩→|00⟩, |01⟩→|01⟩, |10⟩→|11⟩, |11⟩→|10⟩`. The **Bell state** `Φ⁺ = (|00⟩+|11⟩)/√2 = CNOT·(H⊗I)·|00⟩` has determinant `1/2 ≠ 0` — maximally entangled.
+
+**Partial measurement** of one qubit projects onto the subspace where that qubit equals the outcome, then renormalizes (or ⊥ if probability 0). Measuring qubit 0 of `Φ⁺`: outcome 0 collapses to `|00⟩` (so qubit 1 is now certainly 0); outcome 1 collapses to `|11⟩` (qubit 1 certainly 1). The two qubits are **perfectly correlated** — a non-local correlation no product of two independent single-qubit distributions can produce. That is precisely where the single-qubit "memory collapses to the last token" Markov reduction fails.
+
+## File structure
+
+New files in `crates/larql-hilbert/`:
+- `src/two_qubit.rs` — `TwoQubit` (ℂ⁴), `tensor`, `is_product`, `marginal_probs`, `measure_qubit`.
+- `src/gate2.rs` — `Gate4`, `mat_mul4`/`dagger4`/`is_unitary4`/`apply4`, `tensor_gate`, `cnot`, `bell`.
+- `src/qlm2.rs` — `TwoQubitLM`.
+
+Modified: `src/lib.rs` — declare the three modules + re-exports.
+
+Existing API used (do not modify): `Qubit { pub amp: [Complex64; 2] }`; `unitary::{Gate, hadamard, identity}`.
+
+---
+
+## Task 1: `TwoQubit` state in ℂ⁴
+
+**Files:**
+- Create: `crates/larql-hilbert/src/two_qubit.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/two_qubit.rs`**
+
+```rust
+//! Two-qubit pure states in ℂ⁴ (basis |00⟩,|01⟩,|10⟩,|11⟩, index = 2·q0 + q1),
+//! the tensor product, the entanglement (non-factorization) test, and partial
+//! single-qubit measurement.
+
+use num_complex::Complex64;
+
+use crate::qubit::Qubit;
+
+#[inline]
+fn c(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+/// A two-qubit pure state. Not assumed normalized.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TwoQubit {
+    pub amp: [Complex64; 4],
+}
+
+impl TwoQubit {
+    /// Computational basis state |q0 q1⟩ (each of q0, q1 ∈ {0, 1}).
+    pub fn ket(q0: usize, q1: usize) -> TwoQubit {
+        let mut amp = [c(0.0, 0.0); 4];
+        amp[2 * q0 + q1] = c(1.0, 0.0);
+        TwoQubit { amp }
+    }
+
+    /// L2 norm.
+    pub fn norm(&self) -> f64 {
+        self.amp.iter().map(|a| a.norm_sqr()).sum::<f64>().sqrt()
+    }
+
+    /// A normalized copy (panics on the zero state).
+    pub fn normalized(&self) -> TwoQubit {
+        let n = self.norm();
+        assert!(n > 0.0, "cannot normalize the zero state");
+        let mut amp = self.amp;
+        for a in amp.iter_mut() {
+            *a /= n;
+        }
+        TwoQubit { amp }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ket_sets_the_right_basis_index() {
+        assert_eq!(TwoQubit::ket(0, 0).amp[0], c(1.0, 0.0));
+        assert_eq!(TwoQubit::ket(1, 0).amp[2], c(1.0, 0.0));
+        assert_eq!(TwoQubit::ket(1, 1).amp[3], c(1.0, 0.0));
+    }
+
+    #[test]
+    fn norm_of_basis_state_is_one() {
+        assert!((TwoQubit::ket(0, 1).norm() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn normalized_scales_to_unit_norm() {
+        let s = TwoQubit { amp: [c(2.0, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(0.0, 0.0)] };
+        assert!((s.normalized().norm() - 1.0).abs() < 1e-12);
+    }
+}
+```
+
+- [ ] **Step 2: Enable the module in `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod two_qubit;
+pub use two_qubit::TwoQubit;
+```
+
+- [ ] **Step 3: Run tests + clippy + commit**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert two_qubit 2>&1 | tail -6
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+Expected: `test result: ok. 3 passed`
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/two_qubit.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): TwoQubit state in C^4"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 2: tensor product + the non-factorization (entanglement) test
+
+**Files:**
+- Modify: `crates/larql-hilbert/src/two_qubit.rs`
+
+- [ ] **Step 1: Add the failing tests**
+
+In `crates/larql-hilbert/src/two_qubit.rs`, inside `mod tests`, add:
+
+```rust
+    use crate::qubit::Qubit;
+    use crate::unitary::hadamard;
+
+    #[test]
+    fn tensor_of_basis_qubits_is_basis_state() {
+        let t = tensor(&Qubit::ket1(), &Qubit::ket0()); // |1⟩⊗|0⟩ = |10⟩
+        assert_eq!(t, TwoQubit::ket(1, 0));
+    }
+
+    #[test]
+    fn product_states_are_recognized_as_product() {
+        let t = tensor(&Qubit::ket0().apply(&hadamard()), &Qubit::ket1());
+        assert!(is_product(&t));
+    }
+
+    #[test]
+    fn bell_like_state_is_not_product() {
+        // (|00⟩ + |11⟩)/√2 — determinant c0·c3 − c1·c2 = 1/2 ≠ 0.
+        let s = 1.0 / std::f64::consts::SQRT_2;
+        let entangled = TwoQubit {
+            amp: [c(s, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(s, 0.0)],
+        };
+        assert!(!is_product(&entangled));
+    }
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert two_qubit 2>&1 | tail -8
+```
+Expected: compile error — `tensor` / `is_product` not defined.
+
+- [ ] **Step 3: Add the functions**
+
+In `crates/larql-hilbert/src/two_qubit.rs`, add after the `impl TwoQubit` block (before `#[cfg(test)]`):
+
+```rust
+/// Tensor (Kronecker) product of two single qubits: amp[2·q0+q1] = a[q0]·b[q1].
+pub fn tensor(a: &Qubit, b: &Qubit) -> TwoQubit {
+    let mut amp = [c(0.0, 0.0); 4];
+    for q0 in 0..2 {
+        for q1 in 0..2 {
+            amp[2 * q0 + q1] = a.amp[q0] * b.amp[q1];
+        }
+    }
+    TwoQubit { amp }
+}
+
+/// Whether a two-qubit state factors as |a⟩⊗|b⟩ (i.e. is NOT entangled). True
+/// iff the 2×2 amplitude matrix [[c0,c1],[c2,c3]] has rank 1, equivalently
+/// c0·c3 − c1·c2 = 0. The determinant's magnitude is the entanglement witness.
+pub fn is_product(s: &TwoQubit) -> bool {
+    let det = s.amp[0] * s.amp[3] - s.amp[1] * s.amp[2];
+    det.norm() < 1e-10
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert two_qubit 2>&1 | tail -8
+```
+Expected: `test result: ok. 6 passed`
+
+- [ ] **Step 5: Re-export + clippy + commit**
+
+In `crates/larql-hilbert/src/lib.rs`, change the two_qubit re-export line to:
+```rust
+pub use two_qubit::{is_product, tensor, TwoQubit};
+```
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/two_qubit.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): tensor product + is_product (entanglement non-factorization test)"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 3: partial (single-qubit) measurement
+
+**Files:**
+- Modify: `crates/larql-hilbert/src/two_qubit.rs`
+
+- [ ] **Step 1: Add the failing tests**
+
+In `crates/larql-hilbert/src/two_qubit.rs`, inside `mod tests`, add:
+
+```rust
+    fn entangled_phi_plus() -> TwoQubit {
+        // (|00⟩ + |11⟩)/√2, built directly (gate construction lands in Task 5).
+        let s = 1.0 / std::f64::consts::SQRT_2;
+        TwoQubit { amp: [c(s, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(s, 0.0)] }
+    }
+
+    #[test]
+    fn marginal_probs_of_phi_plus_are_fair() {
+        let p = marginal_probs(&entangled_phi_plus(), 0);
+        assert!((p[0] - 0.5).abs() < 1e-12 && (p[1] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn measuring_one_qubit_forces_the_other() {
+        let b = entangled_phi_plus();
+        // measure qubit 0 = 0 → collapses to |00⟩ → qubit 1 is certainly 0.
+        let after0 = measure_qubit(&b, 0, 0).unwrap();
+        let m1 = marginal_probs(&after0, 1);
+        assert!((m1[0] - 1.0).abs() < 1e-12);
+        // measure qubit 0 = 1 → |11⟩ → qubit 1 certainly 1.
+        let after1 = measure_qubit(&b, 0, 1).unwrap();
+        let m1b = marginal_probs(&after1, 1);
+        assert!((m1b[1] - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn impossible_partial_outcome_is_bottom() {
+        // |00⟩: measuring qubit 0 = 1 is impossible → None (⊥).
+        assert!(measure_qubit(&TwoQubit::ket(0, 0), 0, 1).is_none());
+    }
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert two_qubit 2>&1 | tail -8
+```
+Expected: compile error — `marginal_probs` / `measure_qubit` not defined.
+
+- [ ] **Step 3: Add the functions**
+
+In `crates/larql-hilbert/src/two_qubit.rs`, add after `is_product`:
+
+```rust
+/// Marginal Born probabilities [P(q=0), P(q=1)] for measuring qubit `which`
+/// (0 or 1) of the normalized state.
+pub fn marginal_probs(s: &TwoQubit, which: usize) -> [f64; 2] {
+    let sn = s.normalized();
+    let mut p = [0.0, 0.0];
+    for q0 in 0..2 {
+        for q1 in 0..2 {
+            let bit = if which == 0 { q0 } else { q1 };
+            p[bit] += sn.amp[2 * q0 + q1].norm_sqr();
+        }
+    }
+    p
+}
+
+/// Partial measurement: project onto the subspace where qubit `which` equals
+/// `outcome`, then renormalize. Returns `None` if that outcome has probability
+/// 0 (⊥) — the two-qubit analogue of `measurement::project`'s ⊥.
+pub fn measure_qubit(s: &TwoQubit, which: usize, outcome: usize) -> Option<TwoQubit> {
+    let sn = s.normalized();
+    let mut amp = [c(0.0, 0.0); 4];
+    let mut norm_sq = 0.0;
+    for q0 in 0..2 {
+        for q1 in 0..2 {
+            let bit = if which == 0 { q0 } else { q1 };
+            if bit == outcome {
+                let a = sn.amp[2 * q0 + q1];
+                amp[2 * q0 + q1] = a;
+                norm_sq += a.norm_sqr();
+            }
+        }
+    }
+    if norm_sq < 1e-300 {
+        return None;
+    }
+    let nrm = norm_sq.sqrt();
+    for a in amp.iter_mut() {
+        *a /= nrm;
+    }
+    Some(TwoQubit { amp })
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert two_qubit 2>&1 | tail -8
+```
+Expected: `test result: ok. 9 passed`
+
+- [ ] **Step 5: Re-export + clippy + commit**
+
+In `crates/larql-hilbert/src/lib.rs`, change the two_qubit re-export line to:
+```rust
+pub use two_qubit::{is_product, marginal_probs, measure_qubit, tensor, TwoQubit};
+```
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/two_qubit.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): partial single-qubit measurement (marginal_probs, measure_qubit)"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 4: two-qubit gate algebra + Kronecker lift
+
+**Files:**
+- Create: `crates/larql-hilbert/src/gate2.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/gate2.rs`**
+
+```rust
+//! Two-qubit gates as 4×4 complex matrices, with hand-written algebra and the
+//! Kronecker lift of single-qubit gates.
+
+use num_complex::Complex64;
+
+use crate::two_qubit::TwoQubit;
+use crate::unitary::Gate;
+
+#[inline]
+fn c(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+/// A two-qubit gate: a 4×4 complex matrix, row-major.
+pub type Gate4 = [[Complex64; 4]; 4];
+
+/// Multiply two 4×4 gates: A·B.
+pub fn mat_mul4(a: &Gate4, b: &Gate4) -> Gate4 {
+    let mut out = [[c(0.0, 0.0); 4]; 4];
+    for (i, row) in out.iter_mut().enumerate() {
+        for (j, cell) in row.iter_mut().enumerate() {
+            let mut s = c(0.0, 0.0);
+            for k in 0..4 {
+                s += a[i][k] * b[k][j];
+            }
+            *cell = s;
+        }
+    }
+    out
+}
+
+/// Conjugate transpose (dagger) of a 4×4 gate.
+pub fn dagger4(a: &Gate4) -> Gate4 {
+    let mut out = [[c(0.0, 0.0); 4]; 4];
+    for (i, row) in out.iter_mut().enumerate() {
+        for (j, cell) in row.iter_mut().enumerate() {
+            *cell = a[j][i].conj();
+        }
+    }
+    out
+}
+
+/// Whether a 4×4 gate is unitary: U U† ≈ I within 1e-10.
+pub fn is_unitary4(a: &Gate4) -> bool {
+    let p = mat_mul4(a, &dagger4(a));
+    for i in 0..4 {
+        for j in 0..4 {
+            let expected = if i == j { c(1.0, 0.0) } else { c(0.0, 0.0) };
+            if (p[i][j] - expected).norm() > 1e-10 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Apply a 4×4 gate to a two-qubit state.
+pub fn apply4(g: &Gate4, s: &TwoQubit) -> TwoQubit {
+    let mut amp = [c(0.0, 0.0); 4];
+    for (i, slot) in amp.iter_mut().enumerate() {
+        let mut acc = c(0.0, 0.0);
+        for j in 0..4 {
+            acc += g[i][j] * s.amp[j];
+        }
+        *slot = acc;
+    }
+    TwoQubit { amp }
+}
+
+/// Kronecker product of two single-qubit gates: (A⊗B) acting on |q0 q1⟩,
+/// with A on qubit 0 and B on qubit 1.
+pub fn tensor_gate(a: &Gate, b: &Gate) -> Gate4 {
+    let mut out = [[c(0.0, 0.0); 4]; 4];
+    for i0 in 0..2 {
+        for i1 in 0..2 {
+            for j0 in 0..2 {
+                for j1 in 0..2 {
+                    out[2 * i0 + i1][2 * j0 + j1] = a[i0][j0] * b[i1][j1];
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unitary::{hadamard, identity, pauli_x};
+
+    #[test]
+    fn tensor_gate_identity_is_4x4_identity() {
+        let ii = tensor_gate(&identity(), &identity());
+        assert!(is_unitary4(&ii));
+        let applied = apply4(&ii, &TwoQubit::ket(1, 0));
+        assert_eq!(applied, TwoQubit::ket(1, 0));
+    }
+
+    #[test]
+    fn tensor_gate_x_on_qubit0_flips_first_index() {
+        // (X⊗I)|00⟩ = |10⟩
+        let xi = tensor_gate(&pauli_x(), &identity());
+        let r = apply4(&xi, &TwoQubit::ket(0, 0));
+        assert_eq!(r, TwoQubit::ket(1, 0));
+    }
+
+    #[test]
+    fn tensor_gate_h_on_qubit0_superposes_first_index() {
+        // (H⊗I)|00⟩ = (|00⟩ + |10⟩)/√2
+        let hi = tensor_gate(&hadamard(), &identity());
+        let r = apply4(&hi, &TwoQubit::ket(0, 0));
+        let s = 1.0 / std::f64::consts::SQRT_2;
+        assert!((r.amp[0].re - s).abs() < 1e-12);
+        assert!((r.amp[2].re - s).abs() < 1e-12);
+        assert!(r.amp[1].norm() < 1e-12 && r.amp[3].norm() < 1e-12);
+    }
+
+    #[test]
+    fn tensor_gate_is_unitary() {
+        assert!(is_unitary4(&tensor_gate(&hadamard(), &pauli_x())));
+    }
+}
+```
+
+- [ ] **Step 2: Enable the module in `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod gate2;
+pub use gate2::Gate4;
+```
+
+- [ ] **Step 3: Run tests + clippy + commit**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert gate2 2>&1 | tail -8
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+Expected: `test result: ok. 4 passed`
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/gate2.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): 4x4 two-qubit gate algebra + Kronecker lift"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 5: CNOT + the Bell entangling operation
+
+**Files:**
+- Modify: `crates/larql-hilbert/src/gate2.rs`
+
+- [ ] **Step 1: Add the failing tests**
+
+In `crates/larql-hilbert/src/gate2.rs`, inside `mod tests`, add:
+
+```rust
+    use crate::two_qubit::is_product;
+
+    #[test]
+    fn cnot_is_unitary_and_flips_target_when_control_set() {
+        assert!(is_unitary4(&cnot()));
+        // |10⟩ → |11⟩ (control=1 flips target)
+        assert_eq!(apply4(&cnot(), &TwoQubit::ket(1, 0)), TwoQubit::ket(1, 1));
+        // |00⟩ → |00⟩ (control=0 leaves target)
+        assert_eq!(apply4(&cnot(), &TwoQubit::ket(0, 0)), TwoQubit::ket(0, 0));
+    }
+
+    #[test]
+    fn bell_is_the_phi_plus_state() {
+        let b = bell();
+        let s = 1.0 / std::f64::consts::SQRT_2;
+        assert!((b.amp[0].re - s).abs() < 1e-12);
+        assert!((b.amp[3].re - s).abs() < 1e-12);
+        assert!(b.amp[1].norm() < 1e-12 && b.amp[2].norm() < 1e-12);
+        assert!((b.norm() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn bell_state_is_entangled() {
+        assert!(!is_product(&bell()));
+    }
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert gate2 2>&1 | tail -8
+```
+Expected: compile error — `cnot` / `bell` not defined.
+
+- [ ] **Step 3: Add the functions**
+
+In `crates/larql-hilbert/src/gate2.rs`, add after `tensor_gate` (before `#[cfg(test)]`):
+
+```rust
+/// CNOT with control = qubit 0, target = qubit 1:
+/// |00⟩→|00⟩, |01⟩→|01⟩, |10⟩→|11⟩, |11⟩→|10⟩.
+pub fn cnot() -> Gate4 {
+    [
+        [c(1.0, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(0.0, 0.0)],
+        [c(0.0, 0.0), c(1.0, 0.0), c(0.0, 0.0), c(0.0, 0.0)],
+        [c(0.0, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(1.0, 0.0)],
+        [c(0.0, 0.0), c(0.0, 0.0), c(1.0, 0.0), c(0.0, 0.0)],
+    ]
+}
+
+/// The Bell state Φ⁺ = (|00⟩ + |11⟩)/√2 = CNOT·(H⊗I)·|00⟩. The canonical
+/// entangling operation: its output does not factor as |a⟩⊗|b⟩.
+pub fn bell() -> TwoQubit {
+    use crate::unitary::{hadamard, identity};
+    let h_i = tensor_gate(&hadamard(), &identity());
+    let prepared = apply4(&h_i, &TwoQubit::ket(0, 0));
+    apply4(&cnot(), &prepared)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert gate2 2>&1 | tail -8
+```
+Expected: `test result: ok. 7 passed`
+
+- [ ] **Step 5: Re-export + clippy + commit**
+
+In `crates/larql-hilbert/src/lib.rs`, change the gate2 re-export line to:
+```rust
+pub use gate2::{bell, cnot, Gate4};
+```
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/gate2.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): CNOT + Bell entangling operation"
+```
+
+## Report
+Status DONE/BLOCKED, test output, commit SHA.
+
+---
+
+## Task 6: minimal two-qubit LM + Bell-correlation integration
+
+**Files:**
+- Create: `crates/larql-hilbert/src/qlm2.rs`
+- Create: `crates/larql-hilbert/tests/bell_integration.rs`
+- Modify: `crates/larql-hilbert/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/larql-hilbert/src/qlm2.rs`**
+
+```rust
+//! Minimal two-qubit language model: a 4-token vocabulary {0,1,2,3} = the joint
+//! computational-basis outcomes |00⟩,|01⟩,|10⟩,|11⟩. The next-token
+//! distribution is the joint Born rule; after observing outcome `t` the state
+//! collapses to |t⟩ (as a two-qubit basis state) and `gates[t]` is applied.
+
+use crate::gate2::{apply4, Gate4};
+use crate::two_qubit::TwoQubit;
+
+/// A two-qubit autoregressive language model over the alphabet {0,1,2,3}.
+pub struct TwoQubitLM {
+    /// `gates[t]` is applied (after collapse to |t⟩) when joint outcome `t` is observed.
+    pub gates: [Gate4; 4],
+    /// Initial two-qubit state before any token.
+    pub init: TwoQubit,
+}
+
+impl TwoQubitLM {
+    /// Joint Born next-token distribution [P(00),P(01),P(10),P(11)].
+    pub fn next_distribution(&self, state: &TwoQubit) -> [f64; 4] {
+        let sn = state.normalized();
+        [
+            sn.amp[0].norm_sqr(),
+            sn.amp[1].norm_sqr(),
+            sn.amp[2].norm_sqr(),
+            sn.amp[3].norm_sqr(),
+        ]
+    }
+
+    /// State after observing joint outcome `t`: collapse to |t⟩, apply gates[t].
+    ///
+    /// # Panics
+    /// Panics if `t` ≥ 4 (the vocabulary is {0,1,2,3}).
+    pub fn step(&self, t: usize) -> TwoQubit {
+        let collapsed = TwoQubit::ket(t / 2, t % 2);
+        apply4(&self.gates[t], &collapsed)
+    }
+
+    /// Autoregressive log-likelihood; an impossible token yields −∞.
+    ///
+    /// # Panics
+    /// Panics if any token is ≥ 4.
+    pub fn score(&self, tokens: &[usize]) -> f64 {
+        let mut state = self.init;
+        let mut ll = 0.0;
+        for &t in tokens {
+            let p = self.next_distribution(&state);
+            ll += p[t].ln();
+            state = self.step(t);
+        }
+        ll
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gate2::{bell, tensor_gate};
+    use crate::unitary::identity;
+
+    fn identity_gates() -> [Gate4; 4] {
+        let ii = tensor_gate(&identity(), &identity());
+        [ii, ii, ii, ii]
+    }
+
+    #[test]
+    fn bell_init_distribution_is_correlated() {
+        // init = Bell Φ⁺ → joint distribution [0.5, 0, 0, 0.5]:
+        // tokens 0 (=00) and 3 (=11) likely; 1 (=01) and 2 (=10) impossible.
+        let lm = TwoQubitLM { gates: identity_gates(), init: bell() };
+        let p = lm.next_distribution(&bell());
+        assert!((p[0] - 0.5).abs() < 1e-12);
+        assert!((p[3] - 0.5).abs() < 1e-12);
+        assert!(p[1].abs() < 1e-12 && p[2].abs() < 1e-12);
+    }
+
+    #[test]
+    fn impossible_joint_token_scores_neg_infinity() {
+        // From Bell init, token 1 (=01) is impossible → −∞.
+        let lm = TwoQubitLM { gates: identity_gates(), init: bell() };
+        let s = lm.score(&[1]);
+        assert!(s.is_infinite() && s < 0.0);
+        // token 0 (=00) is possible → finite.
+        assert!(lm.score(&[0]).is_finite());
+    }
+
+    #[test]
+    fn next_distribution_sums_to_one() {
+        let lm = TwoQubitLM { gates: identity_gates(), init: bell() };
+        let p = lm.next_distribution(&TwoQubit::ket(0, 1));
+        assert!((p.iter().sum::<f64>() - 1.0).abs() < 1e-12);
+    }
+}
+```
+
+- [ ] **Step 2: Enable the module in `lib.rs`**
+
+Append to `crates/larql-hilbert/src/lib.rs`:
+
+```rust
+pub mod qlm2;
+pub use qlm2::TwoQubitLM;
+```
+
+- [ ] **Step 3: Run the module tests**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert qlm2 2>&1 | tail -8
+```
+Expected: `test result: ok. 3 passed`
+
+- [ ] **Step 4: Create the integration test**
+
+Create `crates/larql-hilbert/tests/bell_integration.rs`:
+
+```rust
+//! End-to-end: the Bell operation produces a non-factorizing state whose partial
+//! measurement is perfectly correlated, and whose LM statistics forbid the
+//! anti-correlated tokens — the place the single-qubit Markov reduction breaks.
+
+use larql_hilbert::gate2::bell;
+use larql_hilbert::qlm2::TwoQubitLM;
+use larql_hilbert::two_qubit::{is_product, marginal_probs, measure_qubit};
+use larql_hilbert::unitary::identity;
+use larql_hilbert::gate2::tensor_gate;
+
+#[test]
+fn bell_is_entangled_and_correlated_end_to_end() {
+    let b = bell();
+    // 1. Non-factorization: the Bell state is genuinely entangled.
+    assert!(!is_product(&b));
+    // 2. Each qubit alone looks fair...
+    assert!((marginal_probs(&b, 0)[0] - 0.5).abs() < 1e-12);
+    // 3. ...but measuring qubit 0 forces qubit 1 (perfect correlation).
+    let after0 = measure_qubit(&b, 0, 0).unwrap();
+    assert!((marginal_probs(&after0, 1)[0] - 1.0).abs() < 1e-12);
+    let after1 = measure_qubit(&b, 0, 1).unwrap();
+    assert!((marginal_probs(&after1, 1)[1] - 1.0).abs() < 1e-12);
+}
+
+#[test]
+fn bell_lm_forbids_anticorrelated_tokens() {
+    let ii = tensor_gate(&identity(), &identity());
+    let lm = TwoQubitLM { gates: [ii, ii, ii, ii], init: bell() };
+    // Anti-correlated joint outcomes 01 and 10 are impossible (−∞);
+    // correlated 00 and 11 are possible (finite). No product of two independent
+    // single-qubit chains can reproduce this.
+    assert!(lm.score(&[1]).is_infinite());
+    assert!(lm.score(&[2]).is_infinite());
+    assert!(lm.score(&[0]).is_finite());
+    assert!(lm.score(&[3]).is_finite());
+}
+```
+
+- [ ] **Step 5: Run the integration test + whole crate suite**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-hilbert --test bell_integration 2>&1 | tail -6
+cd /home/metavacua/larql && cargo test -p larql-hilbert 2>&1 | tail -6
+```
+Expected: 2 integration tests pass; whole-crate suite passes.
+
+- [ ] **Step 6: Add a roadmap note to `lib.rs`**
+
+In `crates/larql-hilbert/src/lib.rs`, update the `# Roadmap` doc section (or append if absent) with:
+
+```rust
+//!
+//! Two qubits (`two_qubit`, `gate2`, `qlm2`) add the tensor product, the Bell
+//! entangling operation, and partial measurement — where states stop factoring
+//! (`A⊗B ≠ A×B`) and the single-qubit Markov reduction breaks. Next: GHZ / W
+//! states for 3+ qubits (`ℂ^{2ⁿ}`), generalizing these primitives.
+```
+
+- [ ] **Step 7: Clippy + commit**
+
+```
+cd /home/metavacua/larql && cargo clippy -p larql-hilbert 2>&1 | grep -iE "warning|error" | head || echo clean
+```
+```bash
+cd /home/metavacua/larql
+git add crates/larql-hilbert/src/qlm2.rs crates/larql-hilbert/tests/bell_integration.rs crates/larql-hilbert/src/lib.rs
+git commit -m "feat(hilbert): minimal two-qubit LM + Bell-correlation integration"
+```
+
+## Report
+Status DONE/BLOCKED, full-crate test count, commit SHA.
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- [x] ℂ⁴ `TwoQubit` state — Task 1
+- [x] Tensor product + non-factorization (`is_product`, `A⊗B ≠ A×B`) — Task 2
+- [x] Partial measurement + Bell correlation — Task 3 (+ end-to-end Task 6)
+- [x] 4×4 gate algebra + Kronecker lift — Task 4
+- [x] CNOT + Bell entangling operation — Task 5
+- [x] Two-qubit LM (joint Born, score, −∞ on impossible joint tokens) — Task 6
+- [x] Roadmap → GHZ / W — Task 6
+
+**Type consistency:**
+- `TwoQubit { pub amp: [Complex64; 4] }`, `TwoQubit::ket(q0,q1)`, `norm`, `normalized` defined Task 1; used throughout.
+- `tensor(&Qubit,&Qubit)->TwoQubit`, `is_product(&TwoQubit)->bool` defined Task 2; `is_product` used in Tasks 5,6.
+- `marginal_probs(&TwoQubit,usize)->[f64;2]`, `measure_qubit(&TwoQubit,usize,usize)->Option<TwoQubit>` defined Task 3; used Task 6.
+- `Gate4 = [[Complex64;4];4]`, `mat_mul4`/`dagger4`/`is_unitary4`/`apply4`/`tensor_gate` defined Task 4; `apply4`/`tensor_gate` used Tasks 5,6.
+- `cnot()->Gate4`, `bell()->TwoQubit` defined Task 5; used Task 6.
+- `TwoQubitLM { gates: [Gate4;4], init: TwoQubit }` with `next_distribution`/`step`/`score` defined Task 6.
+- `lib.rs` re-exports grow incrementally; each references items present by the task adding the line.
+
+**No placeholders:** every code step is complete; every run step has an exact command + expected count. The Task 3 tests construct `Φ⁺` directly (gate construction lands in Task 5) so each task is independently runnable.

--- a/docs/superpowers/plans/2026-06-11-vindex-entanglement-analysis.md
+++ b/docs/superpowers/plans/2026-06-11-vindex-entanglement-analysis.md
@@ -1,0 +1,361 @@
+# Vindex Entanglement / Compressibility Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `larql entanglement <vindex>` — a CLI that loads a vindex's attention weights, computes per-head the Hilbertian residual **and** the entanglement entropy of the QK coupling, and writes `entanglement_meta.json` — turning the classical-vs-quantum compressibility conjecture into measured numbers on a real model.
+
+**Architecture:** A new `larql-cli` subcommand parallel to `larql hilbertian`. It reuses the existing attention loader and per-head helpers from `larql-vindex` (`load_attention_qk`, `head_block`, `head_coupling`, `commutator_residual`, `complex_structure_split_half`, `kv_head_for_query`) and the new `entanglement_entropy` from `larql-hilbert`. For each head it forms the coupling `C = W_Q W_Kᵀ`, then reports its residual (complex-linearity) and its entanglement entropy (Schmidt/tensor-network compressibility, in ebits). Purely additive — no existing vindex file is modified.
+
+**Tech Stack:** Rust 2021, `ndarray` 0.16, `serde`/`serde_json` (all already in `larql-cli`), `larql-vindex` (loaders + head helpers), `larql-hilbert` (`entanglement_entropy`, new dependency).
+
+---
+
+## Scope note
+
+This is **Phase 7** of the QLM roadmap (`docs/QLM-ROADMAP.md`): the *analysis* that runs the Phase-4 meter on real weights. It builds on the entanglement-entropy meter (PR #141) and the Hilbertian command (PR #137). Deferred to a later pass: the **canonical-vs-raw** and **on-shell-vs-full** comparisons (need the canonical whitening applied to the weights and the on-shell mask joined in) and the **Zipfian/HTSR** power-law fit — this plan delivers the raw per-head residual+entropy numbers first.
+
+## Domain background (read once)
+
+For attention head `h` (query head `h`, its GQA key head `g = h / (num_q_heads/num_kv_heads)`), the **QK coupling** is `C_h = W_Q^{(h)} (W_K^{(g)})ᵀ` (shape `[head_dim, head_dim]`). Two per-head compressibility quantities, on the *same* matrix:
+
+- **Hilbertian residual** `‖[C_h, J]‖_F / ‖C_h‖_F ∈ [0,2]` — complex-linearity; `0` ⇒ the head is complex-compressible (the superdense factor-2). Already computed by `larql hilbertian`.
+- **Entanglement entropy** `S(C_h) ∈ [0, log₂(head_dim)]` ebits — the spectral entropy of the squared singular values; `0` ⇒ rank-1 (fully tensor-network-compressible), `log₂(head_dim)` ⇒ flat (incompressible).
+
+Reused APIs (all `pub`, verified):
+- `larql_vindex::format::attn_load::load_attention_qk(dir, num_layers) -> Result<Vec<(Array2<f32>, Array2<f32>)>, VindexError>` — per-layer `(W_Q [n_q·head_dim, hidden], W_K [n_kv·head_dim, hidden])`.
+- `larql_vindex::format::load::load_vindex_config(dir) -> Result<VindexConfig, VindexError>`; `config.model_config: Option<VindexModelConfig>` with `num_q_heads`, `num_kv_heads`, `head_dim`.
+- `larql_vindex::canonical::{complex_structure_split_half, head_block, head_coupling, commutator_residual, kv_head_for_query}`.
+- `larql_hilbert::entanglement_entropy(&Array2<f64>) -> f64`.
+
+## File structure
+
+- Modify: `crates/larql-cli/Cargo.toml` — add `larql-hilbert` dependency.
+- Create: `crates/larql-cli/src/commands/extraction/entanglement_cmd.rs` — types, the pure `coupling_metrics` helper, and `run`.
+- Modify: `crates/larql-cli/src/commands/extraction/mod.rs` — `pub mod entanglement_cmd;`.
+- Modify: `crates/larql-cli/src/main.rs` — `Entanglement` variant + dispatch.
+
+---
+
+## Task 1: Dependency + types + the per-head metric helper (TDD)
+
+**Files:**
+- Modify: `crates/larql-cli/Cargo.toml`
+- Create: `crates/larql-cli/src/commands/extraction/entanglement_cmd.rs`
+
+- [ ] **Step 1: Add `larql-hilbert` to `crates/larql-cli/Cargo.toml`**
+
+In the `[dependencies]` section, after the `larql-vindex = { path = "../larql-vindex" }` line, add:
+```toml
+larql-hilbert = { path = "../larql-hilbert" }
+```
+
+- [ ] **Step 2: Create `crates/larql-cli/src/commands/extraction/entanglement_cmd.rs` with the failing test**
+
+Write this file (types + the pure helper + its test; the `run` function is added in Task 2):
+
+```rust
+use std::path::PathBuf;
+use std::time::Instant;
+
+use clap::Args;
+use ndarray::Array2;
+use serde::{Deserialize, Serialize};
+
+use larql_hilbert::entanglement_entropy;
+use larql_vindex::canonical::{
+    commutator_residual, complex_structure_split_half, head_block, head_coupling, kv_head_for_query,
+};
+use larql_vindex::format::{attn_load::load_attention_qk, load::load_vindex_config};
+
+/// Per-head compressibility metrics on the QK coupling `C = W_Q W_Kᵀ`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeadEntanglementInfo {
+    pub layer: usize,
+    pub query_head: usize,
+    pub kv_head: usize,
+    /// Hilbertian residual ‖[C,J]‖/‖C‖ ∈ [0,2] — complex-linearity.
+    pub residual: f64,
+    /// Entanglement entropy of C, in ebits ∈ [0, log2(head_dim)].
+    pub entropy: f64,
+}
+
+/// Root metadata written to `entanglement_meta.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntanglementMeta {
+    pub version: u32,
+    pub model: String,
+    pub head_dim: usize,
+    pub num_q_heads: usize,
+    pub num_kv_heads: usize,
+    pub heads: Vec<HeadEntanglementInfo>,
+}
+
+#[derive(Args)]
+pub struct EntanglementArgs {
+    /// Path to the .vindex directory to analyse.
+    vindex: PathBuf,
+}
+
+/// The two compressibility metrics of a coupling matrix `C` against the
+/// split-half complex structure `J`: (Hilbertian residual, entanglement entropy).
+fn coupling_metrics(coupling: &Array2<f64>, j: &Array2<f64>) -> (f64, f64) {
+    let residual = commutator_residual(coupling, j);
+    let entropy = entanglement_entropy(coupling);
+    (residual, entropy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn identity_coupling_is_complex_linear_and_flat() {
+        // I₄ commutes with J → residual 0; flat spectrum → log2(4) = 2 ebits.
+        let c = Array2::<f64>::eye(4);
+        let j = complex_structure_split_half(4);
+        let (r, s) = coupling_metrics(&c, &j);
+        assert!(r.abs() < 1e-9, "identity should commute with J → residual 0, got {r}");
+        assert!((s - 2.0).abs() < 1e-9, "I₄ flat spectrum → 2 ebits, got {s}");
+    }
+
+    #[test]
+    fn rank_one_coupling_has_zero_entanglement() {
+        // Rank-1 4×4 (a 2×2 rank-1 block, rest zero) → 0 ebits.
+        let c = array![
+            [1.0, 2.0, 0.0, 0.0],
+            [2.0, 4.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ];
+        let j = complex_structure_split_half(4);
+        let (_r, s) = coupling_metrics(&c, &j);
+        assert!(s.abs() < 1e-9, "rank-1 coupling → 0 ebits, got {s}");
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to confirm it passes (it exercises the new dependency + reused helpers)**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-cli entanglement 2>&1 | tail -10
+```
+Expected: `test result: ok. 2 passed`. If it fails to compile because `larql_vindex::canonical::commutator_residual` (or another helper) is not at that path, check `crates/larql-vindex/src/canonical/mod.rs` (the `pub use hilbertian::{...}` block re-exports them) and fix the import path; do NOT modify `larql-vindex`.
+
+NOTE: the `EntanglementArgs`, `HeadEntanglementInfo`, `EntanglementMeta`, and the imports of `head_block`, `kv_head_for_query`, `head_coupling`, `load_attention_qk`, `load_vindex_config`, `Instant`, `PathBuf` are unused until Task 2 — the compiler will warn about unused imports/types. That is expected at this checkpoint; do NOT delete them (Task 2 uses them). If `cargo test` treats warnings as errors (it does not by default), add a temporary `#![allow(unused)]`-free workaround is unnecessary — warnings are fine. Proceed once the 2 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-cli/Cargo.toml crates/larql-cli/src/commands/extraction/entanglement_cmd.rs
+git commit -m "feat(cli): entanglement command scaffold — coupling_metrics (residual + entropy)"
+```
+
+## Report
+Status DONE/BLOCKED, test output last 5 lines, commit SHA.
+
+---
+
+## Task 2: The `run` function (load, per-head loop, write sidecar)
+
+**Files:**
+- Modify: `crates/larql-cli/src/commands/extraction/entanglement_cmd.rs`
+
+- [ ] **Step 1: Add the `run` function**
+
+In `crates/larql-cli/src/commands/extraction/entanglement_cmd.rs`, add (after `coupling_metrics`, before the `#[cfg(test)]` block):
+
+```rust
+pub fn run(args: EntanglementArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = &args.vindex;
+    let t0 = Instant::now();
+    println!("Entanglement / compressibility analysis for vindex at {}", dir.display());
+
+    let config = load_vindex_config(dir)?;
+    let mc = config
+        .model_config
+        .as_ref()
+        .ok_or("entanglement: index.json has no model_config (need head_dim / head counts)")?;
+    let (num_q, num_kv, head_dim) = (mc.num_q_heads, mc.num_kv_heads, mc.head_dim);
+    println!(
+        "  model: {} ({}), {} layers, q_heads={num_q}, kv_heads={num_kv}, head_dim={head_dim}",
+        config.model, config.family, config.num_layers
+    );
+
+    let j = complex_structure_split_half(head_dim);
+
+    print!("  loading attention Q/K ... ");
+    let qk = load_attention_qk(dir, config.num_layers)?;
+    println!("{} layers ({:.1}ms)", qk.len(), t0.elapsed().as_secs_f64() * 1000.0);
+
+    let mut heads: Vec<HeadEntanglementInfo> = Vec::with_capacity(config.num_layers * num_q);
+    for (layer, (wq, wk)) in qk.iter().enumerate() {
+        if wq.nrows() < num_q * head_dim || wk.nrows() < num_kv * head_dim {
+            return Err(format!(
+                "layer {layer}: attention weights too small (wq {} rows, wk {} rows; need {} and {})",
+                wq.nrows(),
+                wk.nrows(),
+                num_q * head_dim,
+                num_kv * head_dim
+            )
+            .into());
+        }
+        let wq64 = wq.mapv(|v| v as f64);
+        let wk64 = wk.mapv(|v| v as f64);
+        for h in 0..num_q {
+            let g = kv_head_for_query(h, num_q, num_kv);
+            let wq_h = head_block(&wq64, h, head_dim);
+            let wk_g = head_block(&wk64, g, head_dim);
+            let coupling = head_coupling(&wq_h, &wk_g);
+            let (residual, entropy) = coupling_metrics(&coupling, &j);
+            heads.push(HeadEntanglementInfo {
+                layer,
+                query_head: h,
+                kv_head: g,
+                residual,
+                entropy,
+            });
+        }
+    }
+
+    let meta = EntanglementMeta {
+        version: 1,
+        model: config.model.clone(),
+        head_dim,
+        num_q_heads: num_q,
+        num_kv_heads: num_kv,
+        heads,
+    };
+
+    let out = dir.join("entanglement_meta.json");
+    std::fs::write(&out, serde_json::to_string_pretty(&meta)?)?;
+
+    let entropies: Vec<f64> = meta.heads.iter().map(|h| h.entropy).collect();
+    let residuals: Vec<f64> = meta.heads.iter().map(|h| h.residual).collect();
+    let mean = |v: &[f64]| v.iter().sum::<f64>() / v.len() as f64;
+    let min = |v: &[f64]| v.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = |v: &[f64]| v.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    println!(
+        "  entropy (ebits)  over {} heads: mean {:.3}, min {:.3}, max {:.3}  (max possible {:.1})",
+        entropies.len(),
+        mean(&entropies),
+        min(&entropies),
+        max(&entropies),
+        (head_dim as f64).log2()
+    );
+    println!(
+        "  residual         over {} heads: mean {:.3}, min {:.3}, max {:.3}",
+        residuals.len(),
+        mean(&residuals),
+        min(&residuals),
+        max(&residuals)
+    );
+    println!("  wrote {}", out.display());
+    println!("  total: {:.1}ms", t0.elapsed().as_secs_f64() * 1000.0);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Build (resolves the previously-unused imports)**
+
+```
+cd /home/metavacua/larql && cargo build -p larql-cli 2>&1 | tail -15
+```
+Expected: compiles cleanly. If a `model_config` field name differs, verify against `crates/larql-vindex/src/config/model.rs` and adjust only this file.
+
+- [ ] **Step 3: Run the unit tests + clippy**
+
+```
+cd /home/metavacua/larql && cargo test -p larql-cli entanglement 2>&1 | tail -5
+cd /home/metavacua/larql && cargo clippy -p larql-cli 2>&1 | grep -iE "entanglement|warning: " | head || echo clean
+```
+Expected: 2 tests pass; clippy clean (fix any genuine warnings in this file).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-cli/src/commands/extraction/entanglement_cmd.rs
+git commit -m "feat(cli): entanglement command run — per-head residual + entropy, writes entanglement_meta.json"
+```
+
+## Report
+Status DONE/BLOCKED, build result, test output, commit SHA.
+
+---
+
+## Task 3: Wire the subcommand into the CLI
+
+**Files:**
+- Modify: `crates/larql-cli/src/commands/extraction/mod.rs`
+- Modify: `crates/larql-cli/src/main.rs`
+
+- [ ] **Step 1: Register the module**
+
+In `crates/larql-cli/src/commands/extraction/mod.rs`, add (alphabetically near the other commands, e.g. after `pub mod embedding_jump_cmd;`):
+```rust
+pub mod entanglement_cmd;
+```
+
+- [ ] **Step 2: Add the `Entanglement` variant**
+
+In `crates/larql-cli/src/main.rs`, in the "Build / extract" section of `enum Commands` (right after the `Hilbertian(hilbertian_cmd::HilbertianArgs)` variant), add:
+```rust
+    #[command(next_help_heading = "Build")]
+    /// Per-head entanglement entropy + Hilbertian residual (compressibility); writes entanglement_meta.json.
+    Entanglement(entanglement_cmd::EntanglementArgs),
+```
+
+- [ ] **Step 3: Add the dispatch arm**
+
+In `crates/larql-cli/src/main.rs`, in the `let result = match cli.command {` block, right after the `Commands::Hilbertian(args) => hilbertian_cmd::run(args),` arm, add:
+```rust
+        Commands::Entanglement(args) => entanglement_cmd::run(args),
+```
+
+- [ ] **Step 4: Build + clippy**
+
+```
+cd /home/metavacua/larql && cargo build -p larql-cli 2>&1 | tail -5
+cd /home/metavacua/larql && cargo clippy -p larql-cli 2>&1 | grep -iE "entanglement|warning: " | head || echo clean
+```
+Expected: compiles; the help shows the command (`./target/debug/larql entanglement --help` prints the usage with `<VINDEX>`).
+
+- [ ] **Step 5: Confirm the command is registered (no model load yet)**
+
+```
+cd /home/metavacua/larql && ./target/debug/larql entanglement --help 2>&1 | head -5
+```
+Expected: usage text mentioning `<VINDEX>` and the description.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/metavacua/larql
+git add crates/larql-cli/src/commands/extraction/mod.rs crates/larql-cli/src/main.rs
+git commit -m "feat(cli): wire larql entanglement subcommand"
+```
+
+## Report
+Status DONE/BLOCKED, build result, commit SHA. (The end-to-end run on the real vindex is done as a separate verification step after this plan, not as a task.)
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- [x] Per-head coupling metrics (residual + entanglement entropy) — Task 1 (`coupling_metrics`)
+- [x] Result types + `entanglement_meta.json` — Task 1 (types) + Task 2 (write)
+- [x] `run`: load vindex, per-head loop, write sidecar, summary — Task 2
+- [x] `larql entanglement` subcommand wired — Task 3
+- [ ] **Deferred (later pass):** canonical-vs-raw, on-shell-vs-full, Zipfian/HTSR fit.
+
+**Type consistency:**
+- `coupling_metrics(&Array2<f64>, &Array2<f64>) -> (f64, f64)` defined Task 1, called in `run` (Task 2).
+- `HeadEntanglementInfo { layer, query_head, kv_head, residual, entropy }` and `EntanglementMeta { version, model, head_dim, num_q_heads, num_kv_heads, heads }` defined Task 1, constructed in Task 2.
+- `EntanglementArgs { vindex }` defined Task 1, used in `run` (Task 2) and the `Commands::Entanglement` variant (Task 3).
+- Reused `larql_vindex::canonical::{commutator_residual, complex_structure_split_half, head_block, head_coupling, kv_head_for_query}` and `larql_hilbert::entanglement_entropy` — signatures verified against the codebase.
+- Runner returns `Result<(), Box<dyn std::error::Error>>` and the dispatch arm returns it directly (matches the `Hilbertian`/`Canonicalize` precedent).
+
+**No placeholders:** every code step contains complete code; every run step has an exact command + expected output. Task 1's unused-until-Task-2 imports are called out explicitly rather than left as a surprise.

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -1,0 +1,33 @@
+# OpenSpec workflow
+
+This directory holds the spec-first contract for larql.
+
+## Layout
+
+```
+openspec/
+  config.yaml                       # OpenSpec project config
+  specs/<capability>/spec.md        # canonical specs, one per capability
+  changes/<change-id>/              # in-flight proposals
+    proposal.md                     # why + what
+    design.md                       # how (cross-cutting changes only)
+    tasks.md                        # implementation backlog
+    specs/<capability>/spec.md      # delta with ## ADDED / MODIFIED / REMOVED
+    gaps-unbacked-scenarios.md      # auto-generated; lists scenarios with no test
+    gaps-untested-code.md           # auto-generated; lists code without tests
+  changes/archive/                  # archived (merged) changes
+  coverage/
+    traceability.md                 # requirement → test matrix
+    traceability.json               # machine-readable trace data
+```
+
+## Authoring rules
+
+1. **One capability per coherent feature area.** Use kebab-case names.
+2. **Each spec is a delta when in `changes/<id>/`.** Top-level header is
+   `## ADDED Requirements` (or `MODIFIED` / `REMOVED` / `RENAMED`).
+3. **Every Requirement contains SHALL or MUST** (or `SHALL NOT`).
+4. **Every Requirement has at least one Scenario.** Scenarios use four
+   hashes (`####`).
+5. **Every Scenario references at least one test.** Annotate with an HTML
+   comment: `<!-- test: path/to/test.rs::test_name -->`.

--- a/openspec/changes/canonical-extraction/proposal.md
+++ b/openspec/changes/canonical-extraction/proposal.md
@@ -1,0 +1,49 @@
+# Proposal: Canonical Vindex Extraction Pipeline
+
+## Status: in-flight
+
+## Why
+
+Vindexes today are coordinate-system-relative: gate vectors live in whatever
+basis the model trainer used, with no formal invariants beyond format
+correctness. Cross-model comparison, formal verification, and
+`wasm32v1-none` inference all require a canonical form with provable uniqueness
+properties.
+
+The flat-canonical (semi-intrinsic, single G) form is the smallest useful
+canonical vindex: it requires only data already present in a browse-level
+vindex (`embeddings.bin`, `gate_vectors.bin`, `down_meta.bin`) and produces a
+`canonical_meta.json` sidecar that is a pure function of the model weights.
+
+## What
+
+Add `larql canonicalize <vindex-path>` that writes `canonical_meta.json` into
+an existing vindex directory. The command:
+
+1. Estimates the activation covariance G from token embeddings (semi-intrinsic
+   calibration — no external corpus).
+2. Computes the Cholesky factor L of G (the whitening operator).
+3. Scores each feature's "on-shell" property using the c_score percentile from
+   existing down_meta.
+4. Classifies each layer's activation regime (Wave / Particle / Wavelet).
+5. Writes all results to `canonical_meta.json` as a pure function of the
+   existing vindex files.
+
+## Non-goals (this change)
+
+- Writing whitened gate vectors (`gate_vectors_whitened.bin`). Deferred to
+  Plan 3 (cross-model alignment) which needs them first.
+- Per-layer G_l (general-relativistic form). Flat canonical only.
+- Knowledge graph integration. Separate change.
+- Cross-model Procrustes alignment. Separate change.
+- wasm32v1-none inference target. Tracked in epic #TBD.
+
+## Related issues
+
+- Epic: canonical-vindex-pipeline (this change)
+- Blocked-by: none
+- Blocks: knowledge-graph-integration, cross-model-alignment, wasm32v1-none-lm
+
+## Risk
+
+Low. Purely additive — no existing files are modified by `larql canonicalize`.

--- a/openspec/changes/canonical-extraction/specs/canonical-vindex/spec.md
+++ b/openspec/changes/canonical-extraction/specs/canonical-vindex/spec.md
@@ -1,0 +1,228 @@
+## ADDED Requirements: canonical-vindex
+
+### REQ-CANON-001: Covariance estimation
+
+The system SHALL estimate the activation covariance matrix G of shape
+[hidden_size, hidden_size] from the token embedding matrix W_E using a
+deterministic subsample of at most `max_samples` rows.
+
+G = (1/N) Σ_{v ∈ S} (s · W_E[v])^T (s · W_E[v])
+
+where s = embed_scale and S is a uniformly-strided subsample of the vocabulary.
+
+#### Scenario: identity embeddings produce scaled identity covariance
+
+Given token embeddings equal to the d×d identity matrix and embed_scale=1.0,
+when covariance is estimated with max_samples=d,
+then G[i,i] = 1/d and G[i,j] = 0 for i≠j.
+
+<!-- test: crates/larql-vindex/src/canonical/covariance.rs::tests::covariance_of_identity_is_identity_scaled -->
+
+#### Scenario: embed_scale squares into covariance
+
+Given any embeddings and embed_scale s,
+when covariance is estimated,
+then G(s) = s² · G(1).
+
+<!-- test: crates/larql-vindex/src/canonical/covariance.rs::tests::embed_scale_squares_into_covariance -->
+
+#### Scenario: G is symmetric and positive semi-definite
+
+Given any token embeddings,
+when covariance is estimated,
+then G[i,j] = G[j,i] for all i,j and G[i,j]² ≤ G[i,i]·G[j,j] (Cauchy-Schwarz).
+
+<!-- test: crates/larql-vindex/src/canonical/covariance.rs::tests::covariance_is_symmetric -->
+<!-- test: crates/larql-vindex/src/canonical/covariance.rs::tests::covariance_is_positive_semidefinite -->
+
+---
+
+### REQ-CANON-002: Cholesky whitening factor
+
+The system SHALL compute the lower-triangular Cholesky factor L of G such that
+L L^T = G + ε·I (with ε = 1e-5 ridge for numerical stability).
+
+The system SHALL provide a packing function that represents L as a flat
+Vec<f64> of length d·(d+1)/2 in row-major lower-triangular order:
+index(i,j) = i·(i+1)/2 + j for j ≤ i.
+
+The system SHALL provide an unpacking function that recovers the dense L from
+the packed form.
+
+#### Scenario: L L^T recovers G up to ridge
+
+Given G, when L = cholesky(G, ridge=1e-5),
+then (L L^T)[i,j] ≈ G[i,j] + 1e-5·δ_{ij} within 1e-8 tolerance.
+
+<!-- test: crates/larql-vindex/src/canonical/whitening.rs::tests::cholesky_recovers_g -->
+
+#### Scenario: L is lower-triangular
+
+Given G, when L = cholesky(G, ridge), then L[i,j] = 0 for j > i.
+
+<!-- test: crates/larql-vindex/src/canonical/whitening.rs::tests::l_is_lower_triangular -->
+
+#### Scenario: pack/unpack round-trips
+
+Given a Cholesky factor L, when packed then unpacked,
+the result equals the original within f64 precision.
+
+<!-- test: crates/larql-vindex/src/canonical/whitening.rs::tests::unpack_roundtrips_packed -->
+
+#### Scenario: whitened dot product equals Mahalanobis inner product
+
+Given g and h in ℝ^d, let g̃ = L^{-T}g and h̃ = L^{-T}h.
+Then g̃·h̃ = g^T G^{-1} h (Mahalanobis inner product).
+
+<!-- test: crates/larql-vindex/src/canonical/whitening.rs::tests::whitening_makes_mahalanobis_a_dot_product -->
+
+---
+
+### REQ-CANON-003: Back-substitution for L^T
+
+The system SHALL provide `back_solve_lt(L, B)` that solves L^T X = B via
+back-substitution, where L is lower-triangular. This is the primitive used to
+compute whitened vectors g̃ = L^{-T} g.
+
+The system SHALL provide `compute_l_inv_t(L)` that returns the dense d×d
+matrix L^{-T} by solving L^T X = I.
+
+#### Scenario: back_solve_lt recovers B
+
+Given lower-triangular L and matrix B,
+when Z = back_solve_lt(L, B), then L^T Z = B within 1e-10 tolerance.
+
+<!-- test: crates/larql-compute/src/cpu/ops/linalg.rs::canonical_linalg_tests::back_solve_lt_recovers_rhs -->
+
+#### Scenario: compute_l_inv_t times L^T is identity
+
+Given L, when M = compute_l_inv_t(L), then M @ L^T = I within 1e-10.
+
+<!-- test: crates/larql-compute/src/cpu/ops/linalg.rs::canonical_linalg_tests::compute_l_inv_t_times_l_t_is_identity -->
+
+---
+
+### REQ-CANON-004: On-shell feature filter
+
+The system SHALL compute a boolean on-shell mask for each layer by ranking
+features by their c_score (logit of top down-projected token from down_meta)
+and marking the top `top_fraction` (default 0.15) as on-shell.
+
+At least one feature SHALL be on-shell even if only one feature exists.
+The mask length SHALL equal the number of features in the layer.
+An empty feature list SHALL produce an empty mask.
+
+#### Scenario: top 15% of 10 features selects 2
+
+Given 10 features with c_scores 0..9 and top_fraction=0.15 (ceil(1.5)=2),
+the on-shell features are those with the two highest c_scores (8 and 9).
+
+<!-- test: crates/larql-vindex/src/canonical/onshell.rs::tests::top_15pct_of_10_is_2 -->
+
+#### Scenario: all-equal c_scores makes all features on-shell
+
+When all c_scores are equal, the threshold equals all scores,
+so all features are on-shell.
+
+<!-- test: crates/larql-vindex/src/canonical/onshell.rs::tests::all_same_scores_all_on_shell -->
+
+---
+
+### REQ-CANON-005: Layer regime classifier
+
+The system SHALL classify each layer as Wave, Particle, or Wavelet based on
+activation density = (features with c_score > 0.1) / total_features:
+
+- density > 0.5  → Wave
+- density < 0.05 → Particle
+- otherwise      → Wavelet
+
+An empty feature list SHALL return Wavelet with density 0.0.
+
+#### Scenario: dense layer is Wave
+
+Given 80% of features with c_score > 0.1, regime = Wave.
+
+<!-- test: crates/larql-vindex/src/canonical/regime.rs::tests::dense_layer_is_wave -->
+
+#### Scenario: sparse layer is Particle
+
+Given 2% of features with c_score > 0.1, regime = Particle.
+
+<!-- test: crates/larql-vindex/src/canonical/regime.rs::tests::sparse_layer_is_particle -->
+
+#### Scenario: mid-density is Wavelet
+
+Given 20% of features active, regime = Wavelet.
+
+<!-- test: crates/larql-vindex/src/canonical/regime.rs::tests::mid_density_is_wavelet -->
+
+---
+
+### REQ-CANON-006: Canonical metadata serialization
+
+The system SHALL write `canonical_meta.json` to the vindex directory containing:
+- version (u32 = 1)
+- model, family, num_layers, hidden_size strings/ints from index.json
+- covariance_sample_size and embed_scale
+- cholesky_l_packed: Vec<f64> of length hidden_size·(hidden_size+1)/2
+- layers: array of {layer, regime, on_shell_count, total_features, mean_density}
+
+The JSON SHALL round-trip losslessly through serde_json.
+
+#### Scenario: regime serializes as snake_case
+
+Wave → "wave", Particle → "particle", Wavelet → "wavelet".
+
+<!-- test: crates/larql-vindex/src/canonical/types.rs::tests::regime_serialises_as_snake_case -->
+
+#### Scenario: CanonicalMeta round-trips
+
+Given a CanonicalMeta value, serializing to JSON and deserializing
+reproduces the original value.
+
+<!-- test: crates/larql-vindex/src/canonical/types.rs::tests::canonical_meta_round_trips_through_json -->
+
+---
+
+### REQ-CANON-007: c_score-only down_meta reader
+
+The system SHALL provide `read_cscores_binary(dir)` that reads c_score values
+from `down_meta.bin` without constructing token strings (no tokenizer
+dependency). It SHALL return Vec<Vec<f32>>, one inner Vec per layer.
+Layers with num_features=0 SHALL return an empty inner Vec.
+
+#### Scenario: c_scores match full read
+
+Given a down_meta.bin file, read_cscores_binary returns the same c_score
+values as the full read_binary function.
+
+<!-- test: crates/larql-vindex/src/format/down_meta.rs::tests::read_cscores_binary_matches_full_read -->
+
+---
+
+### REQ-CANON-008: CLI command `larql canonicalize`
+
+The system SHALL provide a `larql canonicalize <vindex-path>` subcommand
+that loads a vindex directory, runs the canonical pipeline, and writes
+`canonical_meta.json`. The command SHALL NOT modify any existing vindex files.
+
+The command SHALL accept:
+- `--onshell-fraction <f32>` (default 0.15)
+- `--covariance-samples <usize>` (default 4096)
+
+The command SHALL print progress and a summary of on-shell feature counts.
+
+#### Scenario: canonical_meta.json is written
+
+Given a valid vindex directory, after `larql canonicalize`,
+canonical_meta.json exists and is valid JSON matching the schema.
+
+<!-- test: integration: cargo run -- canonicalize <vindex> then check file exists -->
+
+#### Scenario: existing files are untouched
+
+After `larql canonicalize`, all pre-existing vindex files have the same
+content as before.
+
+<!-- test: integration: checksum vindex files before/after -->

--- a/openspec/changes/qlm-foundation/proposal.md
+++ b/openspec/changes/qlm-foundation/proposal.md
@@ -1,0 +1,45 @@
+# Proposal: Quantum Language Model Foundation
+
+## Status: in-flight
+
+## Why
+
+The QLM line (see `docs/QLM-ROADMAP.md`) formalizes language models as
+Hilbert-space objects — qubit states, unitary evolution, Born-rule readout — and
+grounds the classical-vs-quantum compressibility programme. The foundation is
+the `larql-hilbert` crate (PRs #137–#140 + the entanglement-entropy work). This
+change captures its requirements as testable contracts, mirroring the
+`canonical-extraction` change.
+
+## What
+
+Specify the `quantum-language-model` capability provided by `larql-hilbert`:
+
+1. The complex-structure core and the unifying theorem
+   `commutator_residual = 2·antilinear_fraction`, plus the real↔complex bridge.
+2. The single-qubit Bloch-sphere LM: state, SU(2) gates, Born readout,
+   autoregressive scoring/generation.
+3. Constructive measurement (elimination rule, ⊥) with no-cloning enforced by
+   the type system, and the bounded-extraction admissibility layer (Δ₀/Σ⁰₁/Π⁰₂).
+4. The two-qubit LM: tensor product, entanglement (non-factorization), CNOT and
+   the Bell operation, partial measurement and its correlation.
+5. The entanglement-entropy meter (quantum compressibility, in ebits).
+
+## Non-goals (this change)
+
+- GHZ / W (3+ qubit) states — Phase 5.
+- Superdense coding protocol and quantum LQL verbs (`MEASURE`/`STEP`) — Phase 6.
+- Vindex-wide compressibility analysis CLI — Phase 7.
+- `wasm32v1-none` / `no_std` certification of the kernels — Phase 8 (epic #132).
+
+## Related
+
+- ADR: `docs/adr/0011-qlm-quantum-language-models.md`.
+- Roadmap: `docs/QLM-ROADMAP.md`.
+- Depends-on: the canonical pipeline (`canonical-extraction` change) — Born
+  readout presupposes the dagger that whitening installs.
+
+## Risk
+
+Low. `larql-hilbert` is an additive pure-Rust leaf crate; nothing in the
+inference/vindex path depends on it.

--- a/openspec/changes/qlm-foundation/specs/quantum-language-model/spec.md
+++ b/openspec/changes/qlm-foundation/specs/quantum-language-model/spec.md
@@ -1,0 +1,197 @@
+## ADDED Requirements: quantum-language-model
+
+### REQ-QLM-001: Complex structure and the antilinear-fraction equivalence
+
+The system SHALL provide the split-half complex structure `J` on `ℝⁿ` (n even)
+with `J² = −I`, the relative commutator residual `‖MJ − JM‖_F / ‖M‖_F`, and the
+antilinear fraction, satisfying the identity
+`commutator_residual(M, J) = 2 · antilinear_fraction(M)`.
+
+#### Scenario: J squares to −I
+
+Given `J = split_half_j(n)`, then `J·J = −I`.
+
+<!-- test: crates/larql-hilbert/src/complex_structure.rs::tests::j_squares_to_negative_identity -->
+
+#### Scenario: residual is twice the antilinear fraction
+
+Given any real matrix M, `commutator_residual(M, J) = 2 · antilinear_fraction(M)`.
+
+<!-- test: crates/larql-hilbert/src/complex_structure.rs::tests::equivalence_theorem_residual_is_twice_antilinear_fraction -->
+
+---
+
+### REQ-QLM-002: Real↔complex bridge
+
+The system SHALL provide `realify(A, B) = [[A, −B], [B, A]]` and `complex_parts`
+that recovers `(A, B)`, with `complex_parts ∘ realify = identity`.
+
+#### Scenario: bridge round-trips
+
+Given real m×m blocks A, B, `complex_parts(realify(A, B)) = (A, B)`.
+
+<!-- test: crates/larql-hilbert/src/complex_structure.rs::tests::complex_parts_inverts_realify -->
+
+---
+
+### REQ-QLM-003: Single-qubit state, Bloch sphere, and SU(2) gates
+
+The system SHALL provide a `Qubit` (`ℂ²`) with Bloch-sphere coordinates and a
+set of unitary gates (Pauli X/Y/Z, Hadamard, rotations) that are unitary and
+square to identity (for the involutory ones).
+
+#### Scenario: Hadamard maps north pole to +x
+
+`H|0⟩` has Bloch vector `(1, 0, 0)`.
+
+<!-- test: crates/larql-hilbert/src/qubit.rs::tests::hadamard_zero_points_to_plus_x -->
+
+#### Scenario: standard gates are unitary
+
+`identity`, `pauli_x/y/z`, `hadamard`, `rz`, `ry` are all unitary.
+
+<!-- test: crates/larql-hilbert/src/unitary.rs::tests::all_standard_gates_are_unitary -->
+
+---
+
+### REQ-QLM-004: Born-rule measurement
+
+The system SHALL provide `measure_probs(&Qubit) -> [f64; 2]` = `[|α|², |β|²]` of
+the normalized state, summing to 1.
+
+#### Scenario: Hadamard state is a fair coin
+
+`measure_probs(H|0⟩) = [0.5, 0.5]`.
+
+<!-- test: crates/larql-hilbert/src/born.rs::tests::hadamard_zero_is_fair_coin -->
+
+---
+
+### REQ-QLM-005: Single-qubit autoregressive language model
+
+The system SHALL provide `SingleQubitLM` (2-token vocabulary) with Born-rule
+`next_distribution`, collapse-then-unitary `step`, autoregressive `score`
+(−∞ on impossible tokens), and reproducible `generate`.
+
+#### Scenario: impossible token scores −∞
+
+From `|0⟩` with identity gates, `score([1])` is −∞.
+
+<!-- test: crates/larql-hilbert/src/qlm.rs::tests::impossible_token_scores_neg_infinity -->
+
+#### Scenario: out-of-vocabulary token is rejected
+
+`score`/`step` panic with a message naming the vocabulary for tokens ≥ 2.
+
+<!-- test: crates/larql-hilbert/src/qlm.rs::tests::score_rejects_out_of_vocabulary_token -->
+
+---
+
+### REQ-QLM-006: Measurement as elimination with no-cloning
+
+The system SHALL provide `project(&Qubit, outcome) -> Option<Qubit>` (the
+elimination rule; `None` = ⊥ for a zero-amplitude outcome) and a `LinearQubit`
+that is `!Copy`/`!Clone` whose `measure(self, …)` consumes it (no-cloning via
+move semantics).
+
+#### Scenario: impossible outcome is ⊥
+
+`project(&|0⟩, 1)` is `None`.
+
+<!-- test: crates/larql-hilbert/src/measurement.rs::tests::project_impossible_outcome_is_bottom -->
+
+#### Scenario: linear measurement consumes the state
+
+`LinearQubit::new(H|0⟩).measure(1)` returns the collapsed state and the
+`LinearQubit` cannot be reused (compile-time).
+
+<!-- test: crates/larql-hilbert/src/measurement.rs::tests::linear_qubit_measure_consumes_and_collapses -->
+
+---
+
+### REQ-QLM-007: Bounded-extraction admissibility (Δ₀ / Σ⁰₁ / Π⁰₂)
+
+The system SHALL classify bounded extraction over the LM by arithmetical
+fragment: `is_realizable` (Δ₀), `exists_continuation` (Σ⁰₁ bounded witness
+search), `uniformly_stable` (Π⁰₂), per Rosko's finite-extraction criterion.
+
+#### Scenario: realizability decides finite sequences
+
+For the identity-gates `|0⟩` LM, `is_realizable([0,0,0])` is true and
+`is_realizable([0,1])` is false.
+
+<!-- test: crates/larql-hilbert/src/admissibility.rs::tests::realizable_distinguishes_possible_from_impossible -->
+
+#### Scenario: Σ⁰₁ finds a bounded witness
+
+`exists_continuation` returns a realizable witness within the bound when one
+exists.
+
+<!-- test: crates/larql-hilbert/src/admissibility.rs::tests::sigma01_finds_a_witness_within_bound -->
+
+---
+
+### REQ-QLM-008: Two-qubit state, tensor product, and entanglement
+
+The system SHALL provide `TwoQubit` (`ℂ⁴`), the tensor product, and
+`is_product` (an entanglement non-factorization test: true iff the 2×2
+amplitude determinant is zero).
+
+#### Scenario: tensor of basis qubits is a basis state
+
+`tensor(|1⟩, |0⟩) = |10⟩`.
+
+<!-- test: crates/larql-hilbert/src/two_qubit.rs::tests::tensor_of_basis_qubits_is_basis_state -->
+
+#### Scenario: a Bell-like state is not a product
+
+`(|00⟩+|11⟩)/√2` is not a product state.
+
+<!-- test: crates/larql-hilbert/src/two_qubit.rs::tests::bell_like_state_is_not_product -->
+
+---
+
+### REQ-QLM-009: Bell operation, partial measurement, and the two-qubit LM
+
+The system SHALL provide CNOT, the Bell operation `Φ⁺ = CNOT·(H⊗I)·|00⟩`
+(entangled), partial single-qubit measurement showing perfect correlation, and a
+`TwoQubitLM` whose Bell-initialized statistics forbid the anti-correlated joint
+tokens (−∞).
+
+#### Scenario: the Bell state is entangled
+
+`is_product(bell())` is false.
+
+<!-- test: crates/larql-hilbert/src/gate2.rs::tests::bell_state_is_entangled -->
+
+#### Scenario: measuring one qubit forces the other
+
+Measuring qubit 0 of `Φ⁺` collapses qubit 1 to the same value.
+
+<!-- test: crates/larql-hilbert/src/two_qubit.rs::tests::measuring_one_qubit_forces_the_other -->
+
+#### Scenario: the Bell LM forbids anti-correlated tokens
+
+With a Bell initial state, joint tokens 01 and 10 score −∞.
+
+<!-- test: crates/larql-hilbert/src/qlm2.rs::tests::impossible_joint_token_scores_neg_infinity -->
+
+---
+
+### REQ-QLM-010: Entanglement-entropy meter (quantum compressibility)
+
+The system SHALL provide `spectral_entropy(&[f64])` = `−Σ pᵢ log₂ pᵢ` of a
+normalized non-negative spectrum (in ebits), with `0` for a rank-1 / single
+nonzero weight and `1` for two equal weights (one ebit).
+
+#### Scenario: two equal weights is one ebit
+
+`spectral_entropy([w, w]) = 1`.
+
+<!-- test: crates/larql-hilbert/src/entropy.rs::tests::two_equal_weights_is_one_ebit -->
+
+#### Scenario: a rank-1 spectrum has zero entropy
+
+`spectral_entropy([w, 0, 0]) = 0`.
+
+<!-- test: crates/larql-hilbert/src/entropy.rs::tests::rank_one_spectrum_has_zero_entropy -->

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## Summary

**Single integration of the full QLM stack** — PRs #133, #137, #138, #139, #140, #141 (+ the #142 compressibility command), reconciled into one branch with every late review-fix included.

## What this consolidates

| PR | Feature |
|---|---|
| #133 | canonical extraction pipeline (`larql canonicalize`) |
| #137 | Hilbertian residual + `larql hilbertian` |
| #138 | single-qubit Bloch LM |
| #139 | constructive measurement + admissibility |
| #140 | two-qubit LM + Bell |
| #141 | entanglement-entropy meter + QLM roadmap/ADR/openspec |
| #142 | `larql entanglement` compressibility analysis |

## Drift reconciled

The stack had drifted: two late review-fix commits landed on *lower* branches after the upper ones were cut, so the leaf was missing them. This integration merges them back in:
- `cbfcf948` — canonical fixes (covariance NaN guard, `unpack_l` length assert, `down_meta` alloc hoist) — from #133's branch.
- `862a7fe6` — single-qubit out-of-vocabulary descriptive panic — from #138's branch.

Both merges were conflict-free.

## Verification

Integrated build clean; full test suites green: **larql-hilbert 73, larql-vindex 1121 (lib), larql-cli 245, larql-compute 682** — 0 failures. (The pre-existing `vector_extractor_ffn_down_byte_identical` golden test fails identically on the base, unrelated — a 64↔32-bit precision config artifact.)

This branch is the foundation for the **n-qubit / n-bit vindex generalization** (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
