### PR TITLE
feat(codebase): query-driven language extractors — 8 languages, N-Triples serializer, Tier-0 wasm32v1-none

### DIFF
--- a/.github/workflows/tier0.yml
+++ b/.github/workflows/tier0.yml
@@ -16,5 +16,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build Tier-0 crates for wasm32v1-none
         run: |
+          # larql-codebase-core includes the languages/ module (EdgeTemplate, query tables,
+          # LQL adapter, compilation matrix) — all must compile for wasm32v1-none.
           cargo build --target wasm32v1-none -p larql-codebase-core
           cargo build --target wasm32v1-none -p larql-lql-core

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,6 +2183,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tree-sitter",
+ "tree-sitter-java",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
@@ -2193,6 +2194,7 @@ dependencies = [
 name = "larql-codebase-core"
 version = "0.1.0"
 dependencies = [
+ "larql-lql-core",
  "libm",
  "serde",
  "thiserror 2.0.18",
@@ -4900,6 +4902,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a818c0d883d7c0801df27be910917750932be279c7bc82dc541b8769425f409"
+dependencies = [
+ "combine",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,12 +2194,14 @@ dependencies = [
 name = "larql-codebase"
 version = "0.1.0"
 dependencies = [
+ "graphql-parser",
  "larql-codebase-core",
  "larql-core",
  "larql-models",
  "larql-vindex",
  "serde",
  "serde_json",
+ "spargebra",
  "tempfile",
  "thiserror 2.0.18",
  "tree-sitter",
@@ -3136,6 +3158,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "oxilangtag"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3b4eb570abd4a1dcb062c31fd37b832264d9dc7292c3e69acfe926c87b063f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "oxiri"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4ed3a7192fa19f5f48f99871f2755047fabefd7f222f12a1df1773796a102"
+
+[[package]]
+name = "oxrdf"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0afd5c28e4a399c57ee2bc3accd40c7b671fdc7b6537499f14e95b265af7d7e0"
+dependencies = [
+ "oxilangtag",
+ "oxiri",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,6 +3212,33 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "peg"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aad070be5b63aa72103f2fcdd70a83adbd5e90112ce5b574171ff1c65501773"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd8ef6825cae95355031ae26a99b616a2a21f22ba2de0197c43dfb05acbe7ee"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7011d97b484a5ebdc4b1fdb3b12d5e4bbbea56e9d22b688f2e79e04b65a7d8a6"
 
 [[package]]
 name = "pem"
@@ -4333,6 +4409,20 @@ dependencies = [
  "byteorder",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spargebra"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46715eb957d1fe960cbbc0b713da8f78e2cb19df315b48fb09c9467a1c84f656"
+dependencies = [
+ "oxilangtag",
+ "oxiri",
+ "oxrdf",
+ "peg",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -2210,6 +2215,8 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "walkdir",
+ "wasmparser 0.252.0",
+ "wat",
 ]
 
 [[package]]
@@ -5378,12 +5385,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.247.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.247.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -5425,13 +5432,15 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.247.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags 2.11.1",
+ "hashbrown 0.17.0",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -5697,24 +5706,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "247.0.0"
+version = "252.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.252.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.247.0"
+version = "1.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
 dependencies = [
- "wast 247.0.0",
+ "wast 252.0.0",
 ]
 
 [[package]]

--- a/crates/larql-cli/src/commands/extraction/extract_codebase_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_codebase_cmd.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::Args;
 use larql_codebase::extract_codebase;
-use larql_codebase::graph_to_nquads;
+use larql_codebase::graph_to_ntriples;
 use larql_codebase::graph_to_weight_repr;
 use larql_codebase::write_weight_repr_to_gguf;
 use larql_codebase_core::basis::BitNetBasis;
@@ -17,7 +17,7 @@ pub struct ExtractCodebaseArgs {
     #[arg(short, long, default_value = "codebase.vindex")]
     output: PathBuf,
 
-    /// Output format: "json" (default) or "nquads" (RDFC-1.0 sorted N-Quads)
+    /// Output format: "json" (default) or "ntriples" (RDFC-1.0 sorted N-Triples)
     #[arg(long, default_value = "json")]
     format: String,
 }
@@ -33,11 +33,11 @@ pub fn run(args: ExtractCodebaseArgs) -> Result<(), Box<dyn std::error::Error>> 
         graph.edge_count()
     );
 
-    if args.format == "nquads" {
-        let nquads = graph_to_nquads(&graph, "urn:larql:");
-        let nq_path = args.output.with_extension("nq");
-        std::fs::write(&nq_path, &nquads)?;
-        eprintln!("  N-Quads written to: {}", nq_path.display());
+    if args.format == "ntriples" {
+        let ntriples = graph_to_ntriples(&graph, "urn:larql:");
+        let nt_path = args.output.with_extension("nt");
+        std::fs::write(&nt_path, &ntriples)?;
+        eprintln!("  N-Triples written to: {}", nt_path.display());
         return Ok(());
     }
 

--- a/crates/larql-cli/src/commands/extraction/extract_codebase_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_codebase_cmd.rs
@@ -36,6 +36,9 @@ pub fn run(args: ExtractCodebaseArgs) -> Result<(), Box<dyn std::error::Error>> 
     if args.format == "ntriples" {
         let ntriples = graph_to_ntriples(&graph, "urn:larql:");
         let nt_path = args.output.with_extension("nt");
+        if let Some(parent) = nt_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
         std::fs::write(&nt_path, &ntriples)?;
         eprintln!("  N-Triples written to: {}", nt_path.display());
         return Ok(());

--- a/crates/larql-cli/src/commands/extraction/extract_codebase_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_codebase_cmd.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use clap::Args;
 use larql_codebase::extract_codebase;
+use larql_codebase::graph_to_nquads;
 use larql_codebase::graph_to_weight_repr;
 use larql_codebase::write_weight_repr_to_gguf;
 use larql_codebase_core::basis::BitNetBasis;
@@ -15,6 +16,10 @@ pub struct ExtractCodebaseArgs {
     /// Output vindex directory (created if absent).
     #[arg(short, long, default_value = "codebase.vindex")]
     output: PathBuf,
+
+    /// Output format: "json" (default) or "nquads" (RDFC-1.0 sorted N-Quads)
+    #[arg(long, default_value = "json")]
+    format: String,
 }
 
 pub fn run(args: ExtractCodebaseArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -27,6 +32,14 @@ pub fn run(args: ExtractCodebaseArgs) -> Result<(), Box<dyn std::error::Error>> 
         graph.node_count(),
         graph.edge_count()
     );
+
+    if args.format == "nquads" {
+        let nquads = graph_to_nquads(&graph, "urn:larql:");
+        let nq_path = args.output.with_extension("nq");
+        std::fs::write(&nq_path, &nquads)?;
+        eprintln!("  N-Quads written to: {}", nq_path.display());
+        return Ok(());
+    }
 
     let repr = graph_to_weight_repr(&graph, &BitNetBasis);
     eprintln!("  {} weight tensors synthesised", repr.tensors.len());

--- a/crates/larql-codebase-core/Cargo.toml
+++ b/crates/larql-codebase-core/Cargo.toml
@@ -10,3 +10,4 @@ description = "Codebase-to-model weight derivation — pure Tier-0 (wasm32v1-non
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 thiserror = { version = "2", default-features = false }
 libm = { version = "0.2", default-features = false }
+larql-lql-core = { path = "../larql-lql-core" }

--- a/crates/larql-codebase-core/src/languages/edge_template.rs
+++ b/crates/larql-codebase-core/src/languages/edge_template.rs
@@ -20,7 +20,7 @@ pub enum Endpoint {
 /// `query` is a standard tree-sitter S-expression pattern string. It is stored
 /// as `&'static str` (Tier-0 data) and compiled to a `tree_sitter::Query`
 /// by the Tier-1 `QueryExtractor` at extraction time.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct EdgeTemplate {
     /// Tree-sitter S-expression pattern, e.g.
     /// `"(function_item name: (identifier) @name)"`.
@@ -37,6 +37,7 @@ pub struct EdgeTemplate {
 }
 
 /// All extraction rules for one language.
+#[derive(Clone, Debug)]
 pub struct LanguageQueries {
     /// File extensions this language handles, e.g. `&["rs"]`.
     pub extensions: &'static [&'static str],

--- a/crates/larql-codebase-core/src/languages/edge_template.rs
+++ b/crates/larql-codebase-core/src/languages/edge_template.rs
@@ -1,0 +1,69 @@
+/// How to resolve one endpoint (subject or object) of an emitted edge.
+///
+/// All variants are `Copy` and contain only `&'static str` or unit — safe
+/// in `const` arrays and on `wasm32v1-none`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Endpoint {
+    /// The value of the named tree-sitter capture (e.g. `"name"` for `@name`).
+    Capture(&'static str),
+    /// The current scope stack value (enclosing named construct). Edge is
+    /// suppressed when the scope stack is empty.
+    Scope,
+    /// The source file path supplied to the extractor.
+    File,
+    /// A compile-time string literal.
+    Literal(&'static str),
+}
+
+/// Maps tree-sitter query captures to a LARQL edge.
+///
+/// `query` is a standard tree-sitter S-expression pattern string. It is stored
+/// as `&'static str` (Tier-0 data) and compiled to a `tree_sitter::Query`
+/// by the Tier-1 `QueryExtractor` at extraction time.
+#[derive(Clone, Copy, Debug)]
+pub struct EdgeTemplate {
+    /// Tree-sitter S-expression pattern, e.g.
+    /// `"(function_item name: (identifier) @name)"`.
+    pub query: &'static str,
+    /// Relation label for the emitted edge, e.g. `"defined_in"`.
+    pub relation: &'static str,
+    /// How to determine the edge subject from the query captures.
+    pub subject: Endpoint,
+    /// How to determine the edge object from the query captures.
+    pub object: Endpoint,
+    /// When `Some(cap)`, the value of capture `cap` is pushed onto the
+    /// scope stack before processing child nodes, enabling call-graph tracking.
+    pub scope_capture: Option<&'static str>,
+}
+
+/// All extraction rules for one language.
+pub struct LanguageQueries {
+    /// File extensions this language handles, e.g. `&["rs"]`.
+    pub extensions: &'static [&'static str],
+    /// Edge templates; each template's query is compiled independently.
+    pub templates: &'static [EdgeTemplate],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_is_copy() {
+        let e = Endpoint::File;
+        let _a = e;
+        let _b = e; // Copy — would fail to compile if not Copy
+    }
+
+    #[test]
+    fn edge_template_const_array() {
+        // Verifies that EdgeTemplate can appear in a const array (wasm32v1-none requirement)
+        const _T: &[EdgeTemplate] = &[EdgeTemplate {
+            query: "(function_item name: (identifier) @name)",
+            relation: "defined_in",
+            subject: Endpoint::Capture("name"),
+            object: Endpoint::File,
+            scope_capture: Some("name"),
+        }];
+    }
+}

--- a/crates/larql-codebase-core/src/languages/edge_template.rs
+++ b/crates/larql-codebase-core/src/languages/edge_template.rs
@@ -37,7 +37,7 @@ pub struct EdgeTemplate {
 }
 
 /// All extraction rules for one language.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LanguageQueries {
     /// File extensions this language handles, e.g. `&["rs"]`.
     pub extensions: &'static [&'static str],

--- a/crates/larql-codebase-core/src/languages/java_queries.rs
+++ b/crates/larql-codebase-core/src/languages/java_queries.rs
@@ -1,0 +1,6 @@
+use super::edge_template::LanguageQueries;
+
+pub const JAVA_QUERIES: LanguageQueries = LanguageQueries {
+    extensions: &["java"],
+    templates: &[],
+};

--- a/crates/larql-codebase-core/src/languages/java_queries.rs
+++ b/crates/larql-codebase-core/src/languages/java_queries.rs
@@ -1,6 +1,62 @@
-use super::edge_template::LanguageQueries;
+use super::edge_template::{EdgeTemplate, Endpoint, LanguageQueries};
 
 pub const JAVA_QUERIES: LanguageQueries = LanguageQueries {
     extensions: &["java"],
-    templates: &[],
+    templates: &[
+        // method_declaration inside a class → scope gives "ClassName::methodName"
+        EdgeTemplate {
+            query: "(method_declaration name: (identifier) @name)",
+            relation: "defined_in",
+            subject: Endpoint::Capture("name"),
+            object: Endpoint::File,
+            scope_capture: None,
+        },
+        // class_declaration → ("ClassName", "has_class", "File.java"), opens scope
+        EdgeTemplate {
+            query: "(class_declaration name: (identifier) @name)",
+            relation: "has_class",
+            subject: Endpoint::Capture("name"),
+            object: Endpoint::File,
+            scope_capture: Some("name"),
+        },
+        // interface_declaration
+        EdgeTemplate {
+            query: "(interface_declaration name: (identifier) @name)",
+            relation: "has_interface",
+            subject: Endpoint::Capture("name"),
+            object: Endpoint::File,
+            scope_capture: None,
+        },
+        // import_declaration — no named field; capture full node text
+        EdgeTemplate {
+            query: "(import_declaration) @import",
+            relation: "imports",
+            subject: Endpoint::File,
+            object: Endpoint::Capture("import"),
+            scope_capture: None,
+        },
+        // method_invocation inside scope → ("ClassName", "calls", "methodName")
+        EdgeTemplate {
+            query: "(method_invocation name: (identifier) @name)",
+            relation: "calls",
+            subject: Endpoint::Scope,
+            object: Endpoint::Capture("name"),
+            scope_capture: None,
+        },
+    ],
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn java_queries_defined_in() {
+        assert!(JAVA_QUERIES.templates.iter().any(|t| t.relation == "defined_in"));
+    }
+
+    #[test]
+    fn java_queries_imports() {
+        assert!(JAVA_QUERIES.templates.iter().any(|t| t.relation == "imports"));
+    }
+}

--- a/crates/larql-codebase-core/src/languages/lql_adapter.rs
+++ b/crates/larql-codebase-core/src/languages/lql_adapter.rs
@@ -1,0 +1,5 @@
+extern crate alloc;
+
+pub fn lql_to_edges(_source: &str) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String, alloc::string::String, f64)> {
+    alloc::vec::Vec::new()
+}

--- a/crates/larql-codebase-core/src/languages/lql_adapter.rs
+++ b/crates/larql-codebase-core/src/languages/lql_adapter.rs
@@ -1,5 +1,73 @@
 extern crate alloc;
+use alloc::string::String;
+use alloc::vec::Vec;
 
-pub fn lql_to_edges(_source: &str) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String, alloc::string::String, f64)> {
-    alloc::vec::Vec::new()
+/// Extract a structural edge from an LQL source string.
+///
+/// Parses with `larql_lql_core::parse()` and maps a `Statement::Insert` to a
+/// `(entity, relation, target, confidence)` tuple. Parse errors are silenced —
+/// callers decide how to surface them. All other statement variants are ignored;
+/// they are query/execution operations, not structural assertions.
+///
+/// Because `larql_lql_core::parse` accepts exactly one statement, this
+/// function returns at most one edge. Pass one INSERT statement per call.
+pub fn lql_to_edges(source: &str) -> Vec<(String, String, String, f64)> {
+    use larql_lql_core::{parse, Statement};
+
+    let mut edges = Vec::new();
+    if let Ok(Statement::Insert {
+        entity,
+        relation,
+        target,
+        confidence,
+        ..
+    }) = parse(source)
+    {
+        let conf = confidence.map(f64::from).unwrap_or(1.0);
+        edges.push((entity, relation, target, conf));
+    }
+    edges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_produces_edge() {
+        // Syntax verified against crates/larql-lql-core/src/parser/mutation.rs:
+        //   INSERT INTO EDGES (entity, relation, target) VALUES ("e", "r", "t")
+        let src = r#"INSERT INTO EDGES (entity, relation, target) VALUES ("Alice", "KNOWS", "Bob");"#;
+        let edges = lql_to_edges(src);
+        assert!(!edges.is_empty(), "Expected at least one edge from INSERT statement");
+        assert_eq!(edges[0].0, "Alice");
+        assert_eq!(edges[0].1, "KNOWS");
+        assert_eq!(edges[0].2, "Bob");
+    }
+
+    #[test]
+    fn parse_error_returns_empty() {
+        let edges = lql_to_edges("this is not valid LQL !!!@#$");
+        assert!(edges.is_empty(), "Parse errors must return empty vec, not panic");
+    }
+
+    #[test]
+    fn confidence_defaults_to_one() {
+        let src = r#"INSERT INTO EDGES (entity, relation, target) VALUES ("X", "IS_A", "Y");"#;
+        let edges = lql_to_edges(src);
+        assert!(!edges.is_empty(), "Expected at least one edge");
+        assert!((edges[0].3 - 1.0).abs() < 1e-9, "Default confidence must be 1.0");
+    }
+
+    #[test]
+    fn explicit_confidence_is_preserved() {
+        let src = r#"INSERT INTO EDGES (entity, relation, target) VALUES ("Alice", "lives-in", "Colchester") CONFIDENCE 0.8;"#;
+        let edges = lql_to_edges(src);
+        assert!(!edges.is_empty(), "Expected at least one edge");
+        assert!(
+            (edges[0].3 - 0.8).abs() < 1e-6,
+            "Explicit confidence must be preserved, got {}",
+            edges[0].3
+        );
+    }
 }

--- a/crates/larql-codebase-core/src/languages/matrix.rs
+++ b/crates/larql-codebase-core/src/languages/matrix.rs
@@ -1,0 +1,23 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WasmTarget {
+    Wasm32V1None,
+    Wasm32Unknown,
+    Wasm32Wasi,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MatrixStatus {
+    Pass,
+    Partial(&'static str),
+    Fail(&'static str),
+    NotApplicable(&'static str),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct MatrixEntry {
+    pub language: &'static str,
+    pub target: WasmTarget,
+    pub status: MatrixStatus,
+}
+
+pub const COMPILATION_MATRIX: &[MatrixEntry] = &[];

--- a/crates/larql-codebase-core/src/languages/matrix.rs
+++ b/crates/larql-codebase-core/src/languages/matrix.rs
@@ -1,18 +1,28 @@
+/// Wasm compilation target variants.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WasmTarget {
+    /// WebAssembly 1.0 MVP + mutable-globals only. No GC, SIMD, threads, bulk-memory.
     Wasm32V1None,
+    /// Standard `wasm32-unknown-unknown`. Enables bulk-memory and other post-MVP proposals.
     Wasm32Unknown,
+    /// WASI systems interface (`wasm32-wasip1`).
     Wasm32Wasi,
 }
 
+/// Compilation status for a (language, target) pair.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MatrixStatus {
+    /// Compiles and produces correct output on this target.
     Pass,
+    /// Compiles with noted constraints.
     Partial(&'static str),
+    /// Cannot compile to this target; reason given.
     Fail(&'static str),
+    /// No compilation model (query language or interpreted only).
     NotApplicable(&'static str),
 }
 
+/// One entry in the compilation strategy matrix.
 #[derive(Clone, Copy, Debug)]
 pub struct MatrixEntry {
     pub language: &'static str,
@@ -20,4 +30,91 @@ pub struct MatrixEntry {
     pub status: MatrixStatus,
 }
 
-pub const COMPILATION_MATRIX: &[MatrixEntry] = &[];
+/// Documented compilation strategy matrix.
+///
+/// CI enforces all `Pass` entries. `Fail` and `Partial` entries document
+/// known limitations. `NotApplicable` entries are query/schema languages.
+///
+/// Introspection/reflection capabilities (Java reflection, Python `inspect`,
+/// TypeScript compiler API, SPARQL/GraphQL introspection) are tracked as the
+/// "native path" — currently future work, not yet enforced by CI.
+pub const COMPILATION_MATRIX: &[MatrixEntry] = &[
+    // Rust — full coverage
+    MatrixEntry { language: "rust", target: WasmTarget::Wasm32V1None, status: MatrixStatus::Pass },
+    MatrixEntry { language: "rust", target: WasmTarget::Wasm32Unknown, status: MatrixStatus::Pass },
+    MatrixEntry { language: "rust", target: WasmTarget::Wasm32Wasi,    status: MatrixStatus::Pass },
+    // AssemblyScript (TypeScript subset)
+    MatrixEntry { language: "assemblyscript", target: WasmTarget::Wasm32Unknown, status: MatrixStatus::Pass },
+    MatrixEntry {
+        language: "assemblyscript",
+        target: WasmTarget::Wasm32V1None,
+        status: MatrixStatus::Partial("--disable bulk-memory required; not all AS programs compile"),
+    },
+    // WAT / Wasm binary
+    MatrixEntry { language: "wat",  target: WasmTarget::Wasm32V1None, status: MatrixStatus::Pass },
+    MatrixEntry { language: "wasm", target: WasmTarget::Wasm32V1None, status: MatrixStatus::Pass },
+    // Java
+    MatrixEntry {
+        language: "java",
+        target: WasmTarget::Wasm32Unknown,
+        status: MatrixStatus::Partial("TeaVM or GraalVM native-image required; standard javac does not emit Wasm"),
+    },
+    MatrixEntry {
+        language: "java",
+        target: WasmTarget::Wasm32V1None,
+        status: MatrixStatus::Fail("No production toolchain targets MVP; TeaVM uses bulk-memory"),
+    },
+    // Python
+    MatrixEntry {
+        language: "python",
+        target: WasmTarget::Wasm32Unknown,
+        status: MatrixStatus::Partial("Pyodide only; requires GC and exceptions Wasm proposals"),
+    },
+    MatrixEntry {
+        language: "python",
+        target: WasmTarget::Wasm32V1None,
+        status: MatrixStatus::Fail("Requires GC and exceptions proposals absent from v1-none"),
+    },
+    // TypeScript (general — not AssemblyScript)
+    MatrixEntry {
+        language: "typescript",
+        target: WasmTarget::Wasm32V1None,
+        status: MatrixStatus::NotApplicable("TypeScript compiles to JavaScript; use AssemblyScript for Wasm"),
+    },
+    // Query / schema languages
+    MatrixEntry {
+        language: "sparql",
+        target: WasmTarget::Wasm32V1None,
+        status: MatrixStatus::NotApplicable("Query language; no compilation model"),
+    },
+    MatrixEntry {
+        language: "graphql",
+        target: WasmTarget::Wasm32V1None,
+        status: MatrixStatus::NotApplicable("Schema/query language; no compilation model"),
+    },
+    // LARQL — larql-lql-core is Tier-0 and compiles for wasm32v1-none
+    MatrixEntry { language: "larql", target: WasmTarget::Wasm32V1None, status: MatrixStatus::Pass },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_wasm32v1none_is_pass() {
+        let entry = COMPILATION_MATRIX
+            .iter()
+            .find(|e| e.language == "rust" && e.target == WasmTarget::Wasm32V1None)
+            .expect("rust/wasm32v1-none must have a matrix entry");
+        assert_eq!(entry.status, MatrixStatus::Pass);
+    }
+
+    #[test]
+    fn larql_wasm32v1none_is_pass() {
+        let entry = COMPILATION_MATRIX
+            .iter()
+            .find(|e| e.language == "larql" && e.target == WasmTarget::Wasm32V1None)
+            .unwrap();
+        assert_eq!(entry.status, MatrixStatus::Pass);
+    }
+}

--- a/crates/larql-codebase-core/src/languages/matrix.rs
+++ b/crates/larql-codebase-core/src/languages/matrix.rs
@@ -23,7 +23,7 @@ pub enum MatrixStatus {
 }
 
 /// One entry in the compilation strategy matrix.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MatrixEntry {
     pub language: &'static str,
     pub target: WasmTarget,

--- a/crates/larql-codebase-core/src/languages/mod.rs
+++ b/crates/larql-codebase-core/src/languages/mod.rs
@@ -1,0 +1,3 @@
+pub mod edge_template;
+
+pub use edge_template::{EdgeTemplate, Endpoint, LanguageQueries};

--- a/crates/larql-codebase-core/src/languages/mod.rs
+++ b/crates/larql-codebase-core/src/languages/mod.rs
@@ -1,3 +1,15 @@
 pub mod edge_template;
+pub mod java_queries;
+pub mod lql_adapter;
+pub mod matrix;
+pub mod python_queries;
+pub mod rust_queries;
+pub mod ts_queries;
 
 pub use edge_template::{EdgeTemplate, Endpoint, LanguageQueries};
+pub use java_queries::JAVA_QUERIES;
+pub use lql_adapter::lql_to_edges;
+pub use matrix::{MatrixEntry, MatrixStatus, WasmTarget, COMPILATION_MATRIX};
+pub use python_queries::PYTHON_QUERIES;
+pub use rust_queries::RUST_QUERIES;
+pub use ts_queries::{ASSEMBLYSCRIPT_QUERIES, TS_QUERIES};

--- a/crates/larql-codebase-core/src/languages/python_queries.rs
+++ b/crates/larql-codebase-core/src/languages/python_queries.rs
@@ -35,4 +35,14 @@ mod tests {
     fn python_queries_extensions() {
         assert!(PYTHON_QUERIES.extensions.contains(&"py"));
     }
+
+    #[test]
+    fn python_queries_has_defined_in_template() {
+        assert!(PYTHON_QUERIES.templates.iter().any(|t| t.relation == "defined_in"));
+    }
+
+    #[test]
+    fn python_queries_has_imports_template() {
+        assert!(PYTHON_QUERIES.templates.iter().any(|t| t.relation == "imports"));
+    }
 }

--- a/crates/larql-codebase-core/src/languages/python_queries.rs
+++ b/crates/larql-codebase-core/src/languages/python_queries.rs
@@ -1,0 +1,38 @@
+use super::edge_template::{EdgeTemplate, Endpoint, LanguageQueries};
+
+pub const PYTHON_QUERIES: LanguageQueries = LanguageQueries {
+    extensions: &["py"],
+    templates: &[
+        EdgeTemplate {
+            query: "(function_definition name: (identifier) @name)",
+            relation: "defined_in",
+            subject: Endpoint::Capture("name"),
+            object: Endpoint::File,
+            scope_capture: None,
+        },
+        EdgeTemplate {
+            query: "(import_statement) @import",
+            relation: "imports",
+            subject: Endpoint::File,
+            object: Endpoint::Capture("import"),
+            scope_capture: None,
+        },
+        EdgeTemplate {
+            query: "(import_from_statement) @import",
+            relation: "imports",
+            subject: Endpoint::File,
+            object: Endpoint::Capture("import"),
+            scope_capture: None,
+        },
+    ],
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn python_queries_extensions() {
+        assert!(PYTHON_QUERIES.extensions.contains(&"py"));
+    }
+}

--- a/crates/larql-codebase-core/src/languages/rust_queries.rs
+++ b/crates/larql-codebase-core/src/languages/rust_queries.rs
@@ -1,0 +1,53 @@
+use super::edge_template::{EdgeTemplate, Endpoint, LanguageQueries};
+
+pub const RUST_QUERIES: LanguageQueries = LanguageQueries {
+    extensions: &["rs"],
+    templates: &[
+        // Function definitions → ("fn_name" or "Mod::fn_name", "defined_in", "path.rs")
+        // scope_capture pushes "fn_name" so nested call_expression nodes see it as scope.
+        EdgeTemplate {
+            query: "(function_item name: (identifier) @name)",
+            relation: "defined_in",
+            subject: Endpoint::Capture("name"),
+            object: Endpoint::File,
+            scope_capture: Some("name"),
+        },
+        // Call expressions inside a function scope → ("caller", "calls", "callee_text")
+        // subject=Scope suppresses the edge when not inside any function.
+        EdgeTemplate {
+            query: "(call_expression function: (_) @callee)",
+            relation: "calls",
+            subject: Endpoint::Scope,
+            object: Endpoint::Capture("callee"),
+            scope_capture: None,
+        },
+        // use declarations → ("path.rs", "imports", "use std::collections::HashMap;")
+        EdgeTemplate {
+            query: "(use_declaration) @import",
+            relation: "imports",
+            subject: Endpoint::File,
+            object: Endpoint::Capture("import"),
+            scope_capture: None,
+        },
+    ],
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_queries_has_extensions() {
+        assert!(RUST_QUERIES.extensions.contains(&"rs"));
+    }
+
+    #[test]
+    fn rust_queries_has_defined_in_template() {
+        assert!(RUST_QUERIES.templates.iter().any(|t| t.relation == "defined_in"));
+    }
+
+    #[test]
+    fn rust_queries_has_calls_template() {
+        assert!(RUST_QUERIES.templates.iter().any(|t| t.relation == "calls"));
+    }
+}

--- a/crates/larql-codebase-core/src/languages/ts_queries.rs
+++ b/crates/larql-codebase-core/src/languages/ts_queries.rs
@@ -1,0 +1,59 @@
+use super::edge_template::{EdgeTemplate, Endpoint, LanguageQueries};
+
+// Base templates shared between TypeScript and AssemblyScript.
+// AssemblyScript is a strict TypeScript subset that compiles to Wasm.
+const TS_BASE_TEMPLATES: &[EdgeTemplate] = &[
+    EdgeTemplate {
+        query: "(function_declaration name: (identifier) @name)",
+        relation: "defined_in",
+        subject: Endpoint::Capture("name"),
+        object: Endpoint::File,
+        scope_capture: None,
+    },
+    EdgeTemplate {
+        query: "(method_definition name: (property_identifier) @name)",
+        relation: "defined_in",
+        subject: Endpoint::Capture("name"),
+        object: Endpoint::File,
+        scope_capture: None,
+    },
+    EdgeTemplate {
+        query: "(import_statement) @import",
+        relation: "imports",
+        subject: Endpoint::File,
+        object: Endpoint::Capture("import"),
+        scope_capture: None,
+    },
+];
+
+/// Rules for TypeScript (.ts, .tsx) using `tree-sitter-typescript`.
+pub const TS_QUERIES: LanguageQueries = LanguageQueries {
+    extensions: &["ts", "tsx"],
+    templates: TS_BASE_TEMPLATES,
+};
+
+/// Rules for AssemblyScript (.ts subset compiling to Wasm).
+/// Uses the same tree-sitter-typescript grammar and the same query set.
+/// Compilation target support is documented in the `COMPILATION_MATRIX`.
+pub const ASSEMBLYSCRIPT_QUERIES: LanguageQueries = LanguageQueries {
+    extensions: &["ts"],
+    templates: TS_BASE_TEMPLATES,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ts_queries_extensions() {
+        assert!(TS_QUERIES.extensions.contains(&"ts"));
+    }
+
+    #[test]
+    fn assemblyscript_shares_templates() {
+        assert!(std::ptr::eq(
+            TS_QUERIES.templates.as_ptr(),
+            ASSEMBLYSCRIPT_QUERIES.templates.as_ptr()
+        ));
+    }
+}

--- a/crates/larql-codebase-core/src/languages/ts_queries.rs
+++ b/crates/larql-codebase-core/src/languages/ts_queries.rs
@@ -56,4 +56,9 @@ mod tests {
             ASSEMBLYSCRIPT_QUERIES.templates.as_ptr()
         ));
     }
+
+    #[test]
+    fn ts_queries_has_defined_in_template() {
+        assert!(TS_QUERIES.templates.iter().any(|t| t.relation == "defined_in"));
+    }
 }

--- a/crates/larql-codebase-core/src/lib.rs
+++ b/crates/larql-codebase-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod adj;
 pub mod arch;
 pub mod basis;
 pub mod god_node;
+pub mod languages;
 pub mod norm;
 pub mod trit;
 

--- a/crates/larql-codebase/Cargo.toml
+++ b/crates/larql-codebase/Cargo.toml
@@ -20,6 +20,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-python = "0.25"
 tree-sitter-typescript = "0.23"
 tree-sitter-java = "0.23"
+spargebra = "0.4.6"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/larql-codebase/Cargo.toml
+++ b/crates/larql-codebase/Cargo.toml
@@ -21,6 +21,7 @@ tree-sitter-python = "0.25"
 tree-sitter-typescript = "0.23"
 tree-sitter-java = "0.23"
 spargebra = "0.4.6"
+graphql-parser = "0.4.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/larql-codebase/Cargo.toml
+++ b/crates/larql-codebase/Cargo.toml
@@ -19,6 +19,7 @@ tree-sitter = "0.26"
 tree-sitter-rust = "0.24"
 tree-sitter-python = "0.25"
 tree-sitter-typescript = "0.23"
+tree-sitter-java = "0.23"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/larql-codebase/Cargo.toml
+++ b/crates/larql-codebase/Cargo.toml
@@ -22,6 +22,8 @@ tree-sitter-typescript = "0.23"
 tree-sitter-java = "0.23"
 spargebra = "0.4.6"
 graphql-parser = "0.4.1"
+wasmparser = "0.252.0"
+wat = "1.252.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/larql-codebase/src/extractor.rs
+++ b/crates/larql-codebase/src/extractor.rs
@@ -7,6 +7,7 @@ use larql_core::core::graph::Graph;
 
 use crate::languages::graphql_extractor::GraphqlExtractor;
 use crate::languages::java_lang::java_extractor;
+use crate::languages::lql_extractor::LqlExtractor;
 use crate::languages::python_lang::python_extractor;
 use crate::languages::rust_lang::rust_extractor;
 use crate::languages::sparql_extractor::SparqlExtractor;
@@ -27,6 +28,7 @@ fn extractors() -> Vec<Box<dyn LanguageExtractor>> {
         Box::new(java_extractor()),
         Box::new(SparqlExtractor),
         Box::new(GraphqlExtractor),
+        Box::new(LqlExtractor),
     ]
 }
 

--- a/crates/larql-codebase/src/extractor.rs
+++ b/crates/larql-codebase/src/extractor.rs
@@ -5,7 +5,10 @@ use walkdir::WalkDir;
 
 use larql_core::core::graph::Graph;
 
-use crate::languages::{LanguageExtractor, PythonExtractor, RustExtractor, TsExtractor};
+use crate::languages::python_lang::python_extractor;
+use crate::languages::rust_lang::rust_extractor;
+use crate::languages::ts_lang::ts_extractor;
+use crate::languages::LanguageExtractor;
 
 #[derive(Error, Debug)]
 pub enum CodebaseError {
@@ -15,9 +18,9 @@ pub enum CodebaseError {
 
 fn extractors() -> Vec<Box<dyn LanguageExtractor>> {
     vec![
-        Box::new(RustExtractor),
-        Box::new(PythonExtractor),
-        Box::new(TsExtractor),
+        Box::new(rust_extractor()),
+        Box::new(python_extractor()),
+        Box::new(ts_extractor()),
     ]
 }
 

--- a/crates/larql-codebase/src/extractor.rs
+++ b/crates/larql-codebase/src/extractor.rs
@@ -12,6 +12,7 @@ use crate::languages::python_lang::python_extractor;
 use crate::languages::rust_lang::rust_extractor;
 use crate::languages::sparql_extractor::SparqlExtractor;
 use crate::languages::ts_lang::ts_extractor;
+use crate::languages::wasm_extractor::WasmExtractor;
 use crate::languages::LanguageExtractor;
 
 #[derive(Error, Debug)]
@@ -29,6 +30,9 @@ fn extractors() -> Vec<Box<dyn LanguageExtractor>> {
         Box::new(SparqlExtractor),
         Box::new(GraphqlExtractor),
         Box::new(LqlExtractor),
+        // WAT text format (.wat); .wasm binary files are skipped by read_to_string
+        // in the walker (non-UTF-8) — future work: add a separate binary-file path.
+        Box::new(WasmExtractor),
     ]
 }
 

--- a/crates/larql-codebase/src/extractor.rs
+++ b/crates/larql-codebase/src/extractor.rs
@@ -5,6 +5,7 @@ use walkdir::WalkDir;
 
 use larql_core::core::graph::Graph;
 
+use crate::languages::graphql_extractor::GraphqlExtractor;
 use crate::languages::java_lang::java_extractor;
 use crate::languages::python_lang::python_extractor;
 use crate::languages::rust_lang::rust_extractor;
@@ -25,6 +26,7 @@ fn extractors() -> Vec<Box<dyn LanguageExtractor>> {
         Box::new(ts_extractor()),
         Box::new(java_extractor()),
         Box::new(SparqlExtractor),
+        Box::new(GraphqlExtractor),
     ]
 }
 

--- a/crates/larql-codebase/src/extractor.rs
+++ b/crates/larql-codebase/src/extractor.rs
@@ -5,6 +5,7 @@ use walkdir::WalkDir;
 
 use larql_core::core::graph::Graph;
 
+use crate::languages::java_lang::java_extractor;
 use crate::languages::python_lang::python_extractor;
 use crate::languages::rust_lang::rust_extractor;
 use crate::languages::ts_lang::ts_extractor;
@@ -21,6 +22,7 @@ fn extractors() -> Vec<Box<dyn LanguageExtractor>> {
         Box::new(rust_extractor()),
         Box::new(python_extractor()),
         Box::new(ts_extractor()),
+        Box::new(java_extractor()),
     ]
 }
 

--- a/crates/larql-codebase/src/extractor.rs
+++ b/crates/larql-codebase/src/extractor.rs
@@ -8,6 +8,7 @@ use larql_core::core::graph::Graph;
 use crate::languages::java_lang::java_extractor;
 use crate::languages::python_lang::python_extractor;
 use crate::languages::rust_lang::rust_extractor;
+use crate::languages::sparql_extractor::SparqlExtractor;
 use crate::languages::ts_lang::ts_extractor;
 use crate::languages::LanguageExtractor;
 
@@ -23,6 +24,7 @@ fn extractors() -> Vec<Box<dyn LanguageExtractor>> {
         Box::new(python_extractor()),
         Box::new(ts_extractor()),
         Box::new(java_extractor()),
+        Box::new(SparqlExtractor),
     ]
 }
 

--- a/crates/larql-codebase/src/languages/graphql_extractor.rs
+++ b/crates/larql-codebase/src/languages/graphql_extractor.rs
@@ -1,0 +1,106 @@
+use graphql_parser::schema::{parse_schema, Definition, TypeDefinition, Type};
+use larql_core::core::graph::Graph;
+
+use super::{ast_edge, LanguageExtractor};
+
+pub struct GraphqlExtractor;
+
+impl LanguageExtractor for GraphqlExtractor {
+    fn extensions(&self) -> &[&'static str] {
+        &["graphql", "gql"]
+    }
+
+    fn extract(&self, source: &str, path: &str, graph: &mut Graph) {
+        let doc = match parse_schema::<String>(source) {
+            Ok(d) => d,
+            Err(_) => return,
+        };
+
+        for def in &doc.definitions {
+            match def {
+                Definition::TypeDefinition(td) => match td {
+                    TypeDefinition::Object(obj) => {
+                        graph.add_edge(ast_edge(&obj.name, "defined_in", path));
+                        for field in &obj.fields {
+                            graph.add_edge(ast_edge(&field.name, "field_of", &obj.name));
+                            let type_name = type_to_str(&field.field_type);
+                            graph.add_edge(ast_edge(&field.name, "returns_type", &type_name));
+                        }
+                    }
+                    TypeDefinition::Interface(iface) => {
+                        graph.add_edge(ast_edge(&iface.name, "has_interface", path));
+                        for field in &iface.fields {
+                            graph.add_edge(ast_edge(&field.name, "field_of", &iface.name));
+                        }
+                    }
+                    TypeDefinition::Enum(en) => {
+                        graph.add_edge(ast_edge(&en.name, "has_enum", path));
+                    }
+                    TypeDefinition::InputObject(input) => {
+                        graph.add_edge(ast_edge(&input.name, "has_input", path));
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+    }
+}
+
+fn type_to_str(t: &Type<String>) -> String {
+    match t {
+        Type::NamedType(name) => name.clone(),
+        Type::ListType(inner) => format!("[{}]", type_to_str(inner)),
+        Type::NonNullType(inner) => format!("{}!", type_to_str(inner)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use larql_core::core::graph::Graph;
+
+    const SCHEMA: &str = r#"
+type User {
+  id: ID!
+  name: String
+  posts: [Post!]!
+}
+type Post {
+  id: ID!
+  title: String
+  author: User
+}
+"#;
+
+    #[test]
+    fn graphql_object_type_produces_defined_in() {
+        let mut g = Graph::new();
+        GraphqlExtractor.extract(SCHEMA, "schema.graphql", &mut g);
+        assert!(
+            g.list_entities().iter().any(|e| e.contains("User")),
+            "Expected 'User' in entities, got: {:?}",
+            g.list_entities()
+        );
+    }
+
+    #[test]
+    fn graphql_field_produces_field_of() {
+        let mut g = Graph::new();
+        GraphqlExtractor.extract(SCHEMA, "schema.graphql", &mut g);
+        assert!(
+            g.edges().iter().any(|e| e.relation == "field_of"),
+            "Expected 'field_of' edges for GraphQL fields"
+        );
+    }
+
+    #[test]
+    fn graphql_field_returns_type() {
+        let mut g = Graph::new();
+        GraphqlExtractor.extract(SCHEMA, "schema.graphql", &mut g);
+        assert!(
+            g.edges().iter().any(|e| e.relation == "returns_type"),
+            "Expected 'returns_type' edges for GraphQL field types"
+        );
+    }
+}

--- a/crates/larql-codebase/src/languages/graphql_extractor.rs
+++ b/crates/larql-codebase/src/languages/graphql_extractor.rs
@@ -17,8 +17,8 @@ impl LanguageExtractor for GraphqlExtractor {
         };
 
         for def in &doc.definitions {
-            match def {
-                Definition::TypeDefinition(td) => match td {
+            if let Definition::TypeDefinition(td) = def {
+                match td {
                     TypeDefinition::Object(obj) => {
                         graph.add_edge(ast_edge(&obj.name, "defined_in", path));
                         for field in &obj.fields {
@@ -40,8 +40,7 @@ impl LanguageExtractor for GraphqlExtractor {
                         graph.add_edge(ast_edge(&input.name, "has_input", path));
                     }
                     _ => {}
-                },
-                _ => {}
+                }
             }
         }
     }

--- a/crates/larql-codebase/src/languages/java_lang.rs
+++ b/crates/larql-codebase/src/languages/java_lang.rs
@@ -1,0 +1,45 @@
+use larql_codebase_core::languages::JAVA_QUERIES;
+
+use super::QueryExtractor;
+
+/// Java source extractor — delegates to the generic `QueryExtractor`
+/// with the Tier-0 `JAVA_QUERIES` table.
+pub fn java_extractor() -> QueryExtractor {
+    QueryExtractor::new(&JAVA_QUERIES, || tree_sitter_java::LANGUAGE.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::languages::LanguageExtractor;
+    use larql_core::core::graph::Graph;
+
+    #[test]
+    fn java_method_produces_defined_in() {
+        let src = r#"
+public class Greeter {
+    public String greet(String name) {
+        return "Hello " + name;
+    }
+}
+"#;
+        let mut g = Graph::new();
+        java_extractor().extract(src, "Greeter.java", &mut g);
+        assert!(
+            g.list_entities().iter().any(|n| n.contains("greet")),
+            "expected 'greet' in entities, got: {:?}",
+            g.list_entities()
+        );
+    }
+
+    #[test]
+    fn java_import_produces_imports_edge() {
+        let src = "import java.util.List;\nclass Foo {}";
+        let mut g = Graph::new();
+        java_extractor().extract(src, "Foo.java", &mut g);
+        assert!(
+            g.edges().iter().any(|e| e.relation == "imports"),
+            "expected an 'imports' edge"
+        );
+    }
+}

--- a/crates/larql-codebase/src/languages/java_lang.rs
+++ b/crates/larql-codebase/src/languages/java_lang.rs
@@ -42,4 +42,45 @@ public class Greeter {
             "expected an 'imports' edge"
         );
     }
+
+    #[test]
+    fn java_class_produces_has_class() {
+        let mut g = Graph::new();
+        java_extractor().extract("class Greeter { }", "Greeter.java", &mut g);
+        assert!(
+            g.edges().iter().any(|e| e.relation == "has_class"),
+            "Expected 'has_class' edge for class declaration, got: {:?}",
+            g.edges()
+        );
+    }
+
+    #[test]
+    fn java_interface_produces_has_interface() {
+        let mut g = Graph::new();
+        java_extractor().extract(
+            "interface Printable { void print(); }",
+            "Printable.java",
+            &mut g,
+        );
+        assert!(
+            g.edges().iter().any(|e| e.relation == "has_interface"),
+            "Expected 'has_interface' edge for interface declaration, got: {:?}",
+            g.edges()
+        );
+    }
+
+    #[test]
+    fn java_method_invocation_produces_calls() {
+        let mut g = Graph::new();
+        java_extractor().extract(
+            "class A { void run() { doSomething(); } }",
+            "A.java",
+            &mut g,
+        );
+        assert!(
+            g.edges().iter().any(|e| e.relation == "calls"),
+            "Expected 'calls' edge for method invocation, got: {:?}",
+            g.edges()
+        );
+    }
 }

--- a/crates/larql-codebase/src/languages/lql_extractor.rs
+++ b/crates/larql-codebase/src/languages/lql_extractor.rs
@@ -1,0 +1,67 @@
+use larql_codebase_core::languages::lql_to_edges;
+use larql_core::core::graph::Graph;
+
+use super::{ast_edge, LanguageExtractor};
+
+pub struct LqlExtractor;
+
+impl LanguageExtractor for LqlExtractor {
+    fn extensions(&self) -> &[&'static str] {
+        &["lql"]
+    }
+
+    fn extract(&self, source: &str, _path: &str, graph: &mut Graph) {
+        for (entity, relation, target, confidence) in lql_to_edges(source) {
+            let mut edge = ast_edge(&entity, &relation, &target);
+            edge.confidence = confidence;
+            graph.add_edge(edge);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use larql_core::core::graph::Graph;
+
+    #[test]
+    fn lql_insert_emits_edge() {
+        // SQL-style INSERT syntax verified against larql-lql-core parser
+        let src = r#"INSERT INTO EDGES (entity, relation, target) VALUES ("Alice", "KNOWS", "Bob");"#;
+        let mut g = Graph::new();
+        LqlExtractor.extract(src, "test.lql", &mut g);
+        assert!(
+            !g.edges().is_empty(),
+            "Expected at least one edge from LQL INSERT"
+        );
+        assert_eq!(g.edges()[0].subject, "Alice");
+        assert_eq!(g.edges()[0].relation, "KNOWS");
+        assert_eq!(g.edges()[0].object, "Bob");
+    }
+
+    #[test]
+    fn lql_insert_confidence_propagated() {
+        let src = r#"INSERT INTO EDGES (entity, relation, target) VALUES ("Alice", "lives-in", "Colchester") CONFIDENCE 0.8;"#;
+        let mut g = Graph::new();
+        LqlExtractor.extract(src, "test.lql", &mut g);
+        assert!(!g.edges().is_empty(), "Expected at least one edge");
+        assert!(
+            (g.edges()[0].confidence - 0.8).abs() < 1e-6,
+            "Expected confidence 0.8, got {}",
+            g.edges()[0].confidence
+        );
+    }
+
+    #[test]
+    fn lql_invalid_source_emits_no_edges() {
+        let src = "this is not valid LQL !!!@#$";
+        let mut g = Graph::new();
+        LqlExtractor.extract(src, "test.lql", &mut g);
+        assert!(g.edges().is_empty(), "Invalid LQL should produce no edges");
+    }
+
+    #[test]
+    fn lql_extensions() {
+        assert!(LqlExtractor.extensions().contains(&"lql"));
+    }
+}

--- a/crates/larql-codebase/src/languages/mod.rs
+++ b/crates/larql-codebase/src/languages/mod.rs
@@ -1,9 +1,11 @@
+pub mod graphql_extractor;
 pub mod java_lang;
 pub mod python_lang;
 pub mod query_extractor;
 pub mod rust_lang;
 pub mod sparql_extractor;
 pub mod ts_lang;
+pub use graphql_extractor::GraphqlExtractor;
 pub use java_lang::java_extractor;
 pub use python_lang::PythonExtractor;
 pub use query_extractor::QueryExtractor;

--- a/crates/larql-codebase/src/languages/mod.rs
+++ b/crates/larql-codebase/src/languages/mod.rs
@@ -2,11 +2,13 @@ pub mod java_lang;
 pub mod python_lang;
 pub mod query_extractor;
 pub mod rust_lang;
+pub mod sparql_extractor;
 pub mod ts_lang;
 pub use java_lang::java_extractor;
 pub use python_lang::PythonExtractor;
 pub use query_extractor::QueryExtractor;
 pub use rust_lang::RustExtractor;
+pub use sparql_extractor::SparqlExtractor;
 pub use ts_lang::TsExtractor;
 
 use larql_core::core::{edge::Edge, enums::SourceType, graph::Graph};

--- a/crates/larql-codebase/src/languages/mod.rs
+++ b/crates/larql-codebase/src/languages/mod.rs
@@ -6,6 +6,7 @@ pub mod query_extractor;
 pub mod rust_lang;
 pub mod sparql_extractor;
 pub mod ts_lang;
+pub mod wasm_extractor;
 pub use graphql_extractor::GraphqlExtractor;
 pub use java_lang::java_extractor;
 pub use lql_extractor::LqlExtractor;
@@ -14,6 +15,7 @@ pub use query_extractor::QueryExtractor;
 pub use rust_lang::RustExtractor;
 pub use sparql_extractor::SparqlExtractor;
 pub use ts_lang::TsExtractor;
+pub use wasm_extractor::WasmExtractor;
 
 use larql_core::core::{edge::Edge, enums::SourceType, graph::Graph};
 

--- a/crates/larql-codebase/src/languages/mod.rs
+++ b/crates/larql-codebase/src/languages/mod.rs
@@ -1,5 +1,6 @@
 pub mod graphql_extractor;
 pub mod java_lang;
+pub mod lql_extractor;
 pub mod python_lang;
 pub mod query_extractor;
 pub mod rust_lang;
@@ -7,6 +8,7 @@ pub mod sparql_extractor;
 pub mod ts_lang;
 pub use graphql_extractor::GraphqlExtractor;
 pub use java_lang::java_extractor;
+pub use lql_extractor::LqlExtractor;
 pub use python_lang::PythonExtractor;
 pub use query_extractor::QueryExtractor;
 pub use rust_lang::RustExtractor;

--- a/crates/larql-codebase/src/languages/mod.rs
+++ b/crates/larql-codebase/src/languages/mod.rs
@@ -1,7 +1,9 @@
+pub mod java_lang;
 pub mod python_lang;
 pub mod query_extractor;
 pub mod rust_lang;
 pub mod ts_lang;
+pub use java_lang::java_extractor;
 pub use python_lang::PythonExtractor;
 pub use query_extractor::QueryExtractor;
 pub use rust_lang::RustExtractor;

--- a/crates/larql-codebase/src/languages/mod.rs
+++ b/crates/larql-codebase/src/languages/mod.rs
@@ -1,7 +1,9 @@
 pub mod python_lang;
+pub mod query_extractor;
 pub mod rust_lang;
 pub mod ts_lang;
 pub use python_lang::PythonExtractor;
+pub use query_extractor::QueryExtractor;
 pub use rust_lang::RustExtractor;
 pub use ts_lang::TsExtractor;
 

--- a/crates/larql-codebase/src/languages/python_lang.rs
+++ b/crates/larql-codebase/src/languages/python_lang.rs
@@ -1,66 +1,35 @@
-use larql_core::core::graph::Graph;
-use tree_sitter::{Node, Parser};
+use larql_codebase_core::languages::PYTHON_QUERIES;
 
-use super::{ast_edge, LanguageExtractor};
+use super::QueryExtractor;
 
-pub struct PythonExtractor;
-
-impl LanguageExtractor for PythonExtractor {
-    fn extensions(&self) -> &[&'static str] {
-        &["py"]
-    }
-
-    fn extract(&self, source: &str, path: &str, graph: &mut Graph) {
-        let mut parser = Parser::new();
-        parser
-            .set_language(&tree_sitter_python::LANGUAGE.into())
-            .expect("tree-sitter-python");
-        let tree = match parser.parse(source, None) {
-            Some(t) => t,
-            None => return,
-        };
-        extract_py(tree.root_node(), source.as_bytes(), path, graph);
-    }
+pub fn python_extractor() -> QueryExtractor {
+    QueryExtractor::new(&PYTHON_QUERIES, || tree_sitter_python::LANGUAGE.into())
 }
 
-fn extract_py(node: Node, src: &[u8], path: &str, graph: &mut Graph) {
-    match node.kind() {
-        "function_definition" => {
-            if let Some(name_node) = node.child_by_field_name("name") {
-                let name = name_node.utf8_text(src).unwrap_or("?");
-                graph.add_edge(ast_edge(name, "defined_in", path));
-            }
-        }
-        "import_statement" => {
-            let text = node.utf8_text(src).unwrap_or("");
-            graph.add_edge(ast_edge(path, "imports", text.trim()));
-        }
-        "import_from_statement" => {
-            let text = node.utf8_text(src).unwrap_or("");
-            graph.add_edge(ast_edge(path, "imports", text.trim()));
-        }
-        _ => {}
-    }
-    for i in 0..node.child_count() {
-        extract_py(node.child(i as u32).unwrap(), src, path, graph);
+/// Preserve the public name for backward compatibility.
+pub struct PythonExtractor;
+
+impl PythonExtractor {
+    pub fn new() -> QueryExtractor {
+        python_extractor()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use larql_core::core::graph::Graph;
+
+    use super::*;
+    use crate::languages::LanguageExtractor;
 
     #[test]
     fn python_def_produces_defined_in() {
         let src = "def compute(x):\n    return x * 2\n";
         let mut g = Graph::new();
-        PythonExtractor.extract(src, "utils.py", &mut g);
-        let entities = g.list_entities();
+        python_extractor().extract(src, "utils.py", &mut g);
         assert!(
-            entities.iter().any(|n| n.contains("compute")),
-            "expected 'compute' in entities, got: {:?}",
-            entities
+            g.list_entities().iter().any(|n| n.contains("compute")),
+            "expected 'compute' in entities"
         );
     }
 
@@ -68,11 +37,10 @@ mod tests {
     fn python_import_produces_imports_edge() {
         let src = "import os\nfrom pathlib import Path\n";
         let mut g = Graph::new();
-        PythonExtractor.extract(src, "main.py", &mut g);
-        let edges = g.edges();
+        python_extractor().extract(src, "main.py", &mut g);
         assert!(
-            edges.iter().any(|e| e.relation == "imports"),
-            "expected an 'imports' edge for import statement"
+            g.edges().iter().any(|e| e.relation == "imports"),
+            "expected an 'imports' edge"
         );
     }
 }

--- a/crates/larql-codebase/src/languages/python_lang.rs
+++ b/crates/larql-codebase/src/languages/python_lang.rs
@@ -10,6 +10,7 @@ pub fn python_extractor() -> QueryExtractor {
 pub struct PythonExtractor;
 
 impl PythonExtractor {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> QueryExtractor {
         python_extractor()
     }

--- a/crates/larql-codebase/src/languages/query_extractor.rs
+++ b/crates/larql-codebase/src/languages/query_extractor.rs
@@ -1,6 +1,6 @@
 use larql_codebase_core::languages::{Endpoint, LanguageQueries};
 use larql_core::core::graph::Graph;
-use tree_sitter::{Language, Parser, Query, QueryCursor, StreamingIterator};
+use tree_sitter::{Language, Node, Parser, Query, QueryCursor, StreamingIterator};
 
 use super::ast_edge;
 use super::LanguageExtractor;
@@ -13,19 +13,13 @@ use super::LanguageExtractor;
 ///
 /// # Scope tracking
 ///
-/// Each `EdgeTemplate` with `scope_capture = Some(cap)` pushes the matched
-/// capture text onto a per-template scope stack. The scope stack is reset at
-/// the start of each template's match pass (i.e. templates are processed
-/// independently). As a result, `Endpoint::Scope` subjects only see the scope
-/// built within the *same* template pass.
-///
-/// **Known limitation:** the `"calls"` template in `RUST_QUERIES` has
-/// `subject: Endpoint::Scope`, but scope is pushed by the separate
-/// `"defined_in"` template pass. Because each template gets its own empty
-/// stack, `calls` edges are never emitted by this implementation. A correct
-/// solution requires a single tree-walk that threads scope through all
-/// templates simultaneously (planned for Task 7: migrate `RustExtractor` to
-/// `QueryExtractor`).
+/// The extractor performs a single depth-first tree walk, maintaining a shared
+/// `scope_stack`. At each node, ALL templates are checked against the node kind.
+/// When a template's `scope_capture` is `Some(cap)`, the captured value is
+/// pushed onto the scope stack before recursing into child nodes, then popped
+/// after. This means `Endpoint::Scope` templates (like `calls`) correctly see
+/// the enclosing scope set by `Endpoint::Capture`-based templates (like
+/// `defined_in`) in the same walk.
 pub struct QueryExtractor {
     rules: &'static LanguageQueries,
     language_fn: fn() -> Language,
@@ -35,6 +29,24 @@ impl QueryExtractor {
     pub fn new(rules: &'static LanguageQueries, language_fn: fn() -> Language) -> Self {
         Self { rules, language_fn }
     }
+}
+
+/// Extract the outermost node kind from a tree-sitter S-expression query.
+///
+/// E.g. `"(function_item name: (identifier) @name)"` → `"function_item"`.
+/// Returns `""` if the pattern doesn't start with `(` followed by an identifier.
+fn kind_from_query(q: &str) -> &str {
+    let q = q.trim();
+    // Must start with '('
+    if !q.starts_with('(') {
+        return "";
+    }
+    let rest = &q[1..];
+    // Find the end of the first identifier (alphanumeric or '_')
+    let end = rest
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .unwrap_or(rest.len());
+    &rest[..end]
 }
 
 impl LanguageExtractor for QueryExtractor {
@@ -55,46 +67,114 @@ impl LanguageExtractor for QueryExtractor {
         };
         let src_bytes = source.as_bytes();
 
-        for template in self.rules.templates {
-            let query = match Query::new(&lang, template.query) {
-                Ok(q) => q,
-                Err(_) => continue, // malformed query — skip, don't panic
-            };
+        // Compile all template queries once.
+        let compiled: Vec<Option<Query>> = self
+            .rules
+            .templates
+            .iter()
+            .map(|t| Query::new(&lang, t.query).ok())
+            .collect();
 
-            let mut cursor = QueryCursor::new();
+        // Precompute node kinds for each template.
+        let kinds: Vec<&str> = self
+            .rules
+            .templates
+            .iter()
+            .map(|t| kind_from_query(t.query))
+            .collect();
 
-            // Each template pass gets a fresh scope stack.
-            // See doc comment above for the known limitation this implies.
-            let mut scope_stack: Vec<String> = Vec::new();
+        let mut scope_stack: Vec<String> = Vec::new();
+        walk_node(
+            tree.root_node(),
+            src_bytes,
+            path,
+            self.rules.templates,
+            &compiled,
+            &kinds,
+            graph,
+            &mut scope_stack,
+        );
+    }
+}
 
-            let mut matches = cursor.matches(&query, tree.root_node(), src_bytes);
-            while let Some(m) = matches.next() {
-                let subject =
-                    resolve(template.subject, m, &query, src_bytes, path, &scope_stack);
-                let object =
-                    resolve(template.object, m, &query, src_bytes, path, &scope_stack);
+#[allow(clippy::too_many_arguments)]
+fn walk_node<'a>(
+    node: Node<'a>,
+    src: &[u8],
+    path: &str,
+    templates: &'static [larql_codebase_core::languages::EdgeTemplate],
+    compiled: &[Option<Query>],
+    kinds: &[&str],
+    graph: &mut Graph,
+    scope_stack: &mut Vec<String>,
+) {
+    let node_kind = node.kind();
+    // Track how many scopes we push at this node level so we can pop them
+    // after recursing into children.
+    let mut scope_push_count: usize = 0;
 
-                if let (Some(s), Some(o)) = (subject, object) {
-                    graph.add_edge(ast_edge(&s, template.relation, &o));
-                }
+    for ((template, query_opt), kind) in
+        templates.iter().zip(compiled.iter()).zip(kinds.iter())
+    {
+        // Only check templates whose query targets the current node kind.
+        if *kind != node_kind {
+            continue;
+        }
+        let query = match query_opt {
+            Some(q) => q,
+            None => continue,
+        };
 
-                // Push scope after emitting the edge so the emitted edge itself
-                // is not attributed to the scope it opens.
-                if let Some(scope_cap) = template.scope_capture {
-                    if let Some(cap_idx) = query.capture_index_for_name(scope_cap) {
-                        let cap_text = m
-                            .captures
-                            .iter()
-                            .find(|c| c.index == cap_idx)
-                            .and_then(|c| c.node.utf8_text(src_bytes).ok())
-                            .map(|s| s.to_owned());
-                        if let Some(val) = cap_text {
-                            scope_stack.push(val);
-                        }
+        // Run the query starting at this node, but only allow matches
+        // rooted here (depth 0). This avoids double-counting when we
+        // also recurse into children that have the same node kind.
+        let mut cursor = QueryCursor::new();
+        cursor.set_max_start_depth(Some(0));
+        let mut matches = cursor.matches(query, node, src);
+        while let Some(m) = matches.next() {
+            let subject = resolve(template.subject, m, query, src, path, scope_stack);
+            let object = resolve(template.object, m, query, src, path, scope_stack);
+
+            if let (Some(s), Some(o)) = (subject, object) {
+                graph.add_edge(ast_edge(&s, template.relation, &o));
+            }
+
+            // Push scope after emitting the edge so the emitted edge itself
+            // is not attributed to the scope it opens.
+            if let Some(scope_cap) = template.scope_capture {
+                if let Some(cap_idx) = query.capture_index_for_name(scope_cap) {
+                    let cap_text = m
+                        .captures
+                        .iter()
+                        .find(|c| c.index == cap_idx)
+                        .and_then(|c| c.node.utf8_text(src).ok())
+                        .map(|s| s.to_owned());
+                    if let Some(val) = cap_text {
+                        scope_stack.push(val);
+                        scope_push_count += 1;
                     }
                 }
             }
         }
+    }
+
+    // Recurse into children with the updated scope_stack.
+    for i in 0..node.child_count() {
+        walk_node(
+            node.child(i as u32).unwrap(),
+            src,
+            path,
+            templates,
+            compiled,
+            kinds,
+            graph,
+            scope_stack,
+        );
+    }
+
+    // Pop all scopes opened at this node level.
+    for _ in 0..scope_push_count {
+        scope_stack.pop();
     }
 }
 
@@ -162,5 +242,40 @@ mod tests {
             "Expected an 'imports' edge, got: {:?}",
             edges
         );
+    }
+
+    #[test]
+    fn extracts_calls_edge_inside_function() {
+        // Use a real function call (not a macro) to test calls edge emission.
+        let src = "fn a() { b(); }";
+        let mut g = Graph::new();
+        make_rust_extractor().extract(src, "src/lib.rs", &mut g);
+        let edges = g.edges();
+        assert!(
+            edges.iter().any(|e| e.relation == "calls"),
+            "Expected a 'calls' edge from a() to b(), got: {:?}",
+            edges
+        );
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.relation == "calls" && e.subject.contains('a')),
+            "Expected subject of 'calls' to contain 'a', got: {:?}",
+            edges
+        );
+    }
+
+    #[test]
+    fn kind_from_query_extracts_kind() {
+        assert_eq!(
+            kind_from_query("(function_item name: (identifier) @name)"),
+            "function_item"
+        );
+        assert_eq!(
+            kind_from_query("(call_expression function: (_) @callee)"),
+            "call_expression"
+        );
+        assert_eq!(kind_from_query("(use_declaration) @import"), "use_declaration");
+        assert_eq!(kind_from_query("not_an_sexp"), "");
     }
 }

--- a/crates/larql-codebase/src/languages/query_extractor.rs
+++ b/crates/larql-codebase/src/languages/query_extractor.rs
@@ -84,6 +84,7 @@ impl LanguageExtractor for QueryExtractor {
             .collect();
 
         let mut scope_stack: Vec<String> = Vec::new();
+        let mut cursor = QueryCursor::new();
         walk_node(
             tree.root_node(),
             src_bytes,
@@ -93,6 +94,7 @@ impl LanguageExtractor for QueryExtractor {
             &kinds,
             graph,
             &mut scope_stack,
+            &mut cursor,
         );
     }
 }
@@ -107,6 +109,7 @@ fn walk_node<'a>(
     kinds: &[&str],
     graph: &mut Graph,
     scope_stack: &mut Vec<String>,
+    cursor: &mut QueryCursor,
 ) {
     let node_kind = node.kind();
     // Track how many scopes we push at this node level so we can pop them
@@ -128,7 +131,6 @@ fn walk_node<'a>(
         // Run the query starting at this node, but only allow matches
         // rooted here (depth 0). This avoids double-counting when we
         // also recurse into children that have the same node kind.
-        let mut cursor = QueryCursor::new();
         cursor.set_max_start_depth(Some(0));
         let mut matches = cursor.matches(query, node, src);
         while let Some(m) = matches.next() {
@@ -169,6 +171,7 @@ fn walk_node<'a>(
             kinds,
             graph,
             scope_stack,
+            cursor,
         );
     }
 

--- a/crates/larql-codebase/src/languages/query_extractor.rs
+++ b/crates/larql-codebase/src/languages/query_extractor.rs
@@ -1,0 +1,166 @@
+use larql_codebase_core::languages::{Endpoint, LanguageQueries};
+use larql_core::core::graph::Graph;
+use tree_sitter::{Language, Parser, Query, QueryCursor, StreamingIterator};
+
+use super::ast_edge;
+use super::LanguageExtractor;
+
+/// A generic extractor driven by tree-sitter S-expression query strings.
+///
+/// `rules` holds the query strings and edge mappings (Tier-0 data from
+/// `larql-codebase-core`). `language_fn` returns the tree-sitter `Language`
+/// for this grammar (Tier-1).
+///
+/// # Scope tracking
+///
+/// Each `EdgeTemplate` with `scope_capture = Some(cap)` pushes the matched
+/// capture text onto a per-template scope stack. The scope stack is reset at
+/// the start of each template's match pass (i.e. templates are processed
+/// independently). As a result, `Endpoint::Scope` subjects only see the scope
+/// built within the *same* template pass.
+///
+/// **Known limitation:** the `"calls"` template in `RUST_QUERIES` has
+/// `subject: Endpoint::Scope`, but scope is pushed by the separate
+/// `"defined_in"` template pass. Because each template gets its own empty
+/// stack, `calls` edges are never emitted by this implementation. A correct
+/// solution requires a single tree-walk that threads scope through all
+/// templates simultaneously (planned for Task 7: migrate `RustExtractor` to
+/// `QueryExtractor`).
+pub struct QueryExtractor {
+    rules: &'static LanguageQueries,
+    language_fn: fn() -> Language,
+}
+
+impl QueryExtractor {
+    pub fn new(rules: &'static LanguageQueries, language_fn: fn() -> Language) -> Self {
+        Self { rules, language_fn }
+    }
+}
+
+impl LanguageExtractor for QueryExtractor {
+    fn extensions(&self) -> &[&'static str] {
+        self.rules.extensions
+    }
+
+    fn extract(&self, source: &str, path: &str, graph: &mut Graph) {
+        let lang = (self.language_fn)();
+
+        let mut parser = Parser::new();
+        if parser.set_language(&lang).is_err() {
+            return;
+        }
+        let tree = match parser.parse(source, None) {
+            Some(t) => t,
+            None => return,
+        };
+        let src_bytes = source.as_bytes();
+
+        for template in self.rules.templates {
+            let query = match Query::new(&lang, template.query) {
+                Ok(q) => q,
+                Err(_) => continue, // malformed query — skip, don't panic
+            };
+
+            let mut cursor = QueryCursor::new();
+
+            // Each template pass gets a fresh scope stack.
+            // See doc comment above for the known limitation this implies.
+            let mut scope_stack: Vec<String> = Vec::new();
+
+            let mut matches = cursor.matches(&query, tree.root_node(), src_bytes);
+            while let Some(m) = matches.next() {
+                let subject =
+                    resolve(template.subject, m, &query, src_bytes, path, &scope_stack);
+                let object =
+                    resolve(template.object, m, &query, src_bytes, path, &scope_stack);
+
+                if let (Some(s), Some(o)) = (subject, object) {
+                    graph.add_edge(ast_edge(&s, template.relation, &o));
+                }
+
+                // Push scope after emitting the edge so the emitted edge itself
+                // is not attributed to the scope it opens.
+                if let Some(scope_cap) = template.scope_capture {
+                    if let Some(cap_idx) = query.capture_index_for_name(scope_cap) {
+                        let cap_text = m
+                            .captures
+                            .iter()
+                            .find(|c| c.index == cap_idx)
+                            .and_then(|c| c.node.utf8_text(src_bytes).ok())
+                            .map(|s| s.to_owned());
+                        if let Some(val) = cap_text {
+                            scope_stack.push(val);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn resolve(
+    endpoint: Endpoint,
+    m: &tree_sitter::QueryMatch<'_, '_>,
+    query: &Query,
+    src: &[u8],
+    path: &str,
+    scope_stack: &[String],
+) -> Option<String> {
+    match endpoint {
+        Endpoint::Capture(name) => {
+            let idx = query.capture_index_for_name(name)?;
+            m.captures
+                .iter()
+                .find(|c| c.index == idx)
+                .and_then(|c| c.node.utf8_text(src).ok())
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        }
+        Endpoint::Scope => scope_stack.last().cloned(),
+        Endpoint::File => Some(path.to_owned()),
+        Endpoint::Literal(s) => Some(s.to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use larql_codebase_core::languages::RUST_QUERIES;
+    use larql_core::core::graph::Graph;
+
+    fn make_rust_extractor() -> QueryExtractor {
+        QueryExtractor::new(&RUST_QUERIES, || tree_sitter_rust::LANGUAGE.into())
+    }
+
+    #[test]
+    fn extracts_function_defined_in() {
+        let src = "fn hello() { }";
+        let mut g = Graph::new();
+        make_rust_extractor().extract(src, "src/lib.rs", &mut g);
+        let entities = g.list_entities();
+        assert!(
+            entities.iter().any(|e| e.contains("hello")),
+            "Expected 'hello' in graph entities, got: {:?}",
+            entities
+        );
+    }
+
+    #[test]
+    fn extensions_match_rules() {
+        let ex = make_rust_extractor();
+        assert!(ex.extensions().contains(&"rs"));
+    }
+
+    #[test]
+    fn extracts_import_edge() {
+        let src = "use std::collections::HashMap;";
+        let mut g = Graph::new();
+        make_rust_extractor().extract(src, "src/main.rs", &mut g);
+        let edges = g.edges();
+        assert!(
+            edges.iter().any(|e| e.relation == "imports"),
+            "Expected an 'imports' edge, got: {:?}",
+            edges
+        );
+    }
+}

--- a/crates/larql-codebase/src/languages/rust_lang.rs
+++ b/crates/larql-codebase/src/languages/rust_lang.rs
@@ -1,98 +1,38 @@
-use larql_core::core::graph::Graph;
-use tree_sitter::{Node, Parser};
+use larql_codebase_core::languages::RUST_QUERIES;
 
-use super::{ast_edge, LanguageExtractor};
+use super::QueryExtractor;
 
-pub struct RustExtractor;
-
-impl LanguageExtractor for RustExtractor {
-    fn extensions(&self) -> &[&'static str] {
-        &["rs"]
-    }
-
-    fn extract(&self, source: &str, path: &str, graph: &mut Graph) {
-        let mut parser = Parser::new();
-        parser
-            .set_language(&tree_sitter_rust::LANGUAGE.into())
-            .expect("tree-sitter-rust load");
-        let tree = match parser.parse(source, None) {
-            Some(t) => t,
-            None => return,
-        };
-        let bytes = source.as_bytes();
-        extract_node(tree.root_node(), bytes, path, graph, None);
-    }
+/// Rust source extractor — delegates to the generic `QueryExtractor`
+/// with the Tier-0 `RUST_QUERIES` table.
+pub fn rust_extractor() -> QueryExtractor {
+    QueryExtractor::new(&RUST_QUERIES, || tree_sitter_rust::LANGUAGE.into())
 }
 
-fn extract_node<'a>(
-    node: Node<'a>,
-    src: &[u8],
-    path: &str,
-    graph: &mut Graph,
-    scope: Option<&str>,
-) {
-    match node.kind() {
-        "function_item" => {
-            if let Some(name_node) = node.child_by_field_name("name") {
-                let fn_name = name_node.utf8_text(src).unwrap_or("?");
-                let qualified = match scope {
-                    Some(s) => format!("{s}::{fn_name}"),
-                    None => fn_name.to_string(),
-                };
-                graph.add_edge(ast_edge(&qualified, "defined_in", path));
-                // Walk body for call_expression children
-                for i in 0..node.child_count() {
-                    extract_node(
-                        node.child(i as u32).unwrap(),
-                        src,
-                        path,
-                        graph,
-                        Some(&qualified),
-                    );
-                }
-                return;
-            }
-        }
-        "call_expression" => {
-            if let Some(func) = node.child_by_field_name("function") {
-                let callee = func.utf8_text(src).unwrap_or("?");
-                if let Some(s) = scope {
-                    graph.add_edge(ast_edge(s, "calls", callee));
-                }
-            }
-        }
-        "use_declaration" => {
-            let text = node.utf8_text(src).unwrap_or("");
-            let path_str = text.trim_start_matches("use ").trim_end_matches(';');
-            graph.add_edge(ast_edge(path, "imports", path_str));
-        }
-        _ => {}
-    }
-    for i in 0..node.child_count() {
-        extract_node(node.child(i as u32).unwrap(), src, path, graph, scope);
+/// Preserve the public name for backward compatibility.
+pub struct RustExtractor;
+
+impl RustExtractor {
+    pub fn new() -> QueryExtractor {
+        rust_extractor()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use larql_core::core::graph::Graph;
+
+    use super::*;
+    use crate::languages::LanguageExtractor;
 
     #[test]
     fn extracts_function_def_edge() {
-        let source = r#"
-            fn hello_world() {
-                println!("hi");
-            }
-        "#;
+        let source = r#"fn hello_world() { println!("hi"); }"#;
         let mut g = Graph::new();
-        let extractor = RustExtractor;
-        extractor.extract(source, "src/lib.rs", &mut g);
-        // Should produce at least one edge involving "hello_world"
+        rust_extractor().extract(source, "src/lib.rs", &mut g);
         let entities = g.list_entities();
         assert!(
             entities.iter().any(|n| n.contains("hello_world")),
-            "expected hello_world to appear as a node, got: {:?}",
+            "expected hello_world, got: {:?}",
             entities
         );
     }
@@ -101,11 +41,10 @@ mod tests {
     fn use_statement_produces_imports_edge() {
         let source = "use std::collections::HashMap;";
         let mut g = Graph::new();
-        RustExtractor.extract(source, "src/main.rs", &mut g);
-        let edges = g.edges();
+        rust_extractor().extract(source, "src/main.rs", &mut g);
         assert!(
-            edges.iter().any(|e| e.relation == "imports"),
-            "expected an 'imports' edge for use statement"
+            g.edges().iter().any(|e| e.relation == "imports"),
+            "expected an 'imports' edge"
         );
     }
 }

--- a/crates/larql-codebase/src/languages/rust_lang.rs
+++ b/crates/larql-codebase/src/languages/rust_lang.rs
@@ -12,6 +12,7 @@ pub fn rust_extractor() -> QueryExtractor {
 pub struct RustExtractor;
 
 impl RustExtractor {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> QueryExtractor {
         rust_extractor()
     }

--- a/crates/larql-codebase/src/languages/sparql_extractor.rs
+++ b/crates/larql-codebase/src/languages/sparql_extractor.rs
@@ -1,0 +1,138 @@
+use larql_core::core::graph::Graph;
+use spargebra::algebra::GraphPattern;
+use spargebra::term::{NamedNodePattern, TermPattern};
+use spargebra::{Query, SparqlParser};
+
+use super::{ast_edge, LanguageExtractor};
+
+pub struct SparqlExtractor;
+
+impl LanguageExtractor for SparqlExtractor {
+    fn extensions(&self) -> &[&'static str] {
+        &["sparql", "rq"]
+    }
+
+    fn extract(&self, source: &str, path: &str, graph: &mut Graph) {
+        let query: Query = match SparqlParser::new().parse_query(source) {
+            Ok(q) => q,
+            Err(_) => return,
+        };
+
+        let pattern: &GraphPattern = match &query {
+            Query::Select { pattern, .. } => pattern,
+            Query::Construct { pattern, .. } => pattern,
+            Query::Ask { pattern, .. } => pattern,
+            Query::Describe { pattern, .. } => pattern,
+        };
+
+        extract_pattern(pattern, path, graph);
+    }
+}
+
+fn extract_pattern(pattern: &GraphPattern, path: &str, graph: &mut Graph) {
+    match pattern {
+        GraphPattern::Bgp { patterns } => {
+            for tp in patterns {
+                let s = term_str(&tp.subject);
+                let p = named_node_str(&tp.predicate);
+                let o = term_str(&tp.object);
+                if let (Some(s), Some(p), Some(o)) = (s, p, o) {
+                    graph.add_edge(ast_edge(&s, &p, &o));
+                }
+            }
+        }
+        GraphPattern::Join { left, right }
+        | GraphPattern::LeftJoin { left, right, .. }
+        | GraphPattern::Union { left, right }
+        | GraphPattern::Minus { left, right } => {
+            extract_pattern(left, path, graph);
+            extract_pattern(right, path, graph);
+        }
+        GraphPattern::Filter { inner, .. }
+        | GraphPattern::Extend { inner, .. }
+        | GraphPattern::OrderBy { inner, .. }
+        | GraphPattern::Project { inner, .. }
+        | GraphPattern::Distinct { inner }
+        | GraphPattern::Reduced { inner }
+        | GraphPattern::Slice { inner, .. }
+        | GraphPattern::Group { inner, .. } => {
+            extract_pattern(inner, path, graph);
+        }
+        GraphPattern::Graph { inner, .. } => extract_pattern(inner, path, graph),
+        GraphPattern::Service { name, inner, .. } => {
+            if let NamedNodePattern::NamedNode(nn) = name {
+                graph.add_edge(ast_edge(path, "uses_service", nn.as_str()));
+            }
+            extract_pattern(inner, path, graph);
+        }
+        _ => {}
+    }
+}
+
+fn term_str(term: &TermPattern) -> Option<String> {
+    match term {
+        TermPattern::NamedNode(n) => Some(n.as_str().to_owned()),
+        TermPattern::Variable(v) => Some(format!("?{}", v.as_str())),
+        TermPattern::BlankNode(b) => Some(format!("_:{}", b.as_str())),
+        TermPattern::Literal(_) => None,
+    }
+}
+
+fn named_node_str(nn: &NamedNodePattern) -> Option<String> {
+    match nn {
+        NamedNodePattern::NamedNode(n) => Some(n.as_str().to_owned()),
+        NamedNodePattern::Variable(v) => Some(format!("?{}", v.as_str())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use larql_core::core::graph::Graph;
+
+    const WIKIDATA_LOGICS: &str = r#"
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+CONSTRUCT {
+  ?logic rdfs:label ?label .
+  ?logic wdt:P31 wd:Q8078 .
+}
+WHERE {
+  ?logic wdt:P31 wd:Q8078 .
+  ?logic rdfs:label ?label .
+  FILTER(LANG(?label) = "en")
+}
+LIMIT 10
+"#;
+
+    #[test]
+    fn sparql_bgp_produces_triple_edges() {
+        let mut g = Graph::new();
+        SparqlExtractor.extract(WIKIDATA_LOGICS, "wikidata-logics.rq", &mut g);
+        assert!(
+            !g.edges().is_empty(),
+            "Expected at least one edge from SPARQL BGP"
+        );
+    }
+
+    #[test]
+    fn sparql_extensions() {
+        assert!(SparqlExtractor.extensions().contains(&"sparql"));
+        assert!(SparqlExtractor.extensions().contains(&"rq"));
+    }
+
+    #[test]
+    fn sparql_select_produces_edges() {
+        let sparql = r#"SELECT * WHERE { ?s <http://ex.org/p> ?o }"#;
+        let mut g = Graph::new();
+        SparqlExtractor.extract(sparql, "test.rq", &mut g);
+        assert!(
+            g.edges()
+                .iter()
+                .any(|e| e.relation == "http://ex.org/p"),
+            "Expected an edge with predicate http://ex.org/p"
+        );
+    }
+}

--- a/crates/larql-codebase/src/languages/ts_lang.rs
+++ b/crates/larql-codebase/src/languages/ts_lang.rs
@@ -46,4 +46,15 @@ mod tests {
             "expected an 'imports' edge"
         );
     }
+
+    #[test]
+    fn ts_method_produces_defined_in() {
+        let mut g = Graph::new();
+        ts_extractor().extract("class Foo { bar() { } }", "foo.ts", &mut g);
+        assert!(
+            g.edges().iter().any(|e| e.subject == "bar"),
+            "Expected 'bar' method in graph entities, got: {:?}",
+            g.edges()
+        );
+    }
 }

--- a/crates/larql-codebase/src/languages/ts_lang.rs
+++ b/crates/larql-codebase/src/languages/ts_lang.rs
@@ -1,68 +1,48 @@
-use larql_core::core::graph::Graph;
-use tree_sitter::{Node, Parser};
+use larql_codebase_core::languages::TS_QUERIES;
 
-use super::{ast_edge, LanguageExtractor};
+use super::QueryExtractor;
 
-pub struct TsExtractor;
-
-impl LanguageExtractor for TsExtractor {
-    fn extensions(&self) -> &[&'static str] {
-        &["ts", "tsx"]
-    }
-
-    fn extract(&self, source: &str, path: &str, graph: &mut Graph) {
-        let mut parser = Parser::new();
-        parser
-            .set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
-            .expect("tree-sitter-typescript");
-        let tree = match parser.parse(source, None) {
-            Some(t) => t,
-            None => return,
-        };
-        extract_ts(tree.root_node(), source.as_bytes(), path, graph);
-    }
+pub fn ts_extractor() -> QueryExtractor {
+    QueryExtractor::new(&TS_QUERIES, || {
+        tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+    })
 }
 
-fn extract_ts(node: Node, src: &[u8], path: &str, graph: &mut Graph) {
-    match node.kind() {
-        "function_declaration" | "arrow_function" => {
-            if let Some(name_node) = node.child_by_field_name("name") {
-                let name = name_node.utf8_text(src).unwrap_or("?");
-                graph.add_edge(ast_edge(name, "defined_in", path));
-            }
-        }
-        "import_statement" => {
-            if let Some(src_node) = node.child_by_field_name("source") {
-                let module = src_node
-                    .utf8_text(src)
-                    .unwrap_or("?")
-                    .trim_matches('"')
-                    .trim_matches('\'');
-                graph.add_edge(ast_edge(path, "imports", module));
-            }
-        }
-        _ => {}
-    }
-    for i in 0..node.child_count() {
-        extract_ts(node.child(i as u32).unwrap(), src, path, graph);
+/// Preserve the public name for backward compatibility.
+pub struct TsExtractor;
+
+impl TsExtractor {
+    pub fn new() -> QueryExtractor {
+        ts_extractor()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use larql_core::core::graph::Graph;
+
+    use super::*;
+    use crate::languages::LanguageExtractor;
 
     #[test]
     fn ts_function_produces_defined_in() {
-        let src = "function greet(name: string): string { return `Hello ${name}`; }";
+        let src = "function greet(name: string): string { return name; }";
         let mut g = Graph::new();
-        TsExtractor.extract(src, "hello.ts", &mut g);
-        let entities = g.list_entities();
+        ts_extractor().extract(src, "src/greet.ts", &mut g);
         assert!(
-            entities.iter().any(|n| n.contains("greet")),
-            "expected 'greet' in entities, got: {:?}",
-            entities
+            g.list_entities().iter().any(|n| n.contains("greet")),
+            "expected 'greet' in entities"
+        );
+    }
+
+    #[test]
+    fn ts_import_produces_imports_edge() {
+        let src = "import { foo } from './bar';";
+        let mut g = Graph::new();
+        ts_extractor().extract(src, "src/main.ts", &mut g);
+        assert!(
+            g.edges().iter().any(|e| e.relation == "imports"),
+            "expected an 'imports' edge"
         );
     }
 }

--- a/crates/larql-codebase/src/languages/ts_lang.rs
+++ b/crates/larql-codebase/src/languages/ts_lang.rs
@@ -12,6 +12,7 @@ pub fn ts_extractor() -> QueryExtractor {
 pub struct TsExtractor;
 
 impl TsExtractor {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> QueryExtractor {
         ts_extractor()
     }

--- a/crates/larql-codebase/src/languages/wasm_extractor.rs
+++ b/crates/larql-codebase/src/languages/wasm_extractor.rs
@@ -7,7 +7,8 @@ pub struct WasmExtractor;
 
 impl LanguageExtractor for WasmExtractor {
     fn extensions(&self) -> &[&'static str] {
-        &["wat", "wasm"]
+        // "wasm" (binary) not yet supported — requires binary file read path
+        &["wat"]
     }
 
     fn extract(&self, source: &str, path: &str, graph: &mut Graph) {
@@ -151,6 +152,7 @@ mod tests {
     #[test]
     fn wasm_extractor_extensions() {
         assert!(WasmExtractor.extensions().contains(&"wat"));
-        assert!(WasmExtractor.extensions().contains(&"wasm"));
+        // "wasm" (binary) not yet supported — binary read path not implemented
+        assert!(!WasmExtractor.extensions().contains(&"wasm"));
     }
 }

--- a/crates/larql-codebase/src/languages/wasm_extractor.rs
+++ b/crates/larql-codebase/src/languages/wasm_extractor.rs
@@ -1,0 +1,156 @@
+use larql_core::core::graph::Graph;
+use wasmparser::{ExternalKind, Parser as WasmParser, Payload, TypeRef};
+
+use super::{ast_edge, LanguageExtractor};
+
+pub struct WasmExtractor;
+
+impl LanguageExtractor for WasmExtractor {
+    fn extensions(&self) -> &[&'static str] {
+        &["wat", "wasm"]
+    }
+
+    fn extract(&self, source: &str, path: &str, graph: &mut Graph) {
+        // .wat text → .wasm binary via the `wat` crate.
+        // For .wasm binary files, LanguageExtractor passes source as &str
+        // (read_to_string fails on non-UTF-8, so only .wat text files reach us
+        // in the standard codebase walker). The binary branch is provided for
+        // completeness but .wasm files are effectively skipped by the walker.
+        let binary: Vec<u8> = if path.ends_with(".wasm") {
+            // Binary .wasm files can't be read as UTF-8 text; skip gracefully.
+            // Future work: add a separate binary-file walk path in extractor.rs.
+            return;
+        } else {
+            match wat::parse_str(source) {
+                Ok(b) => b,
+                Err(_) => return,
+            }
+        };
+
+        extract_binary(&binary, path, graph);
+    }
+}
+
+fn extract_binary(binary: &[u8], path: &str, graph: &mut Graph) {
+    for payload in WasmParser::new(0).parse_all(binary) {
+        let payload = match payload {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+
+        match payload {
+            Payload::ImportSection(reader) => {
+                // In wasmparser 0.252.0, ImportSectionReader yields Imports<'_>
+                // (which may encode compact groups). Call .into_imports() to flatten
+                // into individual Import items.
+                for import in reader.into_imports() {
+                    let import = match import {
+                        Ok(i) => i,
+                        Err(_) => continue,
+                    };
+                    // Track all imports (func, global, memory, table)
+                    let kind = match import.ty {
+                        TypeRef::Func(_) | TypeRef::FuncExact(_) => "func",
+                        TypeRef::Global(_) => "global",
+                        TypeRef::Memory(_) => "memory",
+                        TypeRef::Table(_) => "table",
+                        TypeRef::Tag(_) => "tag",
+                    };
+                    let name = format!("{}::{}", import.module, import.name);
+                    graph.add_edge(ast_edge(path, &format!("imports_{kind}"), &name));
+                }
+            }
+            Payload::ExportSection(reader) => {
+                for export in reader {
+                    let export = match export {
+                        Ok(e) => e,
+                        Err(_) => continue,
+                    };
+                    match export.kind {
+                        ExternalKind::Func | ExternalKind::FuncExact => {
+                            graph.add_edge(ast_edge(export.name, "defined_in", path));
+                            graph.add_edge(ast_edge(path, "exports", export.name));
+                        }
+                        ExternalKind::Global => {
+                            graph.add_edge(ast_edge(path, "exports_global", export.name));
+                        }
+                        ExternalKind::Memory => {
+                            graph.add_edge(ast_edge(path, "exports_memory", export.name));
+                        }
+                        ExternalKind::Table => {
+                            graph.add_edge(ast_edge(path, "exports_table", export.name));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use larql_core::core::graph::Graph;
+
+    const SIMPLE_WAT: &str = r#"
+(module
+  (func $add (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.add)
+  (export "add" (func $add))
+)
+"#;
+
+    const IMPORT_WAT: &str = r#"
+(module
+  (import "env" "log" (func (param i32)))
+  (func $main)
+)
+"#;
+
+    #[test]
+    fn wat_export_produces_defined_in() {
+        let mut g = Graph::new();
+        WasmExtractor.extract(SIMPLE_WAT, "math.wat", &mut g);
+        assert!(!g.edges().is_empty(), "Expected edges from WAT module");
+        assert!(
+            g.edges()
+                .iter()
+                .any(|e| e.relation == "defined_in" || e.relation == "exports"),
+            "Expected 'defined_in' or 'exports' edge from exported function"
+        );
+    }
+
+    #[test]
+    fn wat_export_subject_is_function_name() {
+        let mut g = Graph::new();
+        WasmExtractor.extract(SIMPLE_WAT, "math.wat", &mut g);
+        assert!(
+            g.edges()
+                .iter()
+                .any(|e| e.subject == "add" && e.relation == "defined_in" && e.object == "math.wat"),
+            "Expected edge: add --defined_in--> math.wat"
+        );
+    }
+
+    #[test]
+    fn wat_import_produces_imports_func_edge() {
+        let mut g = Graph::new();
+        WasmExtractor.extract(IMPORT_WAT, "app.wat", &mut g);
+        assert!(
+            g.edges()
+                .iter()
+                .any(|e| e.relation == "imports_func" && e.object == "env::log"),
+            "Expected imports_func edge for env::log"
+        );
+    }
+
+    #[test]
+    fn wasm_extractor_extensions() {
+        assert!(WasmExtractor.extensions().contains(&"wat"));
+        assert!(WasmExtractor.extensions().contains(&"wasm"));
+    }
+}

--- a/crates/larql-codebase/src/lib.rs
+++ b/crates/larql-codebase/src/lib.rs
@@ -8,5 +8,5 @@ pub mod vindex_builder;
 pub use extractor::{extract_codebase, CodebaseError};
 pub use gguf::write_weight_repr_to_gguf;
 pub use languages::{LanguageExtractor, PythonExtractor, RustExtractor, TsExtractor};
-pub use nquads::graph_to_nquads;
+pub use nquads::graph_to_ntriples;
 pub use vindex_builder::graph_to_weight_repr;

--- a/crates/larql-codebase/src/lib.rs
+++ b/crates/larql-codebase/src/lib.rs
@@ -2,9 +2,11 @@
 pub mod extractor;
 pub mod gguf;
 pub mod languages;
+pub mod nquads;
 pub mod vindex_builder;
 
 pub use extractor::{extract_codebase, CodebaseError};
 pub use gguf::write_weight_repr_to_gguf;
 pub use languages::{LanguageExtractor, PythonExtractor, RustExtractor, TsExtractor};
+pub use nquads::graph_to_nquads;
 pub use vindex_builder::graph_to_weight_repr;

--- a/crates/larql-codebase/src/nquads.rs
+++ b/crates/larql-codebase/src/nquads.rs
@@ -1,0 +1,109 @@
+use larql_core::core::graph::Graph;
+
+/// Serialize a `Graph` to sorted N-Quads (RDFC-1.0 for all-named-node graphs).
+///
+/// Each edge `(subject, relation, object)` becomes one N-Quads line:
+/// `<subject_iri> <relation_iri> <object_iri> .\n`
+///
+/// IRIs that are already absolute (`http://`, `https://`, `urn:`, `file://`) are
+/// used verbatim. All other strings are percent-encoded and prefixed with
+/// `base_iri` (e.g. `"urn:larql:"`).
+///
+/// The output is sorted lexicographically — a stable, content-addressable
+/// fingerprint equivalent to RDFC-1.0 for graphs with no blank nodes.
+pub fn graph_to_nquads(graph: &Graph, base_iri: &str) -> String {
+    let mut lines: Vec<String> = graph
+        .edges()
+        .iter()
+        .map(|e| {
+            let s = mint_iri(&e.subject, base_iri);
+            let p = mint_iri(&e.relation, base_iri);
+            let o = mint_iri(&e.object, base_iri);
+            format!("{} {} {} .\n", s, p, o)
+        })
+        .collect();
+    lines.sort();
+    lines.join("")
+}
+
+fn mint_iri(s: &str, base_iri: &str) -> String {
+    if s.starts_with("http://")
+        || s.starts_with("https://")
+        || s.starts_with("urn:")
+        || s.starts_with("file://")
+    {
+        format!("<{}>", s)
+    } else {
+        let encoded = percent_encode(s);
+        format!("<{}{}>", base_iri, encoded)
+    }
+}
+
+fn percent_encode(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~' | '/' | ':') {
+                c.to_string().chars().collect::<Vec<char>>()
+            } else {
+                // encode as UTF-8 percent-escaped bytes
+                c.to_string()
+                    .as_bytes()
+                    .iter()
+                    .flat_map(|b| format!("%{:02X}", b).chars().collect::<Vec<char>>())
+                    .collect()
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use larql_core::core::{edge::Edge, graph::Graph};
+
+    fn make_graph_with_edge(s: &str, r: &str, o: &str) -> Graph {
+        let mut g = Graph::new();
+        g.add_edge(Edge::new(s, r, o));
+        g
+    }
+
+    #[test]
+    fn nquads_output_ends_with_newline() {
+        let g = make_graph_with_edge("Alice", "knows", "Bob");
+        let out = graph_to_nquads(&g, "urn:larql:");
+        assert!(out.ends_with('\n'), "N-Quads must end with newline");
+    }
+
+    #[test]
+    fn nquads_output_is_sorted() {
+        let mut g = Graph::new();
+        g.add_edge(Edge::new("Z", "rel", "A"));
+        g.add_edge(Edge::new("A", "rel", "Z"));
+        let out = graph_to_nquads(&g, "urn:larql:");
+        let lines: Vec<&str> = out.lines().collect();
+        let mut sorted = lines.clone();
+        sorted.sort();
+        assert_eq!(lines, sorted, "N-Quads lines must be sorted");
+    }
+
+    #[test]
+    fn http_iris_not_re_minted() {
+        let g = make_graph_with_edge(
+            "http://example.org/Alice",
+            "http://schema.org/knows",
+            "http://example.org/Bob",
+        );
+        let out = graph_to_nquads(&g, "urn:larql:");
+        assert!(
+            out.contains("<http://example.org/Alice>"),
+            "HTTP IRIs must appear verbatim in angle brackets"
+        );
+    }
+
+    #[test]
+    fn non_iri_strings_are_minted() {
+        let g = make_graph_with_edge("hello world", "is", "greeting");
+        let out = graph_to_nquads(&g, "urn:larql:");
+        assert!(out.contains("urn:larql:"), "non-IRI strings must be minted");
+    }
+}

--- a/crates/larql-codebase/src/nquads.rs
+++ b/crates/larql-codebase/src/nquads.rs
@@ -43,20 +43,15 @@ fn mint_iri(s: &str, base_iri: &str) -> String {
 }
 
 fn percent_encode(s: &str) -> String {
-    s.chars()
-        .flat_map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~' | '/' | ':') {
-                c.to_string().chars().collect::<Vec<char>>()
-            } else {
-                // encode as UTF-8 percent-escaped bytes
-                c.to_string()
-                    .as_bytes()
-                    .iter()
-                    .flat_map(|b| format!("%{:02X}", b).chars().collect::<Vec<char>>())
-                    .collect()
-            }
-        })
-        .collect()
+    let mut encoded = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~' | b'/' | b':') {
+            encoded.push(b as char);
+        } else {
+            encoded.push_str(&format!("%{:02X}", b));
+        }
+    }
+    encoded
 }
 
 #[cfg(test)]

--- a/crates/larql-codebase/src/nquads.rs
+++ b/crates/larql-codebase/src/nquads.rs
@@ -1,8 +1,8 @@
 use larql_core::core::graph::Graph;
 
-/// Serialize a `Graph` to sorted N-Quads (RDFC-1.0 for all-named-node graphs).
+/// Serialize a `Graph` to sorted N-Triples (RDFC-1.0 for all-named-node graphs).
 ///
-/// Each edge `(subject, relation, object)` becomes one N-Quads line:
+/// Each edge `(subject, relation, object)` becomes one N-Triples line:
 /// `<subject_iri> <relation_iri> <object_iri> .\n`
 ///
 /// IRIs that are already absolute (`http://`, `https://`, `urn:`, `file://`) are
@@ -11,7 +11,10 @@ use larql_core::core::graph::Graph;
 ///
 /// The output is sorted lexicographically — a stable, content-addressable
 /// fingerprint equivalent to RDFC-1.0 for graphs with no blank nodes.
-pub fn graph_to_nquads(graph: &Graph, base_iri: &str) -> String {
+///
+/// Note: this emits 3-term triples `<s> <p> <o> .` without a graph label —
+/// that is N-Triples format, not N-Quads (which requires a 4th graph IRI).
+pub fn graph_to_ntriples(graph: &Graph, base_iri: &str) -> String {
     let mut lines: Vec<String> = graph
         .edges()
         .iter()
@@ -68,22 +71,22 @@ mod tests {
     }
 
     #[test]
-    fn nquads_output_ends_with_newline() {
+    fn ntriples_output_ends_with_newline() {
         let g = make_graph_with_edge("Alice", "knows", "Bob");
-        let out = graph_to_nquads(&g, "urn:larql:");
-        assert!(out.ends_with('\n'), "N-Quads must end with newline");
+        let out = graph_to_ntriples(&g, "urn:larql:");
+        assert!(out.ends_with('\n'), "N-Triples must end with newline");
     }
 
     #[test]
-    fn nquads_output_is_sorted() {
+    fn ntriples_output_is_sorted() {
         let mut g = Graph::new();
         g.add_edge(Edge::new("Z", "rel", "A"));
         g.add_edge(Edge::new("A", "rel", "Z"));
-        let out = graph_to_nquads(&g, "urn:larql:");
+        let out = graph_to_ntriples(&g, "urn:larql:");
         let lines: Vec<&str> = out.lines().collect();
         let mut sorted = lines.clone();
         sorted.sort();
-        assert_eq!(lines, sorted, "N-Quads lines must be sorted");
+        assert_eq!(lines, sorted, "N-Triples lines must be sorted");
     }
 
     #[test]
@@ -93,7 +96,7 @@ mod tests {
             "http://schema.org/knows",
             "http://example.org/Bob",
         );
-        let out = graph_to_nquads(&g, "urn:larql:");
+        let out = graph_to_ntriples(&g, "urn:larql:");
         assert!(
             out.contains("<http://example.org/Alice>"),
             "HTTP IRIs must appear verbatim in angle brackets"
@@ -103,7 +106,7 @@ mod tests {
     #[test]
     fn non_iri_strings_are_minted() {
         let g = make_graph_with_edge("hello world", "is", "greeting");
-        let out = graph_to_nquads(&g, "urn:larql:");
+        let out = graph_to_ntriples(&g, "urn:larql:");
         assert!(out.contains("urn:larql:"), "non-IRI strings must be minted");
     }
 }


### PR DESCRIPTION
## Summary

Implements Plan 4: query-driven language extractors for larql-codebase and larql-codebase-core. Stacks on PR #229 (Plans 1–3).

- **Tier-0 (`larql-codebase-core`, `#![no_std]`, wasm32v1-none)** — `languages/` module:
  - `EdgeTemplate` + `LanguageQueries` structs — tree-sitter S-expression query strings as `&'static str` const data (no tree-sitter in Tier-0)
  - `Endpoint` enum: `Capture`, `Scope`, `File`, `Literal`
  - Per-language query tables: Rust, Python, TypeScript/AssemblyScript, Java
  - LQL AST adapter: `lql_to_edges()` — wraps `larql-lql-core::parse()` to emit `(entity, relation, target, confidence)` tuples
  - Compilation strategy matrix: `COMPILATION_MATRIX` const documenting which (language, wasm target) pairs compile

- **Tier-1 (`larql-codebase`, std)** — 8 language extractors:
  - `QueryExtractor` — generic tree-sitter walker using unified DFS tree walk with shared `scope_stack`; `kind_from_query()` gates each template to matching node kinds; `cursor.set_max_start_depth(Some(0))` prevents double-counting
  - Rust, Python, TypeScript/AssemblyScript — migrated to `QueryExtractor`; backward-compat `::new()` shims preserved
  - Java — `QueryExtractor` + `tree-sitter-java = "0.23"`
  - SPARQL BGP — `SparqlExtractor` via `spargebra = "0.4.6"`; walks all `GraphPattern` variants
  - GraphQL SDL — `GraphqlExtractor` via `graphql-parser = "0.4.1"`; emits type/field/interface/enum edges
  - LQL — `LqlExtractor` wrapping Tier-0 `lql_to_edges()`
  - WAT — `WasmExtractor` via `wat = "1.252.0"` (text→binary) + `wasmparser = "0.252.0"` (export/import edges); `.wasm` binary path deferred

- **N-Triples serializer** — `graph_to_ntriples(graph, base_iri) -> String`; sorted output = RDFC-1.0 canonical form for all-named-node graphs; `--format ntriples` CLI flag writes `.nt` file

- **CI** — comment in `tier0.yml` documenting `languages/` module coverage under existing wasm32v1-none check

## Verification

- `cargo test -p larql-codebase -p larql-codebase-core` → **79 passed, 0 failed**
- `cargo clippy -p larql-codebase -p larql-codebase-core -- -D warnings` → **0 warnings**
- `cargo build --target wasm32v1-none -p larql-codebase-core` → **exit 0**

## Test plan

- [ ] `cargo test -p larql-codebase -p larql-codebase-core` → 79 passed, 0 failed
- [ ] `cargo clippy -p larql-codebase -p larql-codebase-core -- -D warnings` → 0 warnings
- [ ] `cargo build --target wasm32v1-none -p larql-codebase-core` → exit 0
- [ ] All 8 extractors listed in `extractor.rs::extractors()` (Rust, Python, TS, Java, SPARQL, GraphQL, LQL, WAT)
- [ ] `graph_to_ntriples()` produces sorted, deterministic N-Triples output
- [ ] Java `calls` edge fires inside class body (scope tracking test passes)
- [ ] WAT export/import edges emitted from `(module ...)` text input

🤖 Generated with [Claude Code](https://claude.com/claude-code)