### PR TITLE
fix(balance): detect multi-subtoken targets via first BPE subtoken

### DIFF
--- a/crates/larql-lql/src/executor/helpers.rs
+++ b/crates/larql-lql/src/executor/helpers.rs
@@ -22,6 +22,26 @@ pub(crate) fn target_prefix(s: &str, n: usize) -> &str {
     }
 }
 
+/// Encode `target` as it appears mid-sentence (space-prefixed) and return
+/// the decoded first BPE subtoken, preserving leading whitespace.
+///
+/// Multi-subtoken targets like `_check_larql` tokenize to `[Ġ_, check, …]`;
+/// `predict_with_ffn` emits `" _"` (with space) — not the full identifier —
+/// so `contains(target)` and `starts_with(prefix)` both miss it. This
+/// function produces the string that actually appears in the prediction list.
+pub(crate) fn target_first_subtoken(
+    tokenizer: &larql_vindex::tokenizers::Tokenizer,
+    target: &str,
+) -> Option<String> {
+    let spaced = format!(" {target}");
+    tokenizer
+        .encode(spaced.as_str(), false)
+        .ok()
+        .and_then(|enc| enc.get_ids().first().copied())
+        .and_then(|id| tokenizer.decode(&[id], true).ok())
+        .filter(|s| !s.is_empty())
+}
+
 /// Average a sequence of embedding rows, applying `embed_scale`. The
 /// pure half of [`entity_query_vec`]: extracted so unit tests can
 /// exercise the math without a tokenizer fixture.

--- a/crates/larql-lql/src/executor/helpers.rs
+++ b/crates/larql-lql/src/executor/helpers.rs
@@ -33,6 +33,9 @@ pub(crate) fn target_first_subtoken(
     tokenizer: &larql_vindex::tokenizers::Tokenizer,
     target: &str,
 ) -> Option<String> {
+    if target.is_empty() {
+        return None;
+    }
     let spaced = format!(" {target}");
     tokenizer
         .encode(spaced.as_str(), false)

--- a/crates/larql-lql/src/executor/mutation/insert/balance.rs
+++ b/crates/larql-lql/src/executor/mutation/insert/balance.rs
@@ -207,7 +207,7 @@ impl Session {
                     .encode(fact.canonical_prompt.as_str(), true)
                     .map_err(|e| LqlError::exec("cross-balance: tokenize", e))?;
                 Ok((
-                    fact.clone(),
+                    fact.target.clone(),
                     enc.get_ids().to_vec(),
                     target_first_subtoken(&tokenizer, &fact.target),
                 ))
@@ -216,7 +216,7 @@ impl Session {
 
         for _iter in 0..CROSS_ITERS {
             let mut any_regressed = false;
-            for (fact, fact_ids, fact_first_subtoken) in &priors_to_check {
+            for (fact_target, fact_ids, fact_first_subtoken) in &priors_to_check {
                 let (_, _, patched) = self.require_vindex()?;
                 let walk =
                     larql_inference::vindex::WalkFfn::new_unlimited_with_trace(&weights, patched);
@@ -227,12 +227,12 @@ impl Session {
                     BALANCE_PROBE_TOP_K,
                     &walk,
                 );
-                let prefix = target_prefix(&fact.target, TARGET_PREFIX_CHARS);
+                let prefix = target_prefix(fact_target, TARGET_PREFIX_CHARS);
                 let p: f64 = r
                     .predictions
                     .iter()
                     .find(|(tok, _)| {
-                        tok.contains(&fact.target)
+                        tok.contains(fact_target.as_str())
                             || tok.starts_with(prefix)
                             || fact_first_subtoken.as_deref() == Some(tok.as_str())
                     })

--- a/crates/larql-lql/src/executor/mutation/insert/balance.rs
+++ b/crates/larql-lql/src/executor/mutation/insert/balance.rs
@@ -12,7 +12,7 @@
 //!     until priors recover, capped at CROSS_ITERS.
 
 use crate::error::LqlError;
-use crate::executor::helpers::{target_prefix, TARGET_PREFIX_CHARS};
+use crate::executor::helpers::{target_first_subtoken, target_prefix, TARGET_PREFIX_CHARS};
 use crate::executor::tuning::{
     canonical_prompt, BALANCE_ITERS, BALANCE_PROBE_TOP_K, CROSS_ITERS, DOWN_SCALE,
     MAX_PRIORS_CHECKED, MAX_STALE, PRIOR_FLOOR, PROB_CEILING, PROB_FLOOR, UP_SCALE,
@@ -57,6 +57,11 @@ impl Session {
             .map_err(|e| LqlError::exec("balance: tokenize", e))?;
         let prompt_ids: Vec<u32> = enc.get_ids().to_vec();
 
+        // Pre-compute target matching values once — both are pure functions of
+        // `target` and the tokenizer and don't change across iterations.
+        let prefix = target_prefix(target, TARGET_PREFIX_CHARS);
+        let first_subtoken = target_first_subtoken(&tokenizer, target);
+
         // Snapshot/restore applies only to the AMPLIFY path: when
         // UP_SCALE saturates (residual blow-up, softmax collapse in
         // late layers), we roll back to the iteration that produced
@@ -80,11 +85,14 @@ impl Session {
                 &walk_ffn,
             );
 
-            let prefix = target_prefix(target, TARGET_PREFIX_CHARS);
             let target_prob: f64 = result
                 .predictions
                 .iter()
-                .find(|(tok, _)| tok.contains(target) || tok.starts_with(prefix))
+                .find(|(tok, _)| {
+                    tok.contains(target)
+                        || tok.starts_with(prefix)
+                        || first_subtoken.as_deref() == Some(tok.as_str())
+                })
                 .map(|(_, prob)| *prob)
                 .unwrap_or(0.0);
 
@@ -186,27 +194,36 @@ impl Session {
         let tokenizer = larql_vindex::load_vindex_tokenizer(path)
             .map_err(|e| LqlError::exec("cross-balance: load tokenizer", e))?;
 
-        for _iter in 0..CROSS_ITERS {
-            let mut any_regressed = false;
-            let priors_to_check: Vec<_> = self
-                .installed_edges
-                .iter()
-                .rev()
-                .take(MAX_PRIORS_CHECKED)
-                .cloned()
-                .collect();
-            for fact in &priors_to_check {
+        // Pre-compute per-fact immutable data once — canonical prompt tokenization
+        // and first subtoken are pure functions of each fact and the tokenizer;
+        // recomputing them across CROSS_ITERS iterations is wasted work.
+        let priors_to_check: Vec<_> = self
+            .installed_edges
+            .iter()
+            .rev()
+            .take(MAX_PRIORS_CHECKED)
+            .map(|fact| -> Result<_, LqlError> {
                 let enc = tokenizer
                     .encode(fact.canonical_prompt.as_str(), true)
                     .map_err(|e| LqlError::exec("cross-balance: tokenize", e))?;
-                let fact_ids: Vec<u32> = enc.get_ids().to_vec();
+                Ok((
+                    fact.clone(),
+                    enc.get_ids().to_vec(),
+                    target_first_subtoken(&tokenizer, &fact.target),
+                ))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for _iter in 0..CROSS_ITERS {
+            let mut any_regressed = false;
+            for (fact, fact_ids, fact_first_subtoken) in &priors_to_check {
                 let (_, _, patched) = self.require_vindex()?;
                 let walk =
                     larql_inference::vindex::WalkFfn::new_unlimited_with_trace(&weights, patched);
                 let r = larql_inference::predict_with_ffn(
                     &weights,
                     &tokenizer,
-                    &fact_ids,
+                    fact_ids,
                     BALANCE_PROBE_TOP_K,
                     &walk,
                 );
@@ -214,7 +231,11 @@ impl Session {
                 let p: f64 = r
                     .predictions
                     .iter()
-                    .find(|(tok, _)| tok.contains(&fact.target) || tok.starts_with(prefix))
+                    .find(|(tok, _)| {
+                        tok.contains(&fact.target)
+                            || tok.starts_with(prefix)
+                            || fact_first_subtoken.as_deref() == Some(tok.as_str())
+                    })
                     .map(|(_, p)| *p)
                     .unwrap_or(0.0);
                 if p < PRIOR_FLOOR {

--- a/crates/larql-lql/src/executor/mutation/rebalance.rs
+++ b/crates/larql-lql/src/executor/mutation/rebalance.rs
@@ -59,35 +59,49 @@ impl Session {
         let mut iters_run = 0usize;
         let mut final_probs: Vec<f64> = vec![0.0; n_facts];
 
+        // Pre-compute per-fact immutable data once — canonical prompt
+        // tokenization, prefix, and first subtoken are pure functions of each
+        // fact and the tokenizer and don't change across max_iters iterations.
+        let facts_precomputed: Vec<_> = {
+            let facts_snapshot = self.installed_edges.clone();
+            facts_snapshot
+                .into_iter()
+                .map(|fact| -> Result<_, LqlError> {
+                    let enc = tokenizer
+                        .encode(fact.canonical_prompt.as_str(), true)
+                        .map_err(|e| LqlError::exec("rebalance: tokenize", e))?;
+                    let ids = enc.get_ids().to_vec();
+                    let prefix_len = target_prefix(&fact.target, TARGET_PREFIX_CHARS).len();
+                    let first_subtoken = target_first_subtoken(&tokenizer, &fact.target);
+                    Ok((fact, ids, prefix_len, first_subtoken))
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        };
+
         for iter in 0..max_iters {
             iters_run = iter + 1;
             let mut any_changed = false;
-            let facts_snapshot = self.installed_edges.clone();
 
-            for (i, fact) in facts_snapshot.iter().enumerate() {
-                let enc = tokenizer
-                    .encode(fact.canonical_prompt.as_str(), true)
-                    .map_err(|e| LqlError::exec("rebalance: tokenize", e))?;
-                let ids: Vec<u32> = enc.get_ids().to_vec();
-
+            for (i, (fact, ids, prefix_len, first_subtoken)) in
+                facts_precomputed.iter().enumerate()
+            {
                 let (_, _, patched) = self.require_vindex()?;
                 let walk =
                     larql_inference::vindex::WalkFfn::new_unlimited_with_trace(&weights, patched);
                 let r = larql_inference::predict_with_ffn(
                     &weights,
                     &tokenizer,
-                    &ids,
+                    ids,
                     REBALANCE_PROBE_TOP_K,
                     &walk,
                 );
 
-                let prefix = target_prefix(&fact.target, TARGET_PREFIX_CHARS);
-                let first_subtoken = target_first_subtoken(&tokenizer, &fact.target);
+                let prefix = &fact.target[..*prefix_len];
                 let prob: f64 = r
                     .predictions
                     .iter()
                     .find(|(tok, _)| {
-                        tok.contains(&fact.target)
+                        tok.contains(fact.target.as_str())
                             || tok.starts_with(prefix)
                             || first_subtoken.as_deref() == Some(tok.as_str())
                     })

--- a/crates/larql-lql/src/executor/mutation/rebalance.rs
+++ b/crates/larql-lql/src/executor/mutation/rebalance.rs
@@ -20,7 +20,7 @@
 //! to dampen oscillation between competing template-shared facts.
 
 use crate::error::LqlError;
-use crate::executor::helpers::{target_prefix, TARGET_PREFIX_CHARS};
+use crate::executor::helpers::{target_first_subtoken, target_prefix, TARGET_PREFIX_CHARS};
 use crate::executor::tuning::{
     REBALANCE_CEILING_DEFAULT, REBALANCE_DOWN_SCALE, REBALANCE_FLOOR_DEFAULT,
     REBALANCE_MAX_ITERS_DEFAULT, REBALANCE_PROBE_TOP_K, REBALANCE_UP_SCALE,
@@ -82,10 +82,15 @@ impl Session {
                 );
 
                 let prefix = target_prefix(&fact.target, TARGET_PREFIX_CHARS);
+                let first_subtoken = target_first_subtoken(&tokenizer, &fact.target);
                 let prob: f64 = r
                     .predictions
                     .iter()
-                    .find(|(tok, _)| tok.contains(&fact.target) || tok.starts_with(prefix))
+                    .find(|(tok, _)| {
+                        tok.contains(&fact.target)
+                            || tok.starts_with(prefix)
+                            || first_subtoken.as_deref() == Some(tok.as_str())
+                    })
                     .map(|(_, p)| *p)
                     .unwrap_or(0.0);
                 final_probs[i] = prob;


### PR DESCRIPTION
Closes #236.

## Summary

`balance_installed`, `cross_fact_regression_check`, and `exec_rebalance`
all use a two-condition predicate to find the target token in top-k predictions:

```rust
tok.contains(target) || tok.starts_with(prefix)
```

This predicate is blind to multi-subtoken targets. `_check_larql` BPE-encodes
to `[Ġ_, check, _, larql]`; `predict_with_ffn` emits `" _"` (with leading
space). Neither condition matches — `" _"` doesn't contain the full identifier,
and `starts_with("_ch")` fails because of the leading space. Result:
`target_prob = 0.0` for every balance iteration, leaving the install
un-balanced.

## Fix

Add `target_first_subtoken()` to `helpers.rs` — encodes `" {target}"`,
decodes the first token ID with space preserved (matching `predict_with_ffn`
exactly) — and add it as a third condition at all three sites.

Also pre-compute `prefix` and `first_subtoken` before loops in
`balance_installed` and `cross_fact_regression_check` (pure functions of
`target`/tokenizer, invariant across iterations), and hoist
`priors_to_check` construction with pre-tokenized `fact_ids` and
`fact_first_subtoken` before the `CROSS_ITERS` loop.

## Files changed

- `crates/larql-lql/src/executor/helpers.rs` — `target_first_subtoken()` helper
- `crates/larql-lql/src/executor/mutation/insert/balance.rs` — 2 predicate sites updated, loop invariants hoisted
- `crates/larql-lql/src/executor/mutation/rebalance.rs` — predicate site updated

## Base branch note

`tracking/upstream-main` is pinned to `ab7a08c1` (upstream `chrishayuk/larql`
main as of 2026-06-26) so this PR shows exactly 1 atomic commit.