### PR TITLE
feat(lql): quantum backend (SP1) — usable QLMs via Dicke quantum vindexes + INFER

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,6 +2295,7 @@ dependencies = [
  "larql-compute",
  "larql-compute-metal",
  "larql-core",
+ "larql-hilbert",
  "larql-inference",
  "larql-models",
  "larql-vindex",

--- a/crates/larql-hilbert/src/nqubit.rs
+++ b/crates/larql-hilbert/src/nqubit.rs
@@ -94,9 +94,9 @@ impl NQubit {
         let mut amp = vec![c(0.0, 0.0); dim];
         let count = (0..dim).filter(|i| (*i as u32).count_ones() as usize == k).count();
         let a = 1.0 / (count as f64).sqrt();
-        for i in 0..dim {
+        for (i, slot) in amp.iter_mut().enumerate() {
             if (i as u32).count_ones() as usize == k {
-                amp[i] = c(a, 0.0);
+                *slot = c(a, 0.0);
             }
         }
         NQubit { amp }

--- a/crates/larql-hilbert/src/nqubit.rs
+++ b/crates/larql-hilbert/src/nqubit.rs
@@ -85,6 +85,23 @@ impl NQubit {
         NQubit { amp }
     }
 
+    /// Dicke state |D^n_k⟩ — the normalized equal superposition of all
+    /// computational-basis states of Hamming weight `k`. `w(n)` is `dicke(n, 1)`.
+    pub fn dicke(n: usize, k: usize) -> NQubit {
+        assert!((1..64).contains(&n), "qubit count {n} must be in 1..64");
+        assert!(k <= n, "excitation k={k} must satisfy k ≤ n={n}");
+        let dim = 1usize << n;
+        let mut amp = vec![c(0.0, 0.0); dim];
+        let count = (0..dim).filter(|i| (*i as u32).count_ones() as usize == k).count();
+        let a = 1.0 / (count as f64).sqrt();
+        for i in 0..dim {
+            if (i as u32).count_ones() as usize == k {
+                amp[i] = c(a, 0.0);
+            }
+        }
+        NQubit { amp }
+    }
+
     /// L2 norm.
     pub fn norm(&self) -> f64 {
         self.amp.iter().map(|a| a.norm_sqr()).sum::<f64>().sqrt()
@@ -260,5 +277,35 @@ mod tests {
     fn from_matrix_rejects_non_power_of_two_dims() {
         use ndarray::array;
         let _ = NQubit::from_matrix(&array![[1.0, 2.0, 3.0]]); // 1x3
+    }
+
+    #[test]
+    fn dicke_one_excitation_is_w() {
+        // |D^3_1⟩ == W_3 (uniform amplitude on 001, 010, 100).
+        let d = NQubit::dicke(3, 1);
+        let w = NQubit::w(3);
+        for (a, b) in d.amp.iter().zip(w.amp.iter()) {
+            assert!((a - b).norm() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn dicke_two_excitations_uniform_weight2() {
+        // |D^4_2⟩: equal Born mass 1/6 on the six weight-2 states, 0 elsewhere.
+        let p = NQubit::dicke(4, 2).born_probs();
+        for (idx, prob) in p.iter().enumerate() {
+            let weight = (idx as u32).count_ones();
+            if weight == 2 {
+                assert!((prob - 1.0 / 6.0).abs() < 1e-12, "idx {idx} should be 1/6");
+            } else {
+                assert!(prob.abs() < 1e-12, "idx {idx} (weight {weight}) should be 0");
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "k")]
+    fn dicke_rejects_k_above_n() {
+        let _ = NQubit::dicke(2, 3);
     }
 }

--- a/crates/larql-lql/Cargo.toml
+++ b/crates/larql-lql/Cargo.toml
@@ -8,6 +8,7 @@ description = "LQL parser, executor, and REPL for LARQL"
 
 [dependencies]
 larql-compute = { path = "../larql-compute" }
+larql-hilbert = { path = "../larql-hilbert" }
 larql-compute-metal = { path = "../larql-compute-metal", optional = true }
 larql-core = { path = "../larql-core" }
 larql-inference = { path = "../larql-inference" }

--- a/crates/larql-lql/examples/quantum_lm_demo.rs
+++ b/crates/larql-lql/examples/quantum_lm_demo.rs
@@ -13,7 +13,8 @@ fn main() {
 
     let mut all_passed = true;
     // (name, n, qlm state json, expected nonzero tokens with their %)
-    let cases: &[(&str, usize, &str, &[(&str, f64)])] = &[
+    type Case<'a> = (&'a str, usize, &'a str, &'a [(&'a str, f64)]);
+    let cases: &[Case] = &[
         ("GHZ_3", 3, r#"{ "class": "ghz" }"#, &[("000", 50.0), ("111", 50.0)]),
         ("W_3 (Dicke k=1)", 3, r#"{ "class": "dicke", "k": 1 }"#,
             &[("001", 33.33), ("010", 33.33), ("100", 33.33)]),

--- a/crates/larql-lql/examples/quantum_lm_demo.rs
+++ b/crates/larql-lql/examples/quantum_lm_demo.rs
@@ -1,0 +1,94 @@
+//! Quantum LM demo: synthesize Dicke quantum vindexes, USE them through the
+//! real Session, INFER, and verify the Born distribution matches the analytic
+//! ground truth. CI-safe (no model download).
+
+use larql_lql::{parse, Session};
+use std::path::Path;
+
+fn main() {
+    println!("=== Quantum Language Model Demo (Dicke quantum vindexes) ===\n");
+    let tmp = std::env::temp_dir().join("larql_quantum_lm_demo");
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).unwrap();
+
+    let mut all_passed = true;
+    // (name, n, qlm state json, expected nonzero tokens with their %)
+    let cases: &[(&str, usize, &str, &[(&str, f64)])] = &[
+        ("GHZ_3", 3, r#"{ "class": "ghz" }"#, &[("000", 50.0), ("111", 50.0)]),
+        ("W_3 (Dicke k=1)", 3, r#"{ "class": "dicke", "k": 1 }"#,
+            &[("001", 33.33), ("010", 33.33), ("100", 33.33)]),
+        ("Dicke(4,2)", 4, r#"{ "class": "dicke", "k": 2 }"#,
+            &[("0011", 16.67), ("0101", 16.67), ("0110", 16.67),
+              ("1001", 16.67), ("1010", 16.67), ("1100", 16.67)]),
+    ];
+
+    for (name, n, state, expected) in cases {
+        println!("── {name} ──");
+        let dir = tmp.join(name.replace([' ', '(', ')', '='], "_"));
+        std::fs::create_dir_all(&dir).unwrap();
+        write_quantum_vindex(&dir, *n, state);
+
+        let mut s = Session::new();
+        run(&mut s, &format!(r#"USE "{}";"#, dir.display()), "USE");
+        let out = run(&mut s, r#"INFER "" TOP 16;"#, "INFER");
+        for (tok, pct) in *expected {
+            let pat = format!("{:.2}%", pct);
+            let ok = out.iter().any(|l| l.contains(tok) && l.contains(&pat));
+            check(&format!("{name}: {tok} at {pat}"), ok, &mut all_passed);
+        }
+        println!();
+    }
+
+    // Classicalization seam: a classical op returns the seam error.
+    println!("── classicalization seam ──");
+    let dir = tmp.join("seam");
+    std::fs::create_dir_all(&dir).unwrap();
+    write_quantum_vindex(&dir, 2, r#"{ "class": "ghz" }"#);
+    let mut s = Session::new();
+    s.execute(&parse(&format!(r#"USE "{}";"#, dir.display())).unwrap()).unwrap();
+    let seam = s.execute(&parse("SELECT * FROM EDGES LIMIT 1;").unwrap());
+    check(
+        "SELECT routes to the classicalization seam",
+        seam.is_err() && seam.as_ref().unwrap_err().to_string().contains("classicalization"),
+        &mut all_passed,
+    );
+    println!();
+
+    let _ = std::fs::remove_dir_all(&tmp);
+    if all_passed {
+        println!("PASS: quantum LMs are usable through larql — INFER reproduces the");
+        println!("  analytic Dicke Born distributions, and classical ops route to the seam.");
+    } else {
+        println!("FAIL: see [FAIL] lines above.");
+        std::process::exit(1);
+    }
+}
+
+fn write_quantum_vindex(dir: &Path, n: usize, state_json: &str) {
+    let vocab = 1usize << n;
+    let index = serde_json::json!({
+        "version": 2, "model": "qlm-demo", "family": "quantum",
+        "num_layers": 1, "hidden_size": n, "intermediate_size": n,
+        "vocab_size": vocab, "embed_scale": 1.0, "layers": [], "down_top_k": 1
+    });
+    std::fs::write(dir.join("index.json"), serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+    std::fs::write(dir.join("qlm.json"),
+        format!(r#"{{ "n_qubits": {n}, "state": {state_json} }}"#)).unwrap();
+}
+
+fn run(s: &mut Session, input: &str, label: &str) -> Vec<String> {
+    let stmt = parse(input).unwrap_or_else(|e| panic!("{label}: parse error: {e}"));
+    match s.execute(&stmt) {
+        Ok(lines) => {
+            println!("  {label}: OK");
+            for l in lines.iter().take(3) { println!("    {l}"); }
+            lines
+        }
+        Err(e) => panic!("{label}: {e}"),
+    }
+}
+
+fn check(label: &str, ok: bool, all_passed: &mut bool) {
+    if ok { println!("    [PASS] {label}"); }
+    else { println!("    [FAIL] {label}"); *all_passed = false; }
+}

--- a/crates/larql-lql/src/error.rs
+++ b/crates/larql-lql/src/error.rs
@@ -10,6 +10,9 @@ pub enum LqlError {
 
     #[error("Mutation requires a vindex. Run EXTRACT first.")]
     MutationRequiresVindex,
+
+    #[error("This operation is served by the classicalization layer (measure/dephase the quantum model), which is not yet wired on the quantum backend.")]
+    QuantumClassicalization,
 }
 
 impl LqlError {

--- a/crates/larql-lql/src/executor/backend.rs
+++ b/crates/larql-lql/src/executor/backend.rs
@@ -54,6 +54,10 @@ pub(crate) enum Backend {
         local_patches: Vec<larql_vindex::VindexPatch>,
         session_id: String,
     },
+    /// Quantum language model loaded from a `family: "quantum"` vindex.
+    /// Serves INFER (Born) + metadata; classical ops route through the
+    /// classicalization seam in `require_vindex`/`require_patched`.
+    Quantum(crate::executor::quantum::QuantumBackend),
     None,
 }
 

--- a/crates/larql-lql/src/executor/backend.rs
+++ b/crates/larql-lql/src/executor/backend.rs
@@ -92,6 +92,7 @@ impl Session {
                 model_id,
                 model_id.split('/').next_back().unwrap_or(model_id),
             ))),
+            Backend::Quantum(_) => Err(LqlError::QuantumClassicalization),
             _ => Err(LqlError::NoBackend),
         }
     }
@@ -120,6 +121,7 @@ impl Session {
                 model_id,
                 model_id.split('/').next_back().unwrap_or(model_id),
             ))),
+            Backend::Quantum(_) => Err(LqlError::QuantumClassicalization),
             _ => Err(LqlError::NoBackend),
         }
     }
@@ -148,6 +150,7 @@ impl Session {
                 model_id,
                 model_id.split('/').next_back().unwrap_or(model_id),
             ))),
+            Backend::Quantum(_) => Err(LqlError::QuantumClassicalization),
             _ => Err(LqlError::NoBackend),
         }
     }

--- a/crates/larql-lql/src/executor/introspection.rs
+++ b/crates/larql-lql/src/executor/introspection.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use super::helpers::{dir_size, format_bytes, format_number, is_content_token};
-use super::Session;
+use super::{Backend, Session};
 use crate::ast::*;
 use crate::error::LqlError;
 use larql_vindex::format::filenames::INDEX_JSON;
@@ -232,6 +232,12 @@ impl Session {
     }
 
     pub(crate) fn exec_show_layers(&self, range: Option<&Range>) -> Result<Vec<String>, LqlError> {
+        if let Backend::Quantum(qb) = &self.backend {
+            return Ok(vec![format!(
+                "Quantum LM: 1 layer (naive L=1), {} qubits, {} tokens, class {}",
+                qb.n, qb.tokens.len(), qb.class_label()
+            )]);
+        }
         let (_path, _config, patched) = self.require_vindex()?;
 
         let all_layers = patched.loaded_layers();
@@ -446,6 +452,12 @@ impl Session {
     }
 
     pub(crate) fn exec_show_models(&self) -> Result<Vec<String>, LqlError> {
+        if let Backend::Quantum(qb) = &self.backend {
+            return Ok(vec![format!(
+                "Active quantum model: {} qubits, {} tokens, class {}",
+                qb.n, qb.tokens.len(), qb.class_label()
+            )]);
+        }
         let mut out = Vec::new();
         out.push(format!(
             "{:<35} {:>10} {:>8} {:>12}",

--- a/crates/larql-lql/src/executor/introspection.rs
+++ b/crates/larql-lql/src/executor/introspection.rs
@@ -233,8 +233,13 @@ impl Session {
 
     pub(crate) fn exec_show_layers(&self, range: Option<&Range>) -> Result<Vec<String>, LqlError> {
         if let Backend::Quantum(qb) = &self.backend {
+            let entropy = if qb.n >= 2 {
+                larql_hilbert::entanglement_entropy_bipartition(&qb.lm.init, &[0])
+            } else {
+                0.0
+            };
             return Ok(vec![format!(
-                "Quantum LM: 1 layer (naive L=1), {} qubits, {} tokens, class {}",
+                "Quantum LM: 1 layer (naive L=1), {} qubits, {} tokens, class {}, entropy {entropy:.4} ebits",
                 qb.n, qb.tokens.len(), qb.class_label()
             )]);
         }
@@ -453,8 +458,13 @@ impl Session {
 
     pub(crate) fn exec_show_models(&self) -> Result<Vec<String>, LqlError> {
         if let Backend::Quantum(qb) = &self.backend {
+            let entropy = if qb.n >= 2 {
+                larql_hilbert::entanglement_entropy_bipartition(&qb.lm.init, &[0])
+            } else {
+                0.0
+            };
             return Ok(vec![format!(
-                "Active quantum model: {} qubits, {} tokens, class {}",
+                "Active quantum model: {} qubits, {} tokens, class {}, entropy {entropy:.4} ebits",
                 qb.n, qb.tokens.len(), qb.class_label()
             )]);
         }

--- a/crates/larql-lql/src/executor/lifecycle/compile/mod.rs
+++ b/crates/larql-lql/src/executor/lifecycle/compile/mod.rs
@@ -25,6 +25,7 @@ impl Session {
             VindexRef::Current => {
                 let vindex_path = match &self.backend {
                     Backend::Vindex { path, .. } => path.clone(),
+                    Backend::Quantum(_) => return Err(LqlError::QuantumClassicalization),
                     _ => return Err(LqlError::NoBackend),
                 };
                 match target {

--- a/crates/larql-lql/src/executor/lifecycle/stats.rs
+++ b/crates/larql-lql/src/executor/lifecycle/stats.rs
@@ -191,15 +191,12 @@ impl Session {
                 Ok(out)
             }
             Backend::Remote { .. } => self.remote_stats(),
-            Backend::Quantum(qb) => {
-                let mut out = Vec::new();
-                out.push("Backend:         quantum".into());
-                out.push(format!("Qubits:          {}", qb.n));
-                out.push(format!("Tokens:          {}", qb.tokens.len()));
-                out.push(String::new());
-                out.push("Supported:       INFER (Born measurement). Classical ops require classicalization.".into());
-                Ok(out)
-            }
+            Backend::Quantum(qb) => Ok(vec![format!(
+                "Quantum LM — {} qubits, {} tokens, class {}",
+                qb.n,
+                qb.tokens.len(),
+                qb.class_label()
+            )]),
             Backend::None => Err(LqlError::NoBackend),
         }
     }

--- a/crates/larql-lql/src/executor/lifecycle/stats.rs
+++ b/crates/larql-lql/src/executor/lifecycle/stats.rs
@@ -191,12 +191,19 @@ impl Session {
                 Ok(out)
             }
             Backend::Remote { .. } => self.remote_stats(),
-            Backend::Quantum(qb) => Ok(vec![format!(
-                "Quantum LM — {} qubits, {} tokens, class {}",
-                qb.n,
-                qb.tokens.len(),
-                qb.class_label()
-            )]),
+            Backend::Quantum(qb) => {
+                let entropy = if qb.n >= 2 {
+                    larql_hilbert::entanglement_entropy_bipartition(&qb.lm.init, &[0])
+                } else {
+                    0.0
+                };
+                Ok(vec![format!(
+                    "Quantum LM — {} qubits, {} tokens, class {}, entropy {entropy:.4} ebits",
+                    qb.n,
+                    qb.tokens.len(),
+                    qb.class_label()
+                )])
+            }
             Backend::None => Err(LqlError::NoBackend),
         }
     }

--- a/crates/larql-lql/src/executor/lifecycle/stats.rs
+++ b/crates/larql-lql/src/executor/lifecycle/stats.rs
@@ -191,6 +191,15 @@ impl Session {
                 Ok(out)
             }
             Backend::Remote { .. } => self.remote_stats(),
+            Backend::Quantum(qb) => {
+                let mut out = Vec::new();
+                out.push("Backend:         quantum".into());
+                out.push(format!("Qubits:          {}", qb.n));
+                out.push(format!("Tokens:          {}", qb.tokens.len()));
+                out.push(String::new());
+                out.push("Supported:       INFER (Born measurement). Classical ops require classicalization.".into());
+                Ok(out)
+            }
             Backend::None => Err(LqlError::NoBackend),
         }
     }

--- a/crates/larql-lql/src/executor/lifecycle/use_cmd.rs
+++ b/crates/larql-lql/src/executor/lifecycle/use_cmd.rs
@@ -32,6 +32,28 @@ impl Session {
                 let config = larql_vindex::load_vindex_config(&path)
                     .map_err(|e| LqlError::exec("failed to load vindex config", e))?;
 
+                // Quantum vindex: reconstruct the QLM from its quantum numbers
+                // and serve it through Backend::Quantum (no gate_vectors / FFN).
+                if config.family == "quantum" {
+                    let qlm_bytes = std::fs::read(path.join("qlm.json"))
+                        .map_err(|e| LqlError::exec("failed to read qlm.json", e))?;
+                    let spec: crate::executor::quantum::QlmSpec =
+                        serde_json::from_slice(&qlm_bytes)
+                            .map_err(|e| LqlError::exec("failed to parse qlm.json", e))?;
+                    let qb = crate::executor::quantum::QuantumBackend::from_spec(&spec)?;
+                    let out = vec![format!(
+                        "Using quantum vindex: {} ({} qubits, {} tokens, model: {})",
+                        path.display(),
+                        qb.n,
+                        qb.tokens.len(),
+                        config.model,
+                    )];
+                    self.backend = Backend::Quantum(qb);
+                    self.patch_recording = None;
+                    self.auto_patch = false;
+                    return Ok(out);
+                }
+
                 let mut cb = larql_vindex::SilentLoadCallbacks;
                 let index = larql_vindex::VectorIndex::load_vindex(&path, &mut cb)
                     .map_err(|e| LqlError::exec("failed to load vindex", e))?;

--- a/crates/larql-lql/src/executor/lifecycle/use_cmd.rs
+++ b/crates/larql-lql/src/executor/lifecycle/use_cmd.rs
@@ -41,6 +41,13 @@ impl Session {
                         serde_json::from_slice(&qlm_bytes)
                             .map_err(|e| LqlError::exec("failed to parse qlm.json", e))?;
                     let qb = crate::executor::quantum::QuantumBackend::from_spec(&spec)?;
+                    let expected_vocab = 1usize << qb.n;
+                    if config.vocab_size != expected_vocab {
+                        return Err(LqlError::Execution(format!(
+                            "quantum vindex: vocab_size = {} but 2^n_qubits = {expected_vocab} (n = {})",
+                            config.vocab_size, qb.n
+                        )));
+                    }
                     let out = vec![format!(
                         "Using quantum vindex: {} ({} qubits, {} tokens, model: {})",
                         path.display(),

--- a/crates/larql-lql/src/executor/mod.rs
+++ b/crates/larql-lql/src/executor/mod.rs
@@ -5,6 +5,7 @@
 
 mod backend;
 mod compact;
+pub(crate) mod quantum;
 mod helpers;
 mod introspection;
 mod lifecycle;

--- a/crates/larql-lql/src/executor/mutation/merge.rs
+++ b/crates/larql-lql/src/executor/mutation/merge.rs
@@ -34,6 +34,7 @@ impl Session {
         } else {
             match &self.backend {
                 Backend::Vindex { path, .. } => path.clone(),
+                Backend::Quantum(_) => return Err(LqlError::QuantumClassicalization),
                 _ => return Err(LqlError::NoBackend),
             }
         };

--- a/crates/larql-lql/src/executor/quantum.rs
+++ b/crates/larql-lql/src/executor/quantum.rs
@@ -105,9 +105,9 @@ impl QuantumBackend {
         Ok(QuantumBackend { lm, tokens, token_index, n })
     }
 
-    /// The dephased classical view — the `NQubit → born_probs` map. The seam
-    /// through which the classical vindex operations will be served by
-    /// measuring the quantum state (a later sub-project).
+    /// Extension point for the classicalization layer (a later sub-project):
+    /// the dephased `NQubit → born_probs` map the classical ops will measure.
+    #[allow(dead_code)]
     pub fn classical_view(&self) -> ClassicalRegister {
         ClassicalRegister { probs: self.lm.init.born_probs() }
     }

--- a/crates/larql-lql/src/executor/quantum.rs
+++ b/crates/larql-lql/src/executor/quantum.rs
@@ -1,0 +1,99 @@
+//! Quantum backend: reconstruct an `NQubitLM` from a quantum-vindex `qlm.json`
+//! (the quantum numbers only) and serve it through the LQL session.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use larql_hilbert::{ClassicalRegister, NQubit, NQubitLM};
+
+use crate::error::LqlError;
+
+/// The on-disk `qlm.json` — the quantum numbers, nothing derived.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct QlmSpec {
+    pub n_qubits: usize,
+    pub state: StateSpec,
+    /// Optional explicit token labels (length 2^n). Default: n-bit strings.
+    #[serde(default)]
+    pub tokens: Option<Vec<String>>,
+}
+
+/// The state's quantum numbers.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "class", rename_all = "lowercase")]
+pub(crate) enum StateSpec {
+    Dicke { k: usize },
+    Ghz,
+    Basis { index: usize },
+}
+
+/// Reconstruct the initial `NQubit` state |ψ⟩ from the quantum numbers.
+pub(crate) fn reconstruct_state(spec: &QlmSpec) -> Result<NQubit, LqlError> {
+    let n = spec.n_qubits;
+    if !(1..64).contains(&n) {
+        return Err(LqlError::Execution(format!(
+            "qlm.json: n_qubits = {n} must be in 1..64"
+        )));
+    }
+    match &spec.state {
+        StateSpec::Dicke { k } => {
+            if *k > n {
+                return Err(LqlError::Execution(format!(
+                    "qlm.json: Dicke excitation k = {k} must satisfy k ≤ n = {n}"
+                )));
+            }
+            Ok(NQubit::dicke(n, *k))
+        }
+        StateSpec::Ghz => Ok(NQubit::ghz(n)),
+        StateSpec::Basis { index } => {
+            let dim = 1usize << n;
+            if *index >= dim {
+                return Err(LqlError::Execution(format!(
+                    "qlm.json: basis index {index} out of range for {n} qubits (dim {dim})"
+                )));
+            }
+            Ok(NQubit::basis(n, *index))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(n: usize, state: StateSpec) -> QlmSpec {
+        QlmSpec { n_qubits: n, state, tokens: None }
+    }
+
+    #[test]
+    fn reconstruct_dicke_matches_analytic_born() {
+        let q = reconstruct_state(&spec(4, StateSpec::Dicke { k: 2 })).unwrap();
+        let p = q.born_probs();
+        for (idx, prob) in p.iter().enumerate() {
+            let expected = if (idx as u32).count_ones() == 2 { 1.0 / 6.0 } else { 0.0 };
+            assert!((prob - expected).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn reconstruct_ghz_is_cat_state() {
+        let q = reconstruct_state(&spec(3, StateSpec::Ghz)).unwrap();
+        let p = q.born_probs();
+        assert!((p[0] - 0.5).abs() < 1e-12 && (p[7] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn reconstruct_rejects_k_above_n() {
+        let err = reconstruct_state(&spec(2, StateSpec::Dicke { k: 3 })).unwrap_err();
+        assert!(err.to_string().contains("k"), "error should name k: {err}");
+    }
+
+    #[test]
+    fn parses_qlm_json() {
+        let json = r#"{ "n_qubits": 3, "state": { "class": "dicke", "k": 1 } }"#;
+        let spec: QlmSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.n_qubits, 3);
+        assert!(matches!(spec.state, StateSpec::Dicke { k: 1 }));
+    }
+}

--- a/crates/larql-lql/src/executor/quantum.rs
+++ b/crates/larql-lql/src/executor/quantum.rs
@@ -58,12 +58,95 @@ pub(crate) fn reconstruct_state(spec: &QlmSpec) -> Result<NQubit, LqlError> {
     }
 }
 
+/// A loaded quantum language model, ready to serve INFER through the session.
+pub(crate) struct QuantumBackend {
+    pub lm: NQubitLM,
+    pub tokens: Vec<String>,
+    pub token_index: HashMap<String, usize>,
+    pub n: usize,
+}
+
+impl std::fmt::Debug for QuantumBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QuantumBackend")
+            .field("n", &self.n)
+            .field("tokens", &self.tokens)
+            .finish_non_exhaustive()
+    }
+}
+
+impl QuantumBackend {
+    /// Build from the quantum numbers: reconstruct |ψ⟩, attach identity
+    /// post-gates (naive L=1), and resolve the token vocabulary.
+    pub fn from_spec(spec: &QlmSpec) -> Result<QuantumBackend, LqlError> {
+        let init = reconstruct_state(spec)?;
+        let n = spec.n_qubits;
+        let dim = 1usize << n;
+        let tokens = match &spec.tokens {
+            Some(t) => {
+                if t.len() != dim {
+                    return Err(LqlError::Execution(format!(
+                        "qlm.json: {} token labels for {dim}-token vocabulary (2^{n})",
+                        t.len()
+                    )));
+                }
+                t.clone()
+            }
+            None => (0..dim).map(|i| format!("{i:0width$b}", width = n)).collect(),
+        };
+        let token_index = tokens
+            .iter()
+            .enumerate()
+            .map(|(i, t)| (t.clone(), i))
+            .collect();
+        // Identity post-gates: after collapse to |t⟩, apply nothing (naive L=1).
+        let post = vec![Vec::new(); dim];
+        let lm = NQubitLM { post, init };
+        Ok(QuantumBackend { lm, tokens, token_index, n })
+    }
+
+    /// The dephased classical view — the `NQubit → born_probs` map. The seam
+    /// through which the classical vindex operations will be served by
+    /// measuring the quantum state (a later sub-project).
+    pub fn classical_view(&self) -> ClassicalRegister {
+        ClassicalRegister { probs: self.lm.init.born_probs() }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn spec(n: usize, state: StateSpec) -> QlmSpec {
         QlmSpec { n_qubits: n, state, tokens: None }
+    }
+
+    #[test]
+    fn backend_default_tokens_are_bit_strings() {
+        let qb = QuantumBackend::from_spec(&spec(2, StateSpec::Ghz)).unwrap();
+        assert_eq!(qb.tokens, vec!["00", "01", "10", "11"]);
+        assert_eq!(qb.token_index["11"], 3);
+        assert_eq!(qb.n, 2);
+    }
+
+    #[test]
+    fn classical_view_is_dephased_born() {
+        // classical_view == ClassicalRegister of the state's born_probs (the
+        // dephasing map the seam is built on).
+        let qb = QuantumBackend::from_spec(&spec(4, StateSpec::Dicke { k: 2 })).unwrap();
+        let cv = qb.classical_view();
+        let born = qb.lm.init.born_probs();
+        for (a, b) in cv.probs.iter().zip(born.iter()) {
+            assert!((a - b).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn from_spec_rejects_token_count_mismatch() {
+        let mut s = spec(2, StateSpec::Ghz);
+        s.tokens = Some(vec!["a".into(), "b".into()]); // only 2, need 4
+        let err = QuantumBackend::from_spec(&s).unwrap_err();
+        assert!(err.to_string().contains("token"), "{err}");
     }
 
     #[test]

--- a/crates/larql-lql/src/executor/quantum.rs
+++ b/crates/larql-lql/src/executor/quantum.rs
@@ -64,6 +64,7 @@ pub(crate) struct QuantumBackend {
     pub tokens: Vec<String>,
     pub token_index: HashMap<String, usize>,
     pub n: usize,
+    pub class: String,
 }
 
 impl std::fmt::Debug for QuantumBackend {
@@ -102,7 +103,12 @@ impl QuantumBackend {
         // Identity post-gates: after collapse to |t⟩, apply nothing (naive L=1).
         let post = vec![Vec::new(); dim];
         let lm = NQubitLM { post, init };
-        Ok(QuantumBackend { lm, tokens, token_index, n })
+        let class = match &spec.state {
+            StateSpec::Dicke { k } => format!("dicke(k={k})"),
+            StateSpec::Ghz => "ghz".to_string(),
+            StateSpec::Basis { index } => format!("basis(index={index})"),
+        };
+        Ok(QuantumBackend { lm, tokens, token_index, n, class })
     }
 
     /// Extension point for the classicalization layer (a later sub-project):
@@ -110,6 +116,10 @@ impl QuantumBackend {
     #[allow(dead_code)]
     pub fn classical_view(&self) -> ClassicalRegister {
         ClassicalRegister { probs: self.lm.init.born_probs() }
+    }
+
+    pub fn class_label(&self) -> &str {
+        &self.class
     }
 }
 
@@ -119,6 +129,12 @@ mod tests {
 
     fn spec(n: usize, state: StateSpec) -> QlmSpec {
         QlmSpec { n_qubits: n, state, tokens: None }
+    }
+
+    #[test]
+    fn class_label_describes_the_state() {
+        assert_eq!(QuantumBackend::from_spec(&spec(4, StateSpec::Dicke { k: 2 })).unwrap().class_label(), "dicke(k=2)");
+        assert_eq!(QuantumBackend::from_spec(&spec(3, StateSpec::Ghz)).unwrap().class_label(), "ghz");
     }
 
     #[test]

--- a/crates/larql-lql/src/executor/query/describe/exec.rs
+++ b/crates/larql-lql/src/executor/query/describe/exec.rs
@@ -37,6 +37,19 @@ impl Session {
     ) -> Result<Vec<String>, LqlError> {
         let verbose = mode != DescribeMode::Brief;
 
+        if let crate::executor::Backend::Quantum(qb) = &self.backend {
+            let entropy = if qb.n >= 2 {
+                larql_hilbert::entanglement_entropy_bipartition(&qb.lm.init, &[0])
+            } else {
+                0.0
+            };
+            return Ok(vec![
+                format!("Quantum model: {} qubits, {} tokens", qb.n, qb.tokens.len()),
+                format!("  state class: {}", qb.class_label()),
+                format!("  entanglement entropy (qubit-0 cut): {entropy:.4} ebits"),
+            ]);
+        }
+
         // MoE router-based DESCRIBE if available.
         if let Some(router_result) = self.try_moe_describe(entity, band, layer, verbose)? {
             return Ok(router_result);

--- a/crates/larql-lql/src/executor/query/infer.rs
+++ b/crates/larql-lql/src/executor/query/infer.rs
@@ -13,6 +13,34 @@ impl Session {
         route: Option<&crate::ast::InferRoute>,
     ) -> Result<Vec<String>, LqlError> {
         let top_k = top.unwrap_or(5) as usize;
+        // Quantum backend: render the Born next-token distribution.
+        if let Backend::Quantum(qb) = &self.backend {
+            // Condition the state on the prompt tokens (naive L=1: each token
+            // collapses to that basis state; empty prompt → the init state).
+            let mut state = qb.lm.init.clone();
+            for word in prompt.split_whitespace() {
+                let id = *qb.token_index.get(word).ok_or_else(|| {
+                    LqlError::Execution(format!(
+                        "unknown token '{word}' (vocabulary has {} tokens)",
+                        qb.tokens.len()
+                    ))
+                })?;
+                state = qb.lm.step(id);
+            }
+            let dist = qb.lm.next_distribution(&state);
+            let mut order: Vec<usize> = (0..dist.len()).collect();
+            order.sort_by(|&a, &b| dist[b].partial_cmp(&dist[a]).unwrap());
+            let mut out = vec!["Predictions (quantum — Born rule):".into()];
+            for (rank, &i) in order.iter().take(top_k).enumerate() {
+                out.push(format!(
+                    "  {:2}. {:20} ({:.2}%)",
+                    rank + 1,
+                    qb.tokens[i],
+                    dist[i] * 100.0
+                ));
+            }
+            return Ok(out);
+        }
         // Resolve the KnnStore router: an explicit `ROUTE VERIFY [FALLBACK]
         // [TOPK n]` clause wins; otherwise inherit the `LARQL_KNN_*` env default
         // (so unclaused INFER stays byte-identical to the Python binding —

--- a/crates/larql-lql/tests/test_quantum_backend.rs
+++ b/crates/larql-lql/tests/test_quantum_backend.rs
@@ -148,6 +148,17 @@ fn show_layers_reports_quantum_numbers() {
     let out = use_and_run(tmp.path(), "SHOW LAYERS;").unwrap();
     let text = out.join("\n");
     assert!(text.contains("quantum") || text.contains("qubit"), "SHOW LAYERS should report quantum info: {text}");
+    assert!(text.contains("ebits"), "SHOW LAYERS should report the entanglement entropy: {text}");
+}
+
+#[test]
+fn stats_reports_quantum_numbers_and_entropy() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 4, r#"{ "class": "dicke", "k": 2 }"#);
+    let out = use_and_run(tmp.path(), "STATS;").unwrap();
+    let text = out.join("\n");
+    // REQ-QB-004: n, class (with k), vocab (tokens), and entropy in ebits.
+    assert!(text.contains('4') && text.contains("dicke") && text.contains("ebits"), "{text}");
 }
 
 #[test]

--- a/crates/larql-lql/tests/test_quantum_backend.rs
+++ b/crates/larql-lql/tests/test_quantum_backend.rs
@@ -124,3 +124,44 @@ fn quantum_numbers_round_trip() {
         }
     }
 }
+
+#[test]
+fn compile_hits_classicalization_seam() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 2, r#"{ "class": "ghz" }"#);
+    let err = use_and_run(tmp.path(), r#"COMPILE CURRENT INTO VINDEX "/tmp/qb_out.vindex";"#).unwrap_err();
+    assert!(err.to_string().contains("classicalization"), "COMPILE should hit the seam, got: {err}");
+}
+
+#[test]
+fn merge_no_target_hits_classicalization_seam() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 2, r#"{ "class": "ghz" }"#);
+    let err = use_and_run(tmp.path(), &format!(r#"MERGE "{}";"#, tmp.path().display())).unwrap_err();
+    assert!(err.to_string().contains("classicalization"), "MERGE no-target should hit the seam, got: {err}");
+}
+
+#[test]
+fn show_layers_reports_quantum_numbers() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 4, r#"{ "class": "dicke", "k": 2 }"#);
+    let out = use_and_run(tmp.path(), "SHOW LAYERS;").unwrap();
+    let text = out.join("\n");
+    assert!(text.contains("quantum") || text.contains("qubit"), "SHOW LAYERS should report quantum info: {text}");
+}
+
+#[test]
+fn vocab_size_mismatch_errors_at_use() {
+    // n=2 → 2^n = 4, but write vocab_size = 99 deliberately.
+    let index = serde_json::json!({
+        "version": 2, "model": "qlm-test", "family": "quantum",
+        "num_layers": 1, "hidden_size": 2, "intermediate_size": 2,
+        "vocab_size": 99, "embed_scale": 1.0, "layers": [], "down_top_k": 1
+    });
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("index.json"), serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+    std::fs::write(tmp.path().join("qlm.json"), r#"{ "n_qubits": 2, "state": { "class": "ghz" } }"#).unwrap();
+    let mut s = Session::new();
+    let err = s.execute(&parse(&format!(r#"USE "{}";"#, tmp.path().display())).unwrap()).unwrap_err();
+    assert!(err.to_string().contains("vocab"), "expected vocab_size mismatch error: {err}");
+}

--- a/crates/larql-lql/tests/test_quantum_backend.rs
+++ b/crates/larql-lql/tests/test_quantum_backend.rs
@@ -45,3 +45,45 @@ fn use_rejects_bad_quantum_numbers() {
         .unwrap_err();
     assert!(err.to_string().contains("k"), "error should name k: {err}");
 }
+
+#[test]
+fn infer_ghz_ranks_correlated_tokens() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 3, r#"{ "class": "ghz" }"#);
+    let out = use_and_run(tmp.path(), r#"INFER "" TOP 4;"#).unwrap();
+    let text = out.join("\n");
+    // GHZ_3: only 000 and 111 carry mass, at 50% each.
+    assert!(text.contains("000") && text.contains("50.00%"), "{text}");
+    assert!(text.contains("111"), "{text}");
+    // An anti-correlated token must not appear among the nonzero ranks.
+    let nonzero_010 = out.iter().any(|l| l.contains("010") && !l.contains("0.00%"));
+    assert!(!nonzero_010, "010 should be 0% (forbidden): {text}");
+}
+
+#[test]
+fn infer_matches_next_distribution() {
+    use larql_hilbert::{NQubit, NQubitLM};
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 2, r#"{ "class": "dicke", "k": 1 }"#);
+    let out = use_and_run(tmp.path(), r#"INFER "" TOP 4;"#).unwrap();
+    // Analytic: W_2 = (|01⟩+|10⟩)/√2 → tokens 01,10 at 50%.
+    let lm = NQubitLM { post: vec![Vec::new(); 4], init: NQubit::dicke(2, 1) };
+    let dist = lm.next_distribution(&lm.init);
+    for (tok, &p) in ["00", "01", "10", "11"].iter().zip(dist.iter()) {
+        if p > 1e-9 {
+            let pct = format!("{:.2}%", p * 100.0);
+            assert!(
+                out.iter().any(|l| l.contains(tok) && l.contains(&pct)),
+                "expected {tok} at {pct} in {out:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn infer_unknown_token_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 2, r#"{ "class": "ghz" }"#);
+    let err = use_and_run(tmp.path(), r#"INFER "qux" TOP 2;"#).unwrap_err();
+    assert!(err.to_string().contains("qux"), "error should name qux: {err}");
+}

--- a/crates/larql-lql/tests/test_quantum_backend.rs
+++ b/crates/larql-lql/tests/test_quantum_backend.rs
@@ -87,3 +87,14 @@ fn infer_unknown_token_errors() {
     let err = use_and_run(tmp.path(), r#"INFER "qux" TOP 2;"#).unwrap_err();
     assert!(err.to_string().contains("qux"), "error should name qux: {err}");
 }
+
+#[test]
+fn unsupported_statement_hits_classicalization_seam() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 2, r#"{ "class": "ghz" }"#);
+    let err = use_and_run(tmp.path(), "SELECT * FROM EDGES LIMIT 5;").unwrap_err();
+    assert!(
+        err.to_string().contains("classicalization"),
+        "expected the classicalization-seam error, got: {err}"
+    );
+}

--- a/crates/larql-lql/tests/test_quantum_backend.rs
+++ b/crates/larql-lql/tests/test_quantum_backend.rs
@@ -98,3 +98,29 @@ fn unsupported_statement_hits_classicalization_seam() {
         "expected the classicalization-seam error, got: {err}"
     );
 }
+
+#[test]
+fn describe_reports_quantum_numbers() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 4, r#"{ "class": "dicke", "k": 2 }"#);
+    let out = use_and_run(tmp.path(), r#"DESCRIBE "state";"#).unwrap();
+    let text = out.join("\n");
+    assert!(text.contains("dicke") && text.contains('4') && text.contains('2'), "{text}");
+}
+
+#[test]
+fn quantum_numbers_round_trip() {
+    use larql_hilbert::NQubit;
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 4, r#"{ "class": "dicke", "k": 2 }"#);
+    // INFER reproduces the analytic Dicke(4,2) distribution (1/6 on weight-2).
+    let out = use_and_run(tmp.path(), r#"INFER "" TOP 16;"#).unwrap();
+    let analytic = NQubit::dicke(4, 2).born_probs();
+    for (idx, &p) in analytic.iter().enumerate() {
+        if p > 1e-9 {
+            let tok = format!("{idx:04b}");
+            let pct = format!("{:.2}%", p * 100.0);
+            assert!(out.iter().any(|l| l.contains(&tok) && l.contains(&pct)), "{tok} {pct}: {out:?}");
+        }
+    }
+}

--- a/crates/larql-lql/tests/test_quantum_backend.rs
+++ b/crates/larql-lql/tests/test_quantum_backend.rs
@@ -1,0 +1,47 @@
+//! Integration tests: drive the quantum backend through the real `Session`.
+
+use std::path::Path;
+
+use larql_lql::{parse, Session};
+
+/// Write a Dicke quantum vindex directory (index.json family=quantum + qlm.json).
+fn write_quantum_vindex(dir: &Path, n: usize, class_json: &str) {
+    let vocab = 1usize << n;
+    let index = serde_json::json!({
+        "version": 2, "model": "qlm-test", "family": "quantum",
+        "num_layers": 1, "hidden_size": n, "intermediate_size": n,
+        "vocab_size": vocab, "embed_scale": 1.0, "layers": [], "down_top_k": 1
+    });
+    std::fs::write(dir.join("index.json"), serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+    let qlm = format!(r#"{{ "n_qubits": {n}, "state": {class_json} }}"#);
+    std::fs::write(dir.join("qlm.json"), qlm).unwrap();
+}
+
+#[allow(dead_code)]
+fn use_and_run(dir: &Path, stmt: &str) -> Result<Vec<String>, larql_lql::LqlError> {
+    let mut s = Session::new();
+    s.execute(&parse(&format!(r#"USE "{}";"#, dir.display())).unwrap()).unwrap();
+    s.execute(&parse(stmt).unwrap())
+}
+
+#[test]
+fn use_quantum_vindex_builds_backend() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 3, r#"{ "class": "ghz" }"#);
+    let mut s = Session::new();
+    let out = s
+        .execute(&parse(&format!(r#"USE "{}";"#, tmp.path().display())).unwrap())
+        .unwrap();
+    assert!(out.iter().any(|l| l.contains("quantum")), "USE output: {out:?}");
+}
+
+#[test]
+fn use_rejects_bad_quantum_numbers() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 2, r#"{ "class": "dicke", "k": 3 }"#);
+    let mut s = Session::new();
+    let err = s
+        .execute(&parse(&format!(r#"USE "{}";"#, tmp.path().display())).unwrap())
+        .unwrap_err();
+    assert!(err.to_string().contains("k"), "error should name k: {err}");
+}

--- a/docs/superpowers/plans/2026-06-12-quantum-backend.md
+++ b/docs/superpowers/plans/2026-06-12-quantum-backend.md
@@ -1,0 +1,832 @@
+# Quantum Backend (SP1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task with two-stage review (spec compliance, then code quality). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make a quantum language model usable through real larql — `USE` a Dicke quantum vindex and `INFER` its Born next-token distribution via the existing `Session`.
+
+**Architecture:** A vindex directory with `index.json` (`family: "quantum"`) + `qlm.json` (the quantum numbers `(n, class, k)`) is loaded into a new `Backend::Quantum` that wraps an `NQubitLM`. `INFER` renders the Born distribution as ranked tokens; metadata ops report the quantum numbers; every other (classical) statement funnels through the `require_vindex`/`require_patched` accessors, whose new `Backend::Quantum` arm is the single "classicalization seam." The state is reconstructed from the quantum numbers — nothing derived is stored.
+
+**Tech Stack:** Rust; `larql-hilbert` (`NQubit`, `NQubitLM`, `ClassicalRegister`), `larql-lql` (`Session`, `Backend`, `exec_*` dispatch), `larql-vindex` (`load_vindex_config`, `VindexConfig`), `serde`/`serde_json`.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-quantum-backend-design.md`; OpenSpec `openspec/changes/quantum-backend/` (REQ-QB-001…006).
+
+**Branch:** `feat/quantum-backend` (already created, stacked on the n-qubit work).
+
+---
+
+## File Structure
+
+- Modify `crates/larql-hilbert/src/nqubit.rs` — add `NQubit::dicke(n, k)`.
+- Create `crates/larql-lql/src/executor/quantum.rs` — `QlmSpec`/`StateSpec` (serde), state reconstruction, `QuantumBackend` struct + `classical_view()`.
+- Modify `crates/larql-lql/Cargo.toml` — add `larql-hilbert` dependency.
+- Modify `crates/larql-lql/src/executor/mod.rs` — declare `pub(crate) mod quantum;`.
+- Modify `crates/larql-lql/src/executor/backend.rs` — `Backend::Quantum` variant + the classicalization-seam arms in `require_vindex`/`require_patched`/`require_patched_mut`.
+- Modify `crates/larql-lql/src/error.rs` — `LqlError::QuantumClassicalization` variant.
+- Modify `crates/larql-lql/src/executor/lifecycle/use_cmd.rs` — branch on `family == "quantum"`.
+- Modify `crates/larql-lql/src/executor/query/infer.rs` — `Backend::Quantum` INFER branch.
+- Modify the STATS/DESCRIBE handlers — quantum-number reporting.
+- Create `crates/larql-lql/tests/test_quantum_backend.rs` — integration tests + the `write_quantum_vindex` helper.
+- Create `crates/larql-lql/examples/quantum_lm_demo.rs` — the runnable demo.
+
+---
+
+## Task 1: `NQubit::dicke(n, k)` (REQ-QB-001)
+
+**Files:** Modify `crates/larql-hilbert/src/nqubit.rs`.
+
+- [ ] **Step 1: Write the failing tests.** Add to the `#[cfg(test)] mod tests` in `crates/larql-hilbert/src/nqubit.rs`:
+
+```rust
+#[test]
+fn dicke_one_excitation_is_w() {
+    // |D^3_1⟩ == W_3 (uniform amplitude on 001, 010, 100).
+    let d = NQubit::dicke(3, 1);
+    let w = NQubit::w(3);
+    for (a, b) in d.amp.iter().zip(w.amp.iter()) {
+        assert!((a - b).norm() < 1e-12);
+    }
+}
+
+#[test]
+fn dicke_two_excitations_uniform_weight2() {
+    // |D^4_2⟩: equal Born mass 1/6 on the six weight-2 states, 0 elsewhere.
+    let p = NQubit::dicke(4, 2).born_probs();
+    for (idx, prob) in p.iter().enumerate() {
+        let weight = (idx as u32).count_ones();
+        if weight == 2 {
+            assert!((prob - 1.0 / 6.0).abs() < 1e-12, "idx {idx} should be 1/6");
+        } else {
+            assert!(prob.abs() < 1e-12, "idx {idx} (weight {weight}) should be 0");
+        }
+    }
+}
+
+#[test]
+#[should_panic(expected = "k")]
+fn dicke_rejects_k_above_n() {
+    let _ = NQubit::dicke(2, 3);
+}
+```
+
+- [ ] **Step 2: Run to verify FAIL.** `cargo test -p larql-hilbert --lib nqubit::tests::dicke 2>&1 | tail -15` — `dicke` not found.
+
+- [ ] **Step 3: Implement.** Add this method inside the `impl NQubit { ... }` block in `nqubit.rs` (next to `ghz`/`w`):
+
+```rust
+    /// Dicke state |D^n_k⟩ — the normalized equal superposition of all
+    /// computational-basis states of Hamming weight `k`. `w(n)` is `dicke(n, 1)`.
+    pub fn dicke(n: usize, k: usize) -> NQubit {
+        assert!((1..64).contains(&n), "qubit count {n} must be in 1..64");
+        assert!(k <= n, "excitation k={k} must satisfy k ≤ n={n}");
+        let dim = 1usize << n;
+        let mut amp = vec![c(0.0, 0.0); dim];
+        let count = (0..dim).filter(|i| (*i as u32).count_ones() as usize == k).count();
+        let a = 1.0 / (count as f64).sqrt();
+        for i in 0..dim {
+            if (i as u32).count_ones() as usize == k {
+                amp[i] = c(a, 0.0);
+            }
+        }
+        NQubit { amp }
+    }
+```
+
+- [ ] **Step 4: Run to verify PASS.** `cargo test -p larql-hilbert --lib nqubit:: 2>&1 | tail -5` — all pass.
+
+- [ ] **Step 5: Update the spec annotation + commit.** In `openspec/changes/quantum-backend/specs/quantum-backend/spec.md`, the three REQ-QB-001 scenarios already point at `nqubit.rs::tests::dicke_one_excitation_is_w`, `dicke_two_excitations_uniform_weight2`, `dicke_rejects_k_above_n` — verify they match. Then:
+```bash
+git add crates/larql-hilbert/src/nqubit.rs
+git commit -m "feat(hilbert): NQubit::dicke(n,k) Dicke/angular-momentum state (w = dicke(n,1))"
+```
+
+---
+
+## Task 2: Quantum-number spec + state reconstruction
+
+**Files:** Modify `crates/larql-lql/Cargo.toml`, `crates/larql-lql/src/executor/mod.rs`; create `crates/larql-lql/src/executor/quantum.rs`.
+
+**Context:** `qlm.json` carries only the quantum numbers. This task parses them and reconstructs the `NQubit` state — the functor G applied. Validation (`k > n`, vocab mismatch) lives here too.
+
+- [ ] **Step 1: Add the dependency.** In `crates/larql-lql/Cargo.toml`, under `[dependencies]`, add:
+```toml
+larql-hilbert = { path = "../larql-hilbert" }
+```
+Confirm `serde` and `serde_json` are already present (they are — used throughout larql-lql). Run `cargo build -p larql-lql 2>&1 | tail -3` to confirm the dep resolves.
+
+- [ ] **Step 2: Declare the module.** In `crates/larql-lql/src/executor/mod.rs`, add near the other `mod` declarations (e.g. after `mod backend;`):
+```rust
+pub(crate) mod quantum;
+```
+
+- [ ] **Step 3: Write the failing tests.** Create `crates/larql-lql/src/executor/quantum.rs` with the serde types, a stub `reconstruct_state` signature, and the tests:
+
+```rust
+//! Quantum backend: reconstruct an `NQubitLM` from a quantum-vindex `qlm.json`
+//! (the quantum numbers only) and serve it through the LQL session.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use larql_hilbert::{ClassicalRegister, NQubit, NQubitLM};
+
+use crate::error::LqlError;
+
+/// The on-disk `qlm.json` — the quantum numbers, nothing derived.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct QlmSpec {
+    pub n_qubits: usize,
+    pub state: StateSpec,
+    /// Optional explicit token labels (length 2^n). Default: n-bit strings.
+    #[serde(default)]
+    pub tokens: Option<Vec<String>>,
+}
+
+/// The state's quantum numbers.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "class", rename_all = "lowercase")]
+pub(crate) enum StateSpec {
+    Dicke { k: usize },
+    Ghz,
+    Basis { index: usize },
+}
+
+/// Reconstruct the initial `NQubit` state |ψ⟩ from the quantum numbers.
+pub(crate) fn reconstruct_state(spec: &QlmSpec) -> Result<NQubit, LqlError> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(n: usize, state: StateSpec) -> QlmSpec {
+        QlmSpec { n_qubits: n, state, tokens: None }
+    }
+
+    #[test]
+    fn reconstruct_dicke_matches_analytic_born() {
+        let q = reconstruct_state(&spec(4, StateSpec::Dicke { k: 2 })).unwrap();
+        let p = q.born_probs();
+        for (idx, prob) in p.iter().enumerate() {
+            let expected = if (idx as u32).count_ones() == 2 { 1.0 / 6.0 } else { 0.0 };
+            assert!((prob - expected).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn reconstruct_ghz_is_cat_state() {
+        let q = reconstruct_state(&spec(3, StateSpec::Ghz)).unwrap();
+        let p = q.born_probs();
+        assert!((p[0] - 0.5).abs() < 1e-12 && (p[7] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn reconstruct_rejects_k_above_n() {
+        let err = reconstruct_state(&spec(2, StateSpec::Dicke { k: 3 })).unwrap_err();
+        assert!(err.to_string().contains("k"), "error should name k: {err}");
+    }
+
+    #[test]
+    fn parses_qlm_json() {
+        let json = r#"{ "n_qubits": 3, "state": { "class": "dicke", "k": 1 } }"#;
+        let spec: QlmSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.n_qubits, 3);
+        assert!(matches!(spec.state, StateSpec::Dicke { k: 1 }));
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify FAIL.** `cargo test -p larql-lql --lib executor::quantum 2>&1 | tail -15` — the tests panic on `todo!()`.
+
+- [ ] **Step 5: Implement `reconstruct_state`.** Replace the `todo!()` body:
+
+```rust
+pub(crate) fn reconstruct_state(spec: &QlmSpec) -> Result<NQubit, LqlError> {
+    let n = spec.n_qubits;
+    if !(1..64).contains(&n) {
+        return Err(LqlError::Execution(format!(
+            "qlm.json: n_qubits = {n} must be in 1..64"
+        )));
+    }
+    match &spec.state {
+        StateSpec::Dicke { k } => {
+            if *k > n {
+                return Err(LqlError::Execution(format!(
+                    "qlm.json: Dicke excitation k = {k} must satisfy k ≤ n = {n}"
+                )));
+            }
+            Ok(NQubit::dicke(n, *k))
+        }
+        StateSpec::Ghz => Ok(NQubit::ghz(n)),
+        StateSpec::Basis { index } => {
+            let dim = 1usize << n;
+            if *index >= dim {
+                return Err(LqlError::Execution(format!(
+                    "qlm.json: basis index {index} out of range for {n} qubits (dim {dim})"
+                )));
+            }
+            Ok(NQubit::basis(n, *index))
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run to verify PASS.** `cargo test -p larql-lql --lib executor::quantum 2>&1 | tail -8` — 4 pass.
+
+- [ ] **Step 7: Commit.**
+```bash
+git add crates/larql-lql/Cargo.toml crates/larql-lql/src/executor/mod.rs crates/larql-lql/src/executor/quantum.rs
+git commit -m "feat(lql): qlm.json quantum-number spec + NQubit state reconstruction"
+```
+
+---
+
+## Task 3: `QuantumBackend` struct + `classical_view`
+
+**Files:** Modify `crates/larql-lql/src/executor/quantum.rs`.
+
+**Context:** Wrap the reconstructed state in an `NQubitLM` (identity `post`, naive `L=1`) plus the token vocabulary, and expose the dephasing map.
+
+- [ ] **Step 1: Write the failing tests.** Add to `quantum.rs`'s `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn backend_default_tokens_are_bit_strings() {
+    let qb = QuantumBackend::from_spec(&spec(2, StateSpec::Ghz)).unwrap();
+    assert_eq!(qb.tokens, vec!["00", "01", "10", "11"]);
+    assert_eq!(qb.token_index["11"], 3);
+    assert_eq!(qb.n, 2);
+}
+
+#[test]
+fn classical_view_is_dephased_born() {
+    // classical_view == ClassicalRegister of the state's born_probs (the
+    // dephasing map the seam is built on).
+    let qb = QuantumBackend::from_spec(&spec(4, StateSpec::Dicke { k: 2 })).unwrap();
+    let cv = qb.classical_view();
+    let born = qb.lm.init.born_probs();
+    for (a, b) in cv.probs.iter().zip(born.iter()) {
+        assert!((a - b).abs() < 1e-12);
+    }
+}
+
+#[test]
+fn from_spec_rejects_token_count_mismatch() {
+    let mut s = spec(2, StateSpec::Ghz);
+    s.tokens = Some(vec!["a".into(), "b".into()]); // only 2, need 4
+    let err = QuantumBackend::from_spec(&s).unwrap_err();
+    assert!(err.to_string().contains("token"), "{err}");
+}
+```
+
+- [ ] **Step 2: Run to verify FAIL.** `cargo test -p larql-lql --lib executor::quantum 2>&1 | tail -15` — `QuantumBackend` not found.
+
+- [ ] **Step 3: Implement.** Add to `quantum.rs` (before the `#[cfg(test)]` module). Note `NQubitLM { post: Vec<Vec<(Gate, usize)>>, init }`; identity `post` is `2^n` empty gate-lists (collapse only):
+
+```rust
+/// A loaded quantum language model, ready to serve INFER through the session.
+pub(crate) struct QuantumBackend {
+    pub lm: NQubitLM,
+    pub tokens: Vec<String>,
+    pub token_index: HashMap<String, usize>,
+    pub n: usize,
+}
+
+impl QuantumBackend {
+    /// Build from the quantum numbers: reconstruct |ψ⟩, attach identity
+    /// post-gates (naive L=1), and resolve the token vocabulary.
+    pub fn from_spec(spec: &QlmSpec) -> Result<QuantumBackend, LqlError> {
+        let init = reconstruct_state(spec)?;
+        let n = spec.n_qubits;
+        let dim = 1usize << n;
+        let tokens = match &spec.tokens {
+            Some(t) => {
+                if t.len() != dim {
+                    return Err(LqlError::Execution(format!(
+                        "qlm.json: {} token labels for {dim}-token vocabulary (2^{n})",
+                        t.len()
+                    )));
+                }
+                t.clone()
+            }
+            None => (0..dim).map(|i| format!("{i:0width$b}", width = n)).collect(),
+        };
+        let token_index = tokens
+            .iter()
+            .enumerate()
+            .map(|(i, t)| (t.clone(), i))
+            .collect();
+        // Identity post-gates: after collapse to |t⟩, apply nothing (naive L=1).
+        let post = vec![Vec::new(); dim];
+        let lm = NQubitLM { post, init };
+        Ok(QuantumBackend { lm, tokens, token_index, n })
+    }
+
+    /// The dephased classical view — the `NQubit → born_probs` map. The seam
+    /// through which the classical vindex operations will be served by
+    /// measuring the quantum state (a later sub-project).
+    pub fn classical_view(&self) -> ClassicalRegister {
+        ClassicalRegister { probs: self.lm.init.born_probs() }
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify PASS.** `cargo test -p larql-lql --lib executor::quantum 2>&1 | tail -8` — all pass.
+
+- [ ] **Step 5: Fix the OpenSpec annotation.** REQ-QB-005's `classical_view_is_dephased_born` scenario currently points at `tests/test_quantum_backend.rs`; it actually lives in the module. In `openspec/changes/quantum-backend/specs/quantum-backend/spec.md`, change that one annotation to:
+```
+<!-- test: crates/larql-lql/src/executor/quantum.rs::tests::classical_view_is_dephased_born -->
+```
+
+- [ ] **Step 6: Commit.**
+```bash
+git add crates/larql-lql/src/executor/quantum.rs openspec/changes/quantum-backend/specs/quantum-backend/spec.md
+git commit -m "feat(lql): QuantumBackend (NQubitLM + tokens) + classical_view dephasing seam"
+```
+
+---
+
+## Task 4: `Backend::Quantum` variant + `USE` branch (REQ-QB-002)
+
+**Files:** Modify `crates/larql-lql/src/executor/backend.rs`, `crates/larql-lql/src/executor/lifecycle/use_cmd.rs`; create `crates/larql-lql/tests/test_quantum_backend.rs`.
+
+- [ ] **Step 1: Add the `Backend::Quantum` variant.** In `crates/larql-lql/src/executor/backend.rs`, add to the `Backend` enum (after `Remote { … }`, before `None`):
+```rust
+    /// Quantum language model loaded from a `family: "quantum"` vindex.
+    /// Serves INFER (Born) + metadata; classical ops route through the
+    /// classicalization seam in `require_vindex`/`require_patched`.
+    Quantum(crate::executor::quantum::QuantumBackend),
+```
+
+- [ ] **Step 2: Write the failing integration test + helper.** Create `crates/larql-lql/tests/test_quantum_backend.rs`:
+
+```rust
+//! Integration tests: drive the quantum backend through the real `Session`.
+
+use std::path::Path;
+
+use larql_lql::{parse, Session};
+
+/// Write a Dicke quantum vindex directory (index.json family=quantum + qlm.json).
+fn write_quantum_vindex(dir: &Path, n: usize, class_json: &str) {
+    let vocab = 1usize << n;
+    let index = serde_json::json!({
+        "version": 2, "model": "qlm-test", "family": "quantum",
+        "num_layers": 1, "hidden_size": n, "intermediate_size": n,
+        "vocab_size": vocab, "embed_scale": 1.0, "layers": [], "down_top_k": 1
+    });
+    std::fs::write(dir.join("index.json"), serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+    let qlm = format!(r#"{{ "n_qubits": {n}, "state": {class_json} }}"#);
+    std::fs::write(dir.join("qlm.json"), qlm).unwrap();
+}
+
+fn use_and_run(dir: &Path, stmt: &str) -> Result<Vec<String>, larql_lql::LqlError> {
+    let mut s = Session::new();
+    s.execute(&parse(&format!(r#"USE "{}";"#, dir.display())).unwrap()).unwrap();
+    s.execute(&parse(stmt).unwrap())
+}
+
+#[test]
+fn use_quantum_vindex_builds_backend() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 3, r#"{ "class": "ghz" }"#);
+    let mut s = Session::new();
+    let out = s
+        .execute(&parse(&format!(r#"USE "{}";"#, tmp.path().display())).unwrap())
+        .unwrap();
+    assert!(out.iter().any(|l| l.contains("quantum")), "USE output: {out:?}");
+}
+
+#[test]
+fn use_rejects_bad_quantum_numbers() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 2, r#"{ "class": "dicke", "k": 3 }"#);
+    let mut s = Session::new();
+    let err = s
+        .execute(&parse(&format!(r#"USE "{}";"#, tmp.path().display())).unwrap())
+        .unwrap_err();
+    assert!(err.to_string().contains("k"), "error should name k: {err}");
+}
+```
+
+- [ ] **Step 3: Run to verify FAIL.** `cargo test -p larql-lql --test test_quantum_backend 2>&1 | tail -20` — `USE` builds a `Backend::Vindex` and fails to load (no gate_vectors), so the test fails.
+
+- [ ] **Step 4: Implement the `USE` branch.** In `crates/larql-lql/src/executor/lifecycle/use_cmd.rs`, inside `UseTarget::Vindex(path_str) => { … }`, immediately **after** the `let config = larql_vindex::load_vindex_config(&path)…?;` line and **before** the `VectorIndex::load_vindex` call, insert:
+
+```rust
+                // Quantum vindex: reconstruct the QLM from its quantum numbers
+                // and serve it through Backend::Quantum (no gate_vectors / FFN).
+                if config.family == "quantum" {
+                    let qlm_bytes = std::fs::read(path.join("qlm.json"))
+                        .map_err(|e| LqlError::exec("failed to read qlm.json", e))?;
+                    let spec: crate::executor::quantum::QlmSpec =
+                        serde_json::from_slice(&qlm_bytes)
+                            .map_err(|e| LqlError::exec("failed to parse qlm.json", e))?;
+                    let qb = crate::executor::quantum::QuantumBackend::from_spec(&spec)?;
+                    let out = vec![format!(
+                        "Using quantum vindex: {} ({} qubits, {} tokens, model: {})",
+                        path.display(),
+                        qb.n,
+                        qb.tokens.len(),
+                        config.model,
+                    )];
+                    self.backend = Backend::Quantum(qb);
+                    self.patch_recording = None;
+                    self.auto_patch = false;
+                    return Ok(out);
+                }
+```
+
+- [ ] **Step 5: Run to verify PASS.** `cargo test -p larql-lql --test test_quantum_backend 2>&1 | tail -8` — both pass. Also `cargo build -p larql-lql 2>&1 | tail -3` clean.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add crates/larql-lql/src/executor/backend.rs crates/larql-lql/src/executor/lifecycle/use_cmd.rs crates/larql-lql/tests/test_quantum_backend.rs
+git commit -m "feat(lql): Backend::Quantum + USE branch on family=quantum"
+```
+
+---
+
+## Task 5: `INFER` Born next-token rendering (REQ-QB-003)
+
+**Files:** Modify `crates/larql-lql/src/executor/query/infer.rs`; add tests to `crates/larql-lql/tests/test_quantum_backend.rs`.
+
+- [ ] **Step 1: Write the failing tests.** Append to `crates/larql-lql/tests/test_quantum_backend.rs`:
+
+```rust
+#[test]
+fn infer_ghz_ranks_correlated_tokens() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 3, r#"{ "class": "ghz" }"#);
+    let out = use_and_run(tmp.path(), r#"INFER "" TOP 4;"#).unwrap();
+    let text = out.join("\n");
+    // GHZ_3: only 000 and 111 carry mass, at 50% each.
+    assert!(text.contains("000") && text.contains("50.00%"), "{text}");
+    assert!(text.contains("111"), "{text}");
+    // An anti-correlated token must not appear among the nonzero ranks.
+    let nonzero_010 = out.iter().any(|l| l.contains("010") && !l.contains("0.00%"));
+    assert!(!nonzero_010, "010 should be 0% (forbidden): {text}");
+}
+
+#[test]
+fn infer_matches_next_distribution() {
+    use larql_hilbert::{NQubit, NQubitLM};
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 2, r#"{ "class": "dicke", "k": 1 }"#);
+    let out = use_and_run(tmp.path(), r#"INFER "" TOP 4;"#).unwrap();
+    // Analytic: W_2 = (|01⟩+|10⟩)/√2 → tokens 01,10 at 50%.
+    let lm = NQubitLM { post: vec![Vec::new(); 4], init: NQubit::dicke(2, 1) };
+    let dist = lm.next_distribution(&lm.init);
+    for (tok, &p) in ["00", "01", "10", "11"].iter().zip(dist.iter()) {
+        if p > 1e-9 {
+            let pct = format!("{:.2}%", p * 100.0);
+            assert!(
+                out.iter().any(|l| l.contains(tok) && l.contains(&pct)),
+                "expected {tok} at {pct} in {out:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn infer_unknown_token_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 2, r#"{ "class": "ghz" }"#);
+    let err = use_and_run(tmp.path(), r#"INFER "qux" TOP 2;"#).unwrap_err();
+    assert!(err.to_string().contains("qux"), "error should name qux: {err}");
+}
+```
+
+- [ ] **Step 2: Run to verify FAIL.** `cargo test -p larql-lql --test test_quantum_backend infer_ 2>&1 | tail -20` — INFER on the quantum backend currently falls through (no Quantum branch) and errors/returns wrong output.
+
+- [ ] **Step 3: Implement the INFER branch.** In `crates/larql-lql/src/executor/query/infer.rs`, at the **start** of `exec_infer` (right after `let top_k = top.unwrap_or(5) as usize;`), insert:
+
+```rust
+        // Quantum backend: render the Born next-token distribution.
+        if let Backend::Quantum(qb) = &self.backend {
+            // Condition the state on the prompt tokens (naive L=1: each token
+            // collapses to that basis state; empty prompt → the init state).
+            let mut state = qb.lm.init.clone();
+            for word in prompt.split_whitespace() {
+                let id = *qb.token_index.get(word).ok_or_else(|| {
+                    LqlError::Execution(format!(
+                        "unknown token '{word}' (vocabulary has {} tokens)",
+                        qb.tokens.len()
+                    ))
+                })?;
+                state = qb.lm.step(id);
+            }
+            let dist = qb.lm.next_distribution(&state);
+            let mut order: Vec<usize> = (0..dist.len()).collect();
+            order.sort_by(|&a, &b| dist[b].partial_cmp(&dist[a]).unwrap());
+            let mut out = vec!["Predictions (quantum — Born rule):".into()];
+            for (rank, &i) in order.iter().take(top_k).enumerate() {
+                out.push(format!(
+                    "  {:2}. {:20} ({:.2}%)",
+                    rank + 1,
+                    qb.tokens[i],
+                    dist[i] * 100.0
+                ));
+            }
+            return Ok(out);
+        }
+```
+
+(The `route`/`compare`/`route_mode` locals above are only read by the Weight/Vindex paths; the early `return` for the quantum branch leaves them unused for quantum, which is fine — they are computed unconditionally but cheaply. If the compiler warns about unused `route_mode`/`exit_requested` for an all-quantum build, that cannot happen: the other backends still use them in the same function.)
+
+- [ ] **Step 4: Run to verify PASS.** `cargo test -p larql-lql --test test_quantum_backend 2>&1 | tail -8` — all quantum tests pass. `cargo build -p larql-lql 2>&1 | grep -c warning` → expect `0`.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add crates/larql-lql/src/executor/query/infer.rs crates/larql-lql/tests/test_quantum_backend.rs
+git commit -m "feat(lql): INFER renders the quantum backend's Born next-token distribution"
+```
+
+---
+
+## Task 6: Classicalization seam (REQ-QB-005)
+
+**Files:** Modify `crates/larql-lql/src/error.rs`, `crates/larql-lql/src/executor/backend.rs`; add a test to `crates/larql-lql/tests/test_quantum_backend.rs`.
+
+**Context:** Every classical op (`WALK`, `SELECT`, mutations, `COMPILE`, `TRACE`, `COMPACT`) funnels through `require_vindex`/`require_patched`/`require_patched_mut`. Adding a `Backend::Quantum` arm to those three is the single seam.
+
+- [ ] **Step 1: Add the error variant.** In `crates/larql-lql/src/error.rs`, add to the `LqlError` enum:
+```rust
+    #[error("This operation is served by the classicalization layer (measure/dephase the quantum model), which is not yet wired on the quantum backend.")]
+    QuantumClassicalization,
+```
+
+- [ ] **Step 2: Write the failing test.** Append to `crates/larql-lql/tests/test_quantum_backend.rs`:
+
+```rust
+#[test]
+fn unsupported_statement_hits_classicalization_seam() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 2, r#"{ "class": "ghz" }"#);
+    let err = use_and_run(tmp.path(), "SELECT * FROM EDGES LIMIT 5;").unwrap_err();
+    assert!(
+        err.to_string().contains("classicalization"),
+        "expected the classicalization-seam error, got: {err}"
+    );
+}
+```
+
+- [ ] **Step 3: Run to verify FAIL.** `cargo test -p larql-lql --test test_quantum_backend classicalization 2>&1 | tail -15` — currently returns generic `NoBackend`, not the seam message.
+
+- [ ] **Step 4: Implement the seam.** In `crates/larql-lql/src/executor/backend.rs`, add a `Backend::Quantum` arm to each of `require_patched`, `require_patched_mut`, and `require_vindex` — placed before the `_ => Err(LqlError::NoBackend)` catch-all. In `require_patched` and `require_vindex` (which match `&self.backend`):
+```rust
+            Backend::Quantum(_) => Err(LqlError::QuantumClassicalization),
+```
+In `require_patched_mut` (which matches `&mut self.backend`):
+```rust
+            Backend::Quantum(_) => Err(LqlError::QuantumClassicalization),
+```
+
+- [ ] **Step 5: Run to verify PASS.** `cargo test -p larql-lql --test test_quantum_backend 2>&1 | tail -8` — all pass. `cargo build -p larql-lql 2>&1 | tail -3` clean.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add crates/larql-lql/src/error.rs crates/larql-lql/src/executor/backend.rs crates/larql-lql/tests/test_quantum_backend.rs
+git commit -m "feat(lql): classicalization seam — quantum backend routes classical ops to one error"
+```
+
+---
+
+## Task 7: Quantum-number metadata + round-trip (REQ-QB-004, REQ-QB-006)
+
+**Files:** Modify the `STATS` and `DESCRIBE` handlers; add tests to `crates/larql-lql/tests/test_quantum_backend.rs`.
+
+**Context:** `exec_stats` and `exec_describe` currently assume a vindex/weight backend. Add a `Backend::Quantum` branch reporting the quantum numbers. First locate the handlers: `grep -rn "fn exec_stats" crates/larql-lql/src/` and `grep -rn "fn exec_describe" crates/larql-lql/src/`.
+
+- [ ] **Step 1: Write the failing tests.** Append to `crates/larql-lql/tests/test_quantum_backend.rs`:
+
+```rust
+#[test]
+fn describe_reports_quantum_numbers() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 4, r#"{ "class": "dicke", "k": 2 }"#);
+    let out = use_and_run(tmp.path(), r#"DESCRIBE "state";"#).unwrap();
+    let text = out.join("\n");
+    assert!(text.contains("dicke") && text.contains('4') && text.contains('2'), "{text}");
+}
+
+#[test]
+fn quantum_numbers_round_trip() {
+    use larql_hilbert::NQubit;
+    let tmp = tempfile::tempdir().unwrap();
+    write_quantum_vindex(tmp.path(), 4, r#"{ "class": "dicke", "k": 2 }"#);
+    // INFER reproduces the analytic Dicke(4,2) distribution (1/6 on weight-2).
+    let out = use_and_run(tmp.path(), r#"INFER "" TOP 16;"#).unwrap();
+    let analytic = NQubit::dicke(4, 2).born_probs();
+    for (idx, &p) in analytic.iter().enumerate() {
+        if p > 1e-9 {
+            let tok = format!("{idx:04b}");
+            let pct = format!("{:.2}%", p * 100.0);
+            assert!(out.iter().any(|l| l.contains(&tok) && l.contains(&pct)), "{tok} {pct}: {out:?}");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify FAIL.** `cargo test -p larql-lql --test test_quantum_backend describe 2>&1 | tail -15` — `DESCRIBE` hits the seam/NoBackend, not quantum-number output.
+
+- [ ] **Step 3: Implement the DESCRIBE branch.** At the start of `exec_describe` (the `fn exec_describe(&self, entity: &str, …)` body), insert a quantum branch that reports the quantum numbers. Use the entanglement entropy across the first-qubit cut as the derived scalar:
+
+```rust
+        if let Backend::Quantum(qb) = &self.backend {
+            let class = match qb.lm.init.amp.len() {
+                _ => "see qlm.json", // placeholder replaced below
+            };
+            // Report directly from the reconstructed state.
+            let entropy = if qb.n >= 2 {
+                larql_hilbert::entanglement_entropy_bipartition(&qb.lm.init, &[0])
+            } else {
+                0.0
+            };
+            return Ok(vec![
+                format!("Quantum model: {} qubits, {} tokens", qb.n, qb.tokens.len()),
+                format!("  state class: {}", qb.class_label()),
+                format!("  entanglement entropy (qubit-0 cut): {entropy:.4} ebits"),
+            ]);
+        }
+```
+
+This needs `qb.class_label()` and `qb.class`. Update `QuantumBackend` in `quantum.rs` to store the class label: add a field `pub class: String` and set it in `from_spec` from the `StateSpec` (e.g. `"dicke(k=2)"`, `"ghz"`, `"basis(i)"`), and add `pub fn class_label(&self) -> &str { &self.class }`. (Add a one-line unit test in `quantum.rs` asserting `from_spec(dicke k=2).class == "dicke(k=2)"`.) Remove the placeholder `let class = …` match — use `qb.class_label()` directly.
+
+- [ ] **Step 4: Implement the STATS branch (optional but expected by REQ-QB-004).** At the start of `exec_stats`, add:
+```rust
+        if let Backend::Quantum(qb) = &self.backend {
+            return Ok(vec![format!(
+                "Quantum LM — {} qubits, {} tokens, class {}",
+                qb.n,
+                qb.tokens.len(),
+                qb.class_label()
+            )]);
+        }
+```
+
+- [ ] **Step 5: Run to verify PASS.** `cargo test -p larql-lql --test test_quantum_backend 2>&1 | tail -8` — all pass. `cargo build -p larql-lql 2>&1 | grep -c warning` → `0`.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add crates/larql-lql/src/executor/quantum.rs crates/larql-lql/src/executor/introspection.rs crates/larql-lql/src/executor/query/describe.rs crates/larql-lql/tests/test_quantum_backend.rs
+git commit -m "feat(lql): quantum-number metadata (STATS/DESCRIBE) + round-trip test"
+```
+(Adjust the `git add` paths to the actual files containing `exec_stats`/`exec_describe` found in Step 0.)
+
+---
+
+## Task 8: The runnable demo
+
+**Files:** Create `crates/larql-lql/examples/quantum_lm_demo.rs`.
+
+**Context:** Mirror the `compile_demo` `section`/`run`/`check` pattern. CI-safe (synthesizes its own vindexes to a tempdir, no model download).
+
+- [ ] **Step 1: Create the demo.** Create `crates/larql-lql/examples/quantum_lm_demo.rs`:
+
+```rust
+//! Quantum LM demo: synthesize Dicke quantum vindexes, USE them through the
+//! real Session, INFER, and verify the Born distribution matches the analytic
+//! ground truth. CI-safe (no model download).
+
+use larql_lql::{parse, Session};
+use std::path::Path;
+
+fn main() {
+    println!("=== Quantum Language Model Demo (Dicke quantum vindexes) ===\n");
+    let tmp = std::env::temp_dir().join("larql_quantum_lm_demo");
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).unwrap();
+
+    let mut all_passed = true;
+    // (name, n, qlm state json, expected nonzero tokens with their %)
+    let cases: &[(&str, usize, &str, &[(&str, f64)])] = &[
+        ("GHZ_3", 3, r#"{ "class": "ghz" }"#, &[("000", 50.0), ("111", 50.0)]),
+        ("W_3 (Dicke k=1)", 3, r#"{ "class": "dicke", "k": 1 }"#,
+            &[("001", 33.33), ("010", 33.33), ("100", 33.33)]),
+        ("Dicke(4,2)", 4, r#"{ "class": "dicke", "k": 2 }"#,
+            &[("0011", 16.67), ("0101", 16.67), ("0110", 16.67),
+              ("1001", 16.67), ("1010", 16.67), ("1100", 16.67)]),
+    ];
+
+    for (name, n, state, expected) in cases {
+        println!("── {name} ──");
+        let dir = tmp.join(name.replace([' ', '(', ')', '='], "_"));
+        std::fs::create_dir_all(&dir).unwrap();
+        write_quantum_vindex(&dir, *n, state);
+
+        let mut s = Session::new();
+        run(&mut s, &format!(r#"USE "{}";"#, dir.display()), "USE");
+        let out = run(&mut s, r#"INFER "" TOP 16;"#, "INFER");
+        let text = out.join("\n");
+        for (tok, pct) in *expected {
+            let pat = format!("{:.2}%", pct);
+            let ok = out.iter().any(|l| l.contains(tok) && l.contains(&pat));
+            check(&format!("{name}: {tok} at {pat}"), ok, &mut all_passed);
+        }
+        println!();
+    }
+
+    // Classicalization seam: a classical op returns the seam error.
+    println!("── classicalization seam ──");
+    let dir = tmp.join("seam");
+    std::fs::create_dir_all(&dir).unwrap();
+    write_quantum_vindex(&dir, 2, r#"{ "class": "ghz" }"#);
+    let mut s = Session::new();
+    s.execute(&parse(&format!(r#"USE "{}";"#, dir.display())).unwrap()).unwrap();
+    let seam = s.execute(&parse("SELECT * FROM EDGES LIMIT 1;").unwrap());
+    check(
+        "SELECT routes to the classicalization seam",
+        seam.is_err() && format!("{:?}", seam).contains("classicalization"),
+        &mut all_passed,
+    );
+    println!();
+
+    let _ = std::fs::remove_dir_all(&tmp);
+    if all_passed {
+        println!("PASS: quantum LMs are usable through larql — INFER reproduces the");
+        println!("  analytic Dicke Born distributions, and classical ops route to the seam.");
+    } else {
+        println!("FAIL: see [FAIL] lines above.");
+        std::process::exit(1);
+    }
+}
+
+fn write_quantum_vindex(dir: &Path, n: usize, state_json: &str) {
+    let vocab = 1usize << n;
+    let index = serde_json::json!({
+        "version": 2, "model": "qlm-demo", "family": "quantum",
+        "num_layers": 1, "hidden_size": n, "intermediate_size": n,
+        "vocab_size": vocab, "embed_scale": 1.0, "layers": [], "down_top_k": 1
+    });
+    std::fs::write(dir.join("index.json"), serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+    std::fs::write(dir.join("qlm.json"),
+        format!(r#"{{ "n_qubits": {n}, "state": {state_json} }}"#)).unwrap();
+}
+
+fn run(s: &mut Session, input: &str, label: &str) -> Vec<String> {
+    let stmt = parse(input).unwrap_or_else(|e| panic!("{label}: parse error: {e}"));
+    match s.execute(&stmt) {
+        Ok(lines) => {
+            println!("  {label}: OK");
+            for l in lines.iter().take(3) { println!("    {l}"); }
+            lines
+        }
+        Err(e) => panic!("{label}: {e}"),
+    }
+}
+
+fn check(label: &str, ok: bool, all_passed: &mut bool) {
+    if ok { println!("    [PASS] {label}"); }
+    else { println!("    [FAIL] {label}"); *all_passed = false; }
+}
+```
+
+- [ ] **Step 2: Build + run the demo.**
+```bash
+cargo run -p larql-lql --example quantum_lm_demo 2>&1 | tail -25
+```
+Expected: every `[PASS]`, final `PASS:` line, exit 0.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add crates/larql-lql/examples/quantum_lm_demo.rs
+git commit -m "docs(lql): quantum_lm_demo — Dicke quantum vindexes through the real Session"
+```
+
+---
+
+## Task 9: Final verification + OpenSpec coverage
+
+**Files:** none (verification) or small annotation fixes.
+
+- [ ] **Step 1: Full sweep.**
+```bash
+cargo test -p larql-hilbert --lib 2>&1 | tail -3
+cargo test -p larql-lql 2>&1 | tail -5
+cargo clippy -p larql-hilbert -p larql-lql 2>&1 | grep -c warning
+cargo run -p larql-lql --example quantum_lm_demo 2>&1 | tail -3
+```
+Expected: all green; clippy `0` (or only pre-existing unrelated warnings — note them).
+
+- [ ] **Step 2: Verify OpenSpec annotations resolve.** For each REQ-QB scenario in `openspec/changes/quantum-backend/specs/quantum-backend/spec.md`, confirm the annotated test exists at the named path and name:
+```bash
+grep -o 'test: [^ ]*' openspec/changes/quantum-backend/specs/quantum-backend/spec.md
+```
+Fix any annotation whose path/name doesn't match an actual `#[test]`.
+
+- [ ] **Step 3: Commit any annotation fixes.**
+```bash
+git add openspec/changes/quantum-backend/ && git commit -m "spec: align REQ-QB test annotations with implemented tests" || echo "nothing to fix"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** REQ-QB-001→T1; -002→T2+T4; -003→T5; -004→T7; -005→T3(classical_view)+T6(seam); -006→T2(reconstruct)+T7(round-trip). All six requirements have backing tasks.
+- **Type consistency:** `QlmSpec { n_qubits, state: StateSpec, tokens }`; `StateSpec::{Dicke{k}, Ghz, Basis{index}}`; `QuantumBackend { lm: NQubitLM, tokens: Vec<String>, token_index: HashMap<String,usize>, n: usize, class: String }` with `from_spec`, `classical_view`, `class_label`; `Backend::Quantum(QuantumBackend)`; `LqlError::QuantumClassicalization`; `NQubit::dicke(n,k)`. Consistent across tasks.
+- **Naive-L=1 honesty:** INFER conditions via `lm.step` (collapse); the entanglement-structured distribution is the empty-prompt one — the demo and tests use `INFER ""`.
+- **Seam is one place:** the three `require_*` accessors; no scattered rejects.
+- **YAGNI:** no `product` state class yet (only dicke/ghz/basis — the three the tests need); `L>0`, hypergraph/feature-basis, and the actual classical-op implementations are explicitly out of scope.

--- a/docs/superpowers/specs/2026-06-12-quantum-backend-design.md
+++ b/docs/superpowers/specs/2026-06-12-quantum-backend-design.md
@@ -1,0 +1,123 @@
+# Quantum Backend (SP1) — Design Spec
+
+**Status:** design, pending implementation plan
+**Date:** 2026-06-12
+**Sub-project:** SP1 of the "usable quantum language models" programme (SP2 = benchmark harness; SP3 = QLM⇄vindex compiler/distiller — both out of scope here).
+
+## Objective
+
+Make the quantum-language-model infrastructure (`larql-hilbert`: `NQubitLM`, `NRegister`, entanglement/compressibility) **actually usable as a language model through larql's real interfaces** — not a mathematical curiosity. Concretely: a quantum model is a real on-disk **quantum vindex** that you `USE`, `INFER`, and inspect through the existing `larql-lql` `Session`, producing ranked next-token predictions. This is the foundation the benchmark (SP2, quantum vs (semi)classical) and the compiler/distiller (SP3) build on.
+
+## Theory: the functor G — why a quantum vindex is specified by its quantum numbers
+
+larql treats an LLM as a (hyper)graph database (nodes/edges/features/layers). A quantum vindex is the image of that structure under a strong monoidal functor **G: GraphDB → FdHilb** — the same categorical-quantum-mechanics bridge that underlies DisCoCat/QNLP (a pregroup grammar and FdHilb are both compact-closed categories; meaning is a strong monoidal functor between them). The dagger (inner product / Born metric) is what canonicalization installs.
+
+| larql graph-DB structure | FdHilb image (under G) | Quantum number |
+|---|---|---|
+| Alphabet `V` | `H = ℂ^d`, `d = \|V\|` | **n = ⌈log₂\|V\|⌉** (the dimension *is* the alphabet size) |
+| Node / token | basis vector `\|i⟩` | the n-bit occupation label `i` |
+| Edge (relation / coupling) | off-diagonal coherence / entangling morphism | the **entanglement (hyper)graph** |
+| Feature (FFN node) | effect / projector — a measurement observable | the **readout basis** (set by the dagger) |
+| Layer | one dagger-composable unitary | **L** — circuit depth |
+| dagger † | inner product = Born metric | installed by canonicalization |
+
+Because the alphabet fixes `n` and the entanglement structure fixes the state, the quantum vindex is **completely specified by its quantum numbers** — the amplitude vector, Born distribution, and entanglement are all *derived* by G, never stored. This is the model-level analogue of the canonical pipeline's "irreducible description = compressibility."
+
+**Two state families, assigned to the two directions** (validated against the literature on graph/hypergraph states):
+- **Synthesis (this SP) → family A: Dicke / angular-momentum `(n, k)` (amplitude-entangled).** `\|D^n_k⟩` (with `W = D^n_1`, plus the GHZ cat state) have *structured* computational-basis amplitudes, so they are an immediately non-trivial language model in the token basis — the entanglement shows up directly as structure in the next-token Born distribution (the existing `TwoQubitLM` "Bell forbids 01/10" behavior). No feature basis needed.
+- **Distillation (SP3) → family B: hypergraph states + feature readout basis (phase-entangled).** Canonical hypergraph states have *flat* computational-basis amplitudes (entanglement in the phases), so they only become a non-trivial LM when read out in a feature basis — exactly the dagger/metric that canonicalization installs. Out of scope here; noted so SP1's artifact format is forward-compatible.
+
+Sources: graph/hypergraph states ([review](https://arxiv.org/abs/2603.10917), [Graph state](https://en.wikipedia.org/wiki/Graph_state)); DisCoCat / categorical quantum NLP ([DisCoCat](https://en.wikipedia.org/wiki/DisCoCat)); LLM-as-hypergraph-DB ([modeling hypergraphs with LLMs](https://arxiv.org/pdf/2510.11728)).
+
+## Architecture
+
+Five units, each independently testable.
+
+### 1. The Dicke quantum vindex (artifact)
+
+A real vindex directory, discriminated by `index.json`'s `family` field, plus a `qlm.json` carrying **only the quantum numbers**:
+
+- `index.json` — a `VindexConfig` with `family: "quantum"`, `model: "<name>"`, `vocab_size: 2^n`, `num_layers: 1` (naive depth), and the other required fields (`version`, `hidden_size`, `intermediate_size`, `embed_scale`, `layers: []`, `down_top_k`). `family == "quantum"` is the loader discriminator.
+- `qlm.json`:
+  ```json
+  { "n_qubits": 3, "state": { "class": "dicke", "k": 1 } }
+  ```
+  `state.class ∈ { "dicke" (+ "k"), "ghz", "basis" (+ "index"), "product" (+ "bloch": [[θ,φ], …]) }`. Optional `"tokens": [<2^n strings>]`; default token labels are the n-bit occupation strings (`"000".."111"`), so token `"101"` ≡ basis state `\|101⟩`.
+
+The state `\|ψ⟩` is **reconstructed** from `(n, class, k)` at load time. Nothing derived is serialized.
+
+### 2. The quantum backend (`larql-lql`)
+
+- Add `larql-hilbert` as a dependency of `larql-lql`.
+- New `Backend::Quantum(QuantumBackend)` variant where
+  ```rust
+  pub struct QuantumBackend {
+      lm: NQubitLM,
+      tokens: Vec<String>,          // length 2^n
+      token_index: HashMap<String, usize>,
+      n: usize,
+  }
+  ```
+- A reconstruction helper builds `init` from the quantum numbers (`NQubit::ghz/w/dicke/basis/product`) with identity `post` gates (naive `L = 1`).
+- `executor/lifecycle/use_cmd.rs` branches on `config.family == "quantum"` and builds `Backend::Quantum`.
+
+**Required `larql-hilbert` addition:** `NQubit::dicke(n, k)` — the equal superposition of all Hamming-weight-`k` basis states, `(1/√C(n,k)) Σ_{\|x\|=k} \|x⟩`. (`w(n)` becomes `dicke(n, 1)`; `ghz` already exists.) Added test-first.
+
+### 3. INFER semantics (the usable LM output)
+
+`INFER "<prompt>" TOP k` on the quantum backend:
+1. Tokenize the prompt by whitespace; map each word to a token id via `token_index` (unknown word → clean `LqlError`).
+2. Condition the state by stepping the `NQubitLM` over the prompt token ids (each observed token collapses + applies its `post`-gates).
+3. Return the **Born next-token distribution** of the resulting state (`next_distribution`), rendered as ranked `N. <token> (XX.XX%)` lines, truncated to `TOP k`.
+4. Empty prompt → the init Dicke distribution — the entanglement-structured one (GHZ₃ → `000`/`111` @ 50%; W₃ → the three weight-1 tokens @ 33%; Dicke(4,2) → the six weight-2 tokens; product → independent per-qubit).
+
+> **Honest note on conditioning:** on the naive `L=1` (identity-`post`) model, stepping over a non-empty prompt collapses the state to the last observed token, so a *conditioned* next-token distribution is deterministic (`δ` at the last token). The rich, entanglement-revealing distribution is therefore the **unconditioned (empty-prompt)** one — that is what the demo and the headline output showcase. Non-trivial conditioning needs `L > 0` re-mixing dynamics (out of scope, above).
+
+`STATS` / `SHOW MODELS` / `SHOW LAYERS` / `DESCRIBE` report the quantum numbers (`n`, `class`, `k`, vocab size, derived entropy in ebits via the existing `entanglement_entropy_bipartition`).
+
+> **Scope boundary:** multi-token *generation* with non-trivial dynamics requires depth `L > 0` (per-step re-mixing unitaries). SP1 ships the single-step next-token distribution (the inspectable, entanglement-revealing output) and the metadata path; `L > 0` autoregressive generation is a clearly-bounded extension, not SP1.
+
+### 4. Supported set + the classicalization seam
+
+- **Native quantum ops:** `USE`, `INFER`, `STATS`, `SHOW MODELS/LAYERS`, `DESCRIBE` (quantum numbers).
+- **Everything else** (`WALK`, `SELECT`, `INSERT`/`DELETE`/`UPDATE`/`MERGE`, `COMPILE`, `TRACE`, `COMPACT`, `EXPLAIN`-with-attention) routes through **one** extension point:
+  ```rust
+  impl QuantumBackend {
+      /// The dephased/measured classical view of the QLM — the seam through
+      /// which the classical vindex operations will be served by measuring the
+      /// quantum state (a later sub-project). NOT faithful to quantum theory
+      /// (measurement destroys coherence) but makes the QLM eventually support
+      /// the full LQL surface.
+      fn classical_view(&self) -> ClassicalRegister { /* born_probs → ClassicalRegister */ }
+  }
+  ```
+  In SP1 the dispatch for these statements calls a single `classicalize_or_unsupported(stmt)` that returns one uniform `LqlError` — *"<stmt> is served by the classicalization layer, not yet wired on the quantum backend"* — from **one** place (mirroring the existing `NoBackend` pattern), not scattered reject arms. A later sub-project implements the classicalization (measure/dephase the QLM → a classical register/vindex-view → run the op) without touching dispatch. `classical_view()` is the same dephasing map (`NQubit → ClassicalRegister`) the SP2 benchmark uses for the "(semi)classical" comparison.
+
+### 5. Verification harness
+
+- **Demo** `crates/larql-lql/examples/quantum_lm_demo.rs` (the `section`/`run`/`run_capture`/`check` pattern, CI-safe, no model download): synthesize GHZ₃, W₃, Dicke(4,2), and a product quantum vindex to a tempdir; `USE` each through `Session`; `INFER` and print the ranked Born distribution; `check` that the rendered distribution matches the analytic Dicke ground truth (GHZ₃ → only `000`/`111` @ 50%; W₃ → only weight-1 @ 33%), that an entanglement-forbidden token is ≈0, and that an unsupported statement returns the uniform classicalization-seam error. Prints a PASS/FAIL narrative, exits non-zero on any failure.
+- **Integration tests** `crates/larql-lql/tests/test_quantum_backend.rs` (CI-enforced, always run): synthesize → `USE` → `INFER` distribution equals `NQubitLM::next_distribution` within `1e-9`; the `(n, class, k)` quantum numbers round-trip through the artifact (write `qlm.json` → load → reconstructed Born equals the analytic Dicke distribution); an unsupported statement returns the classicalization-seam error; `DESCRIBE` reports the correct quantum numbers.
+
+All harness paths drive the real `Session::execute` surface — proving the QLM is usable *through larql*, not merely as a library object.
+
+## Data flow
+
+`qlm.json (quantum numbers) → reconstruct NQubitLM (G applied) → Backend::Quantum → Session::execute(INFER) → Born next-token distribution → ranked tokens`. The classical ops branch: `→ classical_view() (dephase) → [future: classical vindex op]`.
+
+## Error handling
+
+- Unknown token in an `INFER` prompt → `LqlError` naming the unknown word.
+- Malformed `qlm.json` (bad class, `k > n`, vocab/`2^n` mismatch) → `LqlError` at `USE` time, naming the violated quantum-number constraint.
+- Unsupported statement → the single uniform classicalization-seam `LqlError`.
+- `n` out of range (`n ≥ 64` or `< 1`) → reuse `larql-hilbert`'s existing `(1..64)` guard.
+
+## Out of scope (explicit)
+
+- `L > 0` autoregressive generation dynamics.
+- Family B (hypergraph + feature-basis) and distillation (SP3).
+- The benchmark harness comparing quantum vs (semi)classical (SP2).
+- Implementing the classical vindex operations via classicalization (a later sub-project) — SP1 only provides the seam.
+
+## Testing strategy
+
+TDD throughout. `NQubit::dicke` is added test-first in `larql-hilbert`. The backend reconstruction, INFER rendering, and the classicalization-seam dispatch each get unit tests; the end-to-end `USE`→`INFER` path is covered by the integration tests above. Ground truth is the analytic Dicke Born distribution, so every assertion is exact (no model download, no fixture drift).

--- a/openspec/changes/quantum-backend/proposal.md
+++ b/openspec/changes/quantum-backend/proposal.md
@@ -1,0 +1,54 @@
+# Proposal: Quantum Backend (usable QLM via larql)
+
+## Status: in-flight
+
+## Why
+
+The QLM infrastructure (`larql-hilbert`: `NQubitLM`, `NRegister`, entanglement)
+is mathematically complete but not *usable* — it has never been driven as a
+language model through larql's real interfaces. This change makes a quantum
+model a real on-disk **quantum vindex** that the existing `larql-lql` `Session`
+can `USE` and `INFER`, producing ranked next-token predictions. It is SP1 of the
+"usable quantum language models" programme (SP2 = quantum-vs-(semi)classical
+benchmark; SP3 = QLM⇄vindex compiler/distiller).
+
+Design: `docs/superpowers/specs/2026-06-12-quantum-backend-design.md`.
+
+## What
+
+1. `NQubit::dicke(n, k)` — the missing Dicke (angular-momentum `(n,k)`) state
+   constructor (`w` = `dicke(n,1)`).
+2. The **Dicke quantum vindex** artifact: a vindex dir with `index.json`
+   (`family: "quantum"`) + `qlm.json` carrying *only the quantum numbers*
+   `(n, state-class, k)`. The state is reconstructed, never stored — "completely
+   specified by its quantum numbers."
+3. `Backend::Quantum` in `larql-lql`: `USE` branches on `family == "quantum"`;
+   `INFER` returns the Born next-token distribution rendered as ranked tokens;
+   `STATS`/`SHOW`/`DESCRIBE` report the quantum numbers.
+4. The **classicalization seam**: every non-native statement routes through one
+   extension point (`classical_view()` → a dephased `ClassicalRegister`) and
+   returns a single uniform error, so a later sub-project can serve the classical
+   vindex operations by measuring the QLM without touching dispatch.
+
+## Non-goals (this change)
+
+- `L > 0` autoregressive generation dynamics (per-step re-mixing unitaries).
+- Family B (hypergraph + feature-basis readout) and distillation — SP3.
+- The benchmark harness comparing quantum vs (semi)classical — SP2.
+- Implementing the classical ops via classicalization — a later sub-project
+  (this change only provides the seam).
+
+## Related
+
+- Design spec: `docs/superpowers/specs/2026-06-12-quantum-backend-design.md`.
+- Builds on: the `quantum-language-model` capability (`qlm-foundation` change) —
+  `NQubitLM`, `NRegister`, `entanglement_entropy_bipartition`.
+- Theory: graph/hypergraph states; DisCoCat / categorical quantum NLP (the
+  functor G: graph-DB → FdHilb); LLM-as-hypergraph-database.
+
+## Risk
+
+Low–moderate. Additive: a new `Backend` variant and a new vindex `family`;
+nothing in the classical inference path changes. The one cross-crate edge is
+`larql-lql → larql-hilbert` (new). Ground truth is the analytic Dicke Born
+distribution, so all assertions are exact (no model download).

--- a/openspec/changes/quantum-backend/specs/quantum-backend/spec.md
+++ b/openspec/changes/quantum-backend/specs/quantum-backend/spec.md
@@ -97,6 +97,14 @@ derived entanglement entropy in ebits).
 
 <!-- test: crates/larql-lql/tests/test_quantum_backend.rs::describe_reports_quantum_numbers -->
 
+#### Scenario: STATS / SHOW LAYERS report the quantum numbers and entropy
+
+`STATS` and `SHOW LAYERS` on a `dicke(4,2)` quantum vindex report the qubit
+count, class, vocabulary, and the derived entanglement entropy in ebits.
+
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::stats_reports_quantum_numbers_and_entropy -->
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::show_layers_reports_quantum_numbers -->
+
 ---
 
 ### REQ-QB-005: Classicalization seam for non-native statements

--- a/openspec/changes/quantum-backend/specs/quantum-backend/spec.md
+++ b/openspec/changes/quantum-backend/specs/quantum-backend/spec.md
@@ -1,0 +1,139 @@
+## ADDED Requirements: quantum-backend
+
+### REQ-QB-001: Dicke state constructor
+
+`larql-hilbert` SHALL provide `NQubit::dicke(n, k)` — the normalized equal
+superposition of all `n`-qubit computational-basis states of Hamming weight `k`,
+`(1/√C(n,k)) · Σ_{|x|=k} |x⟩` — with `w(n)` equal to `dicke(n, 1)` and `k ≤ n`
+required.
+
+#### Scenario: Dicke(n,1) is the W state
+
+`dicke(3, 1)` equals `w(3)` (uniform amplitude on `001`, `010`, `100`).
+
+<!-- test: crates/larql-hilbert/src/nqubit.rs::tests::dicke_one_excitation_is_w -->
+
+#### Scenario: Dicke(4,2) is uniform over the weight-2 sector
+
+`dicke(4, 2)` puts equal Born mass `1/6` on each of the six weight-2 basis
+states and zero elsewhere.
+
+<!-- test: crates/larql-hilbert/src/nqubit.rs::tests::dicke_two_excitations_uniform_weight2 -->
+
+#### Scenario: k greater than n panics
+
+`dicke(2, 3)` panics naming the `k ≤ n` constraint.
+
+<!-- test: crates/larql-hilbert/src/nqubit.rs::tests::dicke_rejects_k_above_n -->
+
+---
+
+### REQ-QB-002: Quantum vindex artifact and loader
+
+The system SHALL load a vindex directory whose `index.json` has
+`family == "quantum"` together with a `qlm.json` carrying only the quantum
+numbers `{ n_qubits, state: { class, k? } }`, reconstructing an `NQubitLM` into
+`Backend::Quantum`. Malformed quantum numbers (unknown class, `k > n`, or
+`vocab_size ≠ 2^n`) SHALL return an `LqlError` at `USE` time naming the violated
+constraint.
+
+#### Scenario: USE a quantum vindex builds the quantum backend
+
+`USE "ghz3.vindex"` (family quantum, `n=3`, class ghz) succeeds and subsequent
+`INFER` is served by the quantum backend.
+
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::use_quantum_vindex_builds_backend -->
+
+#### Scenario: malformed quantum numbers error at USE
+
+A `qlm.json` with `k > n` returns an `LqlError` at `USE` naming the `k ≤ n`
+constraint.
+
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::use_rejects_bad_quantum_numbers -->
+
+---
+
+### REQ-QB-003: INFER returns the Born next-token distribution
+
+`INFER "<prompt>" TOP k` on the quantum backend SHALL tokenize the prompt
+against the vocabulary, condition the state on the prompt tokens, and return the
+Born next-token distribution rendered as ranked `N. <token> (XX.XX%)` lines
+truncated to `k`. For the empty prompt the distribution SHALL equal
+`NQubitLM::next_distribution(init)`. An unknown prompt token SHALL return an
+`LqlError` naming the word.
+
+#### Scenario: GHZ_3 ranks only the correlated tokens
+
+`INFER ""` on a GHZ_3 quantum vindex ranks `000` and `111` at 50% each and all
+other tokens at 0%.
+
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::infer_ghz_ranks_correlated_tokens -->
+
+#### Scenario: rendered distribution equals the model distribution
+
+The INFER probabilities equal `NQubitLM::next_distribution(init)` within `1e-9`.
+
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::infer_matches_next_distribution -->
+
+#### Scenario: unknown prompt token errors
+
+`INFER "qux"` against a vocabulary lacking `qux` returns an `LqlError` naming
+`qux`.
+
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::infer_unknown_token_errors -->
+
+---
+
+### REQ-QB-004: Quantum-number metadata operations
+
+`STATS`, `SHOW MODELS`, `SHOW LAYERS`, and `DESCRIBE` on the quantum backend
+SHALL report the quantum numbers (`n`, state class, `k`, vocabulary size, and a
+derived entanglement entropy in ebits).
+
+#### Scenario: DESCRIBE reports the quantum numbers
+
+`DESCRIBE` on a `dicke(4,2)` quantum vindex reports `n = 4`, class `dicke`,
+`k = 2`, vocabulary `16`.
+
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::describe_reports_quantum_numbers -->
+
+---
+
+### REQ-QB-005: Classicalization seam for non-native statements
+
+Statements not natively supported on the quantum backend (`WALK`, `SELECT`,
+`INSERT`/`DELETE`/`UPDATE`/`MERGE`, `COMPILE`, `TRACE`, `COMPACT`) SHALL be
+routed through a single classicalization extension point and return one uniform
+`LqlError` indicating the operation is served by the (not-yet-wired)
+classicalization layer. The backend SHALL expose `classical_view()` returning
+the dephased `ClassicalRegister` (the `NQubit → born_probs` map) that the seam is
+built on.
+
+#### Scenario: an unsupported statement returns the seam error
+
+`SELECT * FROM EDGES` on the quantum backend returns the uniform
+classicalization-seam `LqlError`.
+
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::unsupported_statement_hits_classicalization_seam -->
+
+#### Scenario: classical_view is the dephased Born register
+
+`classical_view()` of a `dicke(4,2)` backend equals a `ClassicalRegister` whose
+distribution is the state's `born_probs()`.
+
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::classical_view_is_dephased_born -->
+
+---
+
+### REQ-QB-006: Quantum numbers completely specify the vindex (round-trip)
+
+The artifact SHALL persist only the quantum numbers; the state reconstructed at
+load SHALL reproduce the analytic Dicke Born distribution, so the round-trip
+(write quantum numbers → load → measure) is exact.
+
+#### Scenario: (n, class, k) round-trips exactly
+
+Writing `qlm.json` for `dicke(4,2)`, loading it, and reading the backend's Born
+distribution reproduces the analytic weight-2 distribution within `1e-9`.
+
+<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::quantum_numbers_round_trip -->

--- a/openspec/changes/quantum-backend/specs/quantum-backend/spec.md
+++ b/openspec/changes/quantum-backend/specs/quantum-backend/spec.md
@@ -121,7 +121,7 @@ classicalization-seam `LqlError`.
 `classical_view()` of a `dicke(4,2)` backend equals a `ClassicalRegister` whose
 distribution is the state's `born_probs()`.
 
-<!-- test: crates/larql-lql/tests/test_quantum_backend.rs::classical_view_is_dephased_born -->
+<!-- test: crates/larql-lql/src/executor/quantum.rs::tests::classical_view_is_dephased_born -->
 
 ---
 


### PR DESCRIPTION
## Summary

**SP1 of the "usable quantum language models" programme:** a quantum language model is now a real on-disk **quantum vindex** you `USE` and `INFER` through the existing `larql-lql` `Session` — the QLM infrastructure goes from mathematical curiosity to a model you actually drive through larql.

Spec: `docs/superpowers/specs/2026-06-12-quantum-backend-design.md`. OpenSpec: `openspec/changes/quantum-backend/` (REQ-QB-001…006, every scenario test-annotated). Built brainstorm → spec → plan → subagent-driven TDD, with two Opus review rounds (integration + final), all findings fixed.

## What it does

A quantum vindex is a directory with `index.json` (`family: "quantum"`) + `qlm.json` carrying **only the quantum numbers** `(n, class, k)` — the state is *reconstructed*, nothing derived is stored ("completely specified by its quantum numbers"). The entanglement shows up directly as structure in the next-token Born distribution:

```
USE "ghz3.vindex";  INFER "" TOP 4;
  Predictions (quantum — Born rule):
     1. 000  (50.00%)
     2. 111  (50.00%)     ← GHZ_3: only the correlated tokens carry mass
```
W₃ → the three weight-1 tokens @ 33.33%; Dicke(4,2) → the six weight-2 tokens @ 16.67%.

## Theory grounding (the functor G)

The mapping graph-DB → FdHilb is **DisCoCat / categorical quantum mechanics**; the alphabet fixes `n = ⌈log₂|V|⌉`, the entanglement structure fixes the state (**graph/hypergraph states**). Synthesis uses **family A — Dicke `(n,k)`** (amplitude-entangled, structured Born distribution); the phase-entangled hypergraph family + feature/canonicalization readout is reserved for distillation (SP3).

## Components

| Unit | What |
|---|---|
| `NQubit::dicke(n,k)` | Dicke state (larql-hilbert); `w = dicke(n,1)` |
| `executor/quantum.rs` | `QlmSpec`/`StateSpec` (serde), state reconstruction, `QuantumBackend` + `classical_view()` |
| `Backend::Quantum` + `USE` branch | `family == "quantum"` → reconstruct → serve (no FFN load) |
| `INFER` | renders the Born next-token distribution as ranked tokens |
| **Classicalization seam** | one extension point (`Backend::Quantum` arm in the three `require_*` accessors) → every classical op (`WALK`/`SELECT`/mutations/`COMPILE`/`MERGE`/`TRACE`/`COMPACT`) returns one uniform `QuantumClassicalization` error; `classical_view()` is the dephased `ClassicalRegister` the seam is built on |
| `STATS`/`SHOW`/`DESCRIBE` | report the quantum numbers + entanglement entropy (ebits) |
| `examples/quantum_lm_demo.rs` | runnable, CI-safe; INFER vs analytic Dicke ground truth |

## Verification

larql-hilbert **120** lib tests; quantum integration **13**; `executor::quantum` **8**; CI clippy (`--all-targets -- -D warnings`) **clean**; demo runs all-PASS. All 12 REQ-QB scenario annotations resolve to passing tests.

## Scope (SP1 boundary)

Out of scope, by design: `L>0` autoregressive dynamics; family B (hypergraph + feature basis) / distillation (SP3); the quantum-vs-(semi)classical benchmark (SP2); implementing the classical ops via classicalization (a later sub-project — SP1 only ships the seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
