### PR TITLE
fix(larql-cli): replace tensor key .unwrap() with actionable errors

### DIFF
--- a/crates/larql-cli/src/commands/extraction/attn_bottleneck_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/attn_bottleneck_cmd.rs
@@ -54,10 +54,14 @@ pub fn run(args: AttnBottleneckArgs) -> Result<(), Box<dyn std::error::Error>> {
     let norm_offset = arch.norm_weight_offset();
     let iters = args.iterations;
 
-    let w_q = weights.tensors.get(&arch.attn_q_key(layer)).unwrap();
-    let w_k = weights.tensors.get(&arch.attn_k_key(layer)).unwrap();
-    let w_v = weights.tensors.get(&arch.attn_v_key(layer)).unwrap();
-    let w_o = weights.tensors.get(&arch.attn_o_key(layer)).unwrap();
+    let w_q = weights.tensors.get(&arch.attn_q_key(layer))
+        .ok_or_else(|| format!("tensor '{}' not found (layer {})", arch.attn_q_key(layer), layer))?;
+    let w_k = weights.tensors.get(&arch.attn_k_key(layer))
+        .ok_or_else(|| format!("tensor '{}' not found (layer {})", arch.attn_k_key(layer), layer))?;
+    let w_v = weights.tensors.get(&arch.attn_v_key(layer))
+        .ok_or_else(|| format!("tensor '{}' not found (layer {})", arch.attn_v_key(layer), layer))?;
+    let w_o = weights.tensors.get(&arch.attn_o_key(layer))
+        .ok_or_else(|| format!("tensor '{}' not found (layer {})", arch.attn_o_key(layer), layer))?;
 
     let q_dim = num_q * head_dim;
     let kv_dim = num_kv * head_dim;

--- a/crates/larql-cli/src/commands/extraction/compile_cmd/edge.rs
+++ b/crates/larql-cli/src/commands/extraction/compile_cmd/edge.rs
@@ -94,21 +94,21 @@ pub fn install_edge(
     let alpha = (d_norm / write_norm) * alpha_mul;
 
     {
-        let gt = tensors.get_mut(gate_key).unwrap();
+        let gt = tensors.get_mut(gate_key).expect("gate key verified above");
         let hidden = gt.shape()[1];
         for j in 0..hidden.min(trigger.len()) {
             gt[[slot, j]] = trigger[j] * g_scale;
         }
     }
     {
-        let ut = tensors.get_mut(up_key).unwrap();
+        let ut = tensors.get_mut(up_key).expect("up key verified above");
         let hidden = ut.shape()[1];
         for j in 0..hidden.min(trigger.len()) {
             ut[[slot, j]] = trigger[j] * u_scale;
         }
     }
     {
-        let dt = tensors.get_mut(down_key).unwrap();
+        let dt = tensors.get_mut(down_key).expect("down key verified above");
         let hidden = dt.shape()[0];
         for j in 0..hidden.min(write.len()) {
             dt[[j, slot]] = write[j] * alpha;

--- a/crates/larql-cli/src/commands/extraction/ffn_bottleneck_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/ffn_bottleneck_cmd.rs
@@ -48,9 +48,12 @@ pub fn run(args: FfnBottleneckArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let layer = args.layer;
     let arch = &*weights.arch;
-    let w_gate = weights.tensors.get(&arch.ffn_gate_key(layer)).unwrap();
-    let w_up = weights.tensors.get(&arch.ffn_up_key(layer)).unwrap();
-    let w_down = weights.tensors.get(&arch.ffn_down_key(layer)).unwrap();
+    let w_gate = weights.tensors.get(&arch.ffn_gate_key(layer))
+        .ok_or_else(|| format!("tensor '{}' not found (layer {})", arch.ffn_gate_key(layer), layer))?;
+    let w_up = weights.tensors.get(&arch.ffn_up_key(layer))
+        .ok_or_else(|| format!("tensor '{}' not found (layer {})", arch.ffn_up_key(layer), layer))?;
+    let w_down = weights.tensors.get(&arch.ffn_down_key(layer))
+        .ok_or_else(|| format!("tensor '{}' not found (layer {})", arch.ffn_down_key(layer), layer))?;
     let intermediate = w_gate.shape()[0];
 
     eprintln!(

--- a/crates/larql-cli/src/commands/extraction/ffn_overlap_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/ffn_overlap_cmd.rs
@@ -54,7 +54,8 @@ pub fn run(args: FfnOverlapArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     for (layer, residual_vec) in &trace.residuals {
         let arch = &*weights.arch;
-        let w_gate = weights.tensors.get(&arch.ffn_gate_key(*layer)).unwrap();
+        let w_gate = weights.tensors.get(&arch.ffn_gate_key(*layer))
+            .ok_or_else(|| format!("tensor '{}' not found (layer {})", arch.ffn_gate_key(*layer), layer))?;
         let _hidden = weights.hidden_size;
 
         // Ground truth: actual gate matmul on the residual


### PR DESCRIPTION
## Summary

Fixes 7 tensor key lookups in extraction commands that panicked with `called Option::unwrap() on a None value` when a tensor key was absent — giving no information about what was missing.

Closes #223

## Affected commands

| File | Lines | Tensors |
|------|-------|---------|
| `attn_bottleneck_cmd.rs` | 57–60 | Q, K, V, O weight matrices |
| `ffn_bottleneck_cmd.rs` | 51–53 | gate, up, down weight matrices |
| `ffn_overlap_cmd.rs` | 57 | gate weight matrix in layer loop |
| `compile_cmd/edge.rs` | 97, 104, 111 | get_mut after verified existence |

## Before vs after

```
# Before
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', ...

# After (attn/ffn bottleneck commands)
Error: "tensor 'blk.20.attn_q.weight' not found (layer 20)"
```

For `compile_cmd/edge.rs`, the three `get_mut()` calls at lines 97/104/111 are after the keys are already verified at lines 76/82/88. Changed to `expect("key verified above")` to make the invariant explicit.

## Test plan

- `cargo check -p larql-cli` passes ✓
- No behavioral change when tensors exist
- Missing tensors now return a readable error instead of panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)