### PR TITLE
feat(extract): GgufWeightSource — per-tensor GGUF dequant weight source

### DIFF
--- a/crates/larql-vindex/src/extract/streaming/mod.rs
+++ b/crates/larql-vindex/src/extract/streaming/mod.rs
@@ -21,7 +21,7 @@
 
 mod context;
 mod stages;
-mod tensor_io;
+pub(crate) mod tensor_io;
 
 use std::path::Path;
 

--- a/crates/larql-vindex/src/extract/streaming/tensor_io.rs
+++ b/crates/larql-vindex/src/extract/streaming/tensor_io.rs
@@ -36,6 +36,10 @@ pub(crate) struct MmapShard {
 /// The MXFP4 raw-pair path (packed expert gate_up/down in DeepSeek-V4)
 /// is safetensors-only — GGUF stores the same expert tensors as standard
 /// blockwise quants (Q4_0/Q4_K/…) handled by `get_tensor_f32` directly.
+/// Validated raw bytes + element count + tensor info for one GGUF tensor,
+/// as returned by `GgufTensorSource::raw_slice_for`.
+type GgufRawSlice<'a> = (&'a [u8], usize, &'a larql_models::loading::gguf::GgufTensorInfo);
+
 pub(crate) enum TensorSource {
     Safetensors {
         shards: Vec<MmapShard>,
@@ -228,14 +232,7 @@ impl GgufTensorSource {
         &self,
         key: &str,
         n_dims: usize,
-    ) -> Result<
-        Option<(
-            &[u8],
-            usize,
-            &larql_models::loading::gguf::GgufTensorInfo,
-        )>,
-        VindexError,
-    > {
+    ) -> Result<Option<GgufRawSlice<'_>>, VindexError> {
         let info_idx = match self.index.get(key) {
             Some(&i) => i,
             None => return Ok(None),

--- a/crates/larql-vindex/src/extract/streaming/tensor_io.rs
+++ b/crates/larql-vindex/src/extract/streaming/tensor_io.rs
@@ -25,9 +25,9 @@ use ndarray::Array2;
 use crate::error::VindexError;
 
 /// Mmap'd safetensors file — kept alive for the duration of extraction.
-pub(super) struct MmapShard {
-    pub(super) _file: std::fs::File,
-    pub(super) mmap: memmap2::Mmap,
+pub(crate) struct MmapShard {
+    pub(crate) _file: std::fs::File,
+    pub(crate) mmap: memmap2::Mmap,
 }
 
 /// Tensor source for the streaming pipeline. Dispatches `get_tensor_f32`
@@ -117,6 +117,8 @@ impl TensorSource {
 
     /// Borrow the GGUF backend for 1-D tensor access (norm/bias weights
     /// via `get_vector_f32`). Returns `None` for the safetensors variant.
+    // consumed by maybe_write_model_weights GGUF dispatch (next commit, #167)
+    #[allow(dead_code)]
     pub(crate) fn gguf_source(&self) -> Option<&GgufTensorSource> {
         match self {
             TensorSource::Gguf(g) => Some(g),

--- a/crates/larql-vindex/src/extract/streaming/tensor_io.rs
+++ b/crates/larql-vindex/src/extract/streaming/tensor_io.rs
@@ -218,126 +218,103 @@ impl GgufTensorSource {
         arr
     }
 
+    /// Validate + locate the raw bytes for `key`, requiring exactly `n_dims`
+    /// dimensions. Returns `Ok(None)` if the key is absent or the rank differs.
+    /// Centralizes the byte-addressing + overflow/bounds guards shared by the
+    /// 1-D and 2-D accessors.
+    fn raw_slice_for(
+        &self,
+        key: &str,
+        n_dims: usize,
+    ) -> Result<
+        Option<(
+            &[u8],
+            usize,
+            &larql_models::loading::gguf::GgufTensorInfo,
+        )>,
+        VindexError,
+    > {
+        let info_idx = match self.index.get(key) {
+            Some(&i) => i,
+            None => return Ok(None),
+        };
+        let info = &self.gguf.tensor_infos[info_idx];
+        if info.n_dims() as usize != n_dims {
+            return Ok(None);
+        }
+
+        let shard_idx = info.shard_idx();
+        let mmap = &self.shard_mmaps[shard_idx];
+        let data_offset = self.gguf.shards[shard_idx].data_offset;
+        let abs_offset = data_offset.checked_add(info.offset()).ok_or_else(|| {
+            VindexError::Parse(format!(
+                "gguf tensor {}: data_offset {data_offset} + offset {} overflows",
+                info.name(),
+                info.offset(),
+            ))
+        })?;
+
+        let dims = info.dims();
+        let n_elements: u64 = dims.iter().product();
+        let n_elements_usize = usize::try_from(n_elements).map_err(|_| {
+            VindexError::Parse(format!(
+                "gguf tensor {}: n_elements {n_elements} exceeds usize",
+                info.name(),
+            ))
+        })?;
+
+        let data_size =
+            larql_models::quant::ggml::tensor_data_size(info.tensor_type(), n_elements_usize)
+                .map_err(|e| VindexError::Parse(e.to_string()))?;
+        let abs_offset_usize = usize::try_from(abs_offset).map_err(|_| {
+            VindexError::Parse(format!(
+                "gguf tensor {}: abs_offset {abs_offset} exceeds usize",
+                info.name(),
+            ))
+        })?;
+        let end = abs_offset_usize.checked_add(data_size).ok_or_else(|| {
+            VindexError::Parse(format!(
+                "gguf tensor {}: offset+size overflows",
+                info.name(),
+            ))
+        })?;
+        if end > mmap.len() {
+            return Err(VindexError::Parse(format!(
+                "gguf tensor {} out of bounds: end {end} > shard len {}",
+                info.name(),
+                mmap.len(),
+            )));
+        }
+
+        let raw = &mmap[abs_offset_usize..end];
+        Ok(Some((raw, n_elements_usize, info)))
+    }
+
     /// Dequantize a 1-D GGUF tensor (norms, biases) to f32. Returns `Ok(None)`
     /// if the key is absent or the tensor is not 1-D. Peak memory: one tensor.
     pub(crate) fn get_vector_f32(&self, key: &str) -> Result<Option<Vec<f32>>, VindexError> {
-        let info_idx = match self.index.get(key) {
-            Some(&i) => i,
-            None => return Ok(None),
-        };
-        let info = &self.gguf.tensor_infos[info_idx];
-        if info.n_dims() != 1 {
-            return Ok(None);
+        match self.raw_slice_for(key, 1)? {
+            None => Ok(None),
+            Some((raw, n_elements_usize, info)) => {
+                let floats =
+                    larql_models::quant::ggml::dequantize(raw, info.tensor_type(), n_elements_usize)
+                        .map_err(|e| VindexError::Parse(e.to_string()))?;
+                Ok(Some(floats))
+            }
         }
-
-        let shard_idx = info.shard_idx();
-        let mmap = &self.shard_mmaps[shard_idx];
-        let data_offset = self.gguf.shards[shard_idx].data_offset;
-        let abs_offset = data_offset.checked_add(info.offset()).ok_or_else(|| {
-            VindexError::Parse(format!(
-                "gguf tensor {}: data_offset {data_offset} + offset {} overflows",
-                info.name(),
-                info.offset(),
-            ))
-        })?;
-
-        let dims = info.dims();
-        let n_elements: u64 = dims.iter().product();
-        let n_elements_usize = usize::try_from(n_elements).map_err(|_| {
-            VindexError::Parse(format!(
-                "gguf tensor {}: n_elements {n_elements} exceeds usize",
-                info.name(),
-            ))
-        })?;
-
-        let data_size =
-            larql_models::quant::ggml::tensor_data_size(info.tensor_type(), n_elements_usize)
-                .map_err(|e| VindexError::Parse(e.to_string()))?;
-        let abs_offset_usize = usize::try_from(abs_offset).map_err(|_| {
-            VindexError::Parse(format!(
-                "gguf tensor {}: abs_offset {abs_offset} exceeds usize",
-                info.name(),
-            ))
-        })?;
-        let end = abs_offset_usize.checked_add(data_size).ok_or_else(|| {
-            VindexError::Parse(format!(
-                "gguf tensor {}: offset+size overflows",
-                info.name(),
-            ))
-        })?;
-        if end > mmap.len() {
-            return Err(VindexError::Parse(format!(
-                "gguf tensor {} out of bounds: end {end} > shard len {}",
-                info.name(),
-                mmap.len(),
-            )));
-        }
-
-        let raw = &mmap[abs_offset_usize..end];
-        let floats =
-            larql_models::quant::ggml::dequantize(raw, info.tensor_type(), n_elements_usize)
-                .map_err(|e| VindexError::Parse(e.to_string()))?;
-
-        Ok(Some(floats))
     }
 
     pub(crate) fn get_tensor_f32(&self, key: &str) -> Result<Option<Array2<f32>>, VindexError> {
-        let info_idx = match self.index.get(key) {
-            Some(&i) => i,
+        let (raw, n_elements_usize, info) = match self.raw_slice_for(key, 2)? {
             None => return Ok(None),
+            Some(v) => v,
         };
-        let info = &self.gguf.tensor_infos[info_idx];
-        if info.n_dims() != 2 {
-            return Ok(None);
-        }
 
-        let shard_idx = info.shard_idx();
-        let mmap = &self.shard_mmaps[shard_idx];
-        let data_offset = self.gguf.shards[shard_idx].data_offset;
-        let abs_offset = data_offset.checked_add(info.offset()).ok_or_else(|| {
-            VindexError::Parse(format!(
-                "gguf tensor {}: data_offset {data_offset} + offset {} overflows",
-                info.name(),
-                info.offset(),
-            ))
-        })?;
-
-        let dims = info.dims();
-        let n_elements: u64 = dims.iter().product();
-        let n_elements_usize = usize::try_from(n_elements).map_err(|_| {
-            VindexError::Parse(format!(
-                "gguf tensor {}: n_elements {n_elements} exceeds usize",
-                info.name(),
-            ))
-        })?;
-
-        let data_size =
-            larql_models::quant::ggml::tensor_data_size(info.tensor_type(), n_elements_usize)
-                .map_err(|e| VindexError::Parse(e.to_string()))?;
-        let abs_offset_usize = usize::try_from(abs_offset).map_err(|_| {
-            VindexError::Parse(format!(
-                "gguf tensor {}: abs_offset {abs_offset} exceeds usize",
-                info.name(),
-            ))
-        })?;
-        let end = abs_offset_usize.checked_add(data_size).ok_or_else(|| {
-            VindexError::Parse(format!(
-                "gguf tensor {}: offset+size overflows",
-                info.name(),
-            ))
-        })?;
-        if end > mmap.len() {
-            return Err(VindexError::Parse(format!(
-                "gguf tensor {} out of bounds: end {end} > shard len {}",
-                info.name(),
-                mmap.len(),
-            )));
-        }
-
-        let raw = &mmap[abs_offset_usize..end];
         let floats =
             larql_models::quant::ggml::dequantize(raw, info.tensor_type(), n_elements_usize)
                 .map_err(|e| VindexError::Parse(e.to_string()))?;
+
+        let dims = info.dims();
 
         // GGUF dim ordering: dims[0] = columns (innermost/fastest),
         // dims[1] = rows (outermost). Raw bytes are contiguous along
@@ -877,5 +854,37 @@ mod tests {
             Some(vec![1.0, 2.0, 3.0, 4.0])
         );
         assert_eq!(src.get_vector_f32("missing").unwrap(), None);
+    }
+
+    #[test]
+    fn gguf_get_vector_f32_returns_none_for_2d_tensor() {
+        // A 2-D tensor must return Ok(None) from get_vector_f32 —
+        // the n_dims guard in raw_slice_for must reject rank != 1.
+        use larql_models::loading::gguf::{GgufFile, GgufTensor, GgufValue, GgufWriter};
+        let vals = [1.0f32, 2.0, 3.0, 4.0];
+        let mut data = Vec::new();
+        for v in vals {
+            data.extend_from_slice(&v.to_le_bytes());
+        }
+        let mut w = GgufWriter::new();
+        w.meta("general.architecture", GgufValue::String("llama".into()));
+        w.tensor(GgufTensor {
+            name: "blk.0.ffn_gate.weight".into(),
+            dims: vec![2, 2],
+            ggml_type: 0,
+            data,
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tiny2d.gguf");
+        w.write_to_file(&path).unwrap();
+        let gguf = GgufFile::open(&path).unwrap();
+        let mut src = GgufTensorSource::from_gguf(gguf, 0, 0).unwrap();
+        src.index =
+            std::collections::HashMap::from([("ffn_gate.weight".to_string(), 0usize)]);
+        assert_eq!(
+            src.get_vector_f32("ffn_gate.weight").unwrap(),
+            None,
+            "2-D tensor must return Ok(None) from get_vector_f32"
+        );
     }
 }

--- a/crates/larql-vindex/src/extract/streaming/tensor_io.rs
+++ b/crates/larql-vindex/src/extract/streaming/tensor_io.rs
@@ -135,7 +135,7 @@ impl GgufTensorSource {
     /// architecture and drive the canonical FFN orientation applied
     /// inside `get_tensor_f32` (mirrors `orient_in_place` in the
     /// in-memory loader).
-    pub(super) fn from_gguf(
+    pub(crate) fn from_gguf(
         gguf: larql_models::loading::gguf::GgufFile,
         hidden_size: usize,
         intermediate_size: usize,

--- a/crates/larql-vindex/src/extract/streaming/tensor_io.rs
+++ b/crates/larql-vindex/src/extract/streaming/tensor_io.rs
@@ -36,7 +36,7 @@ pub(super) struct MmapShard {
 /// The MXFP4 raw-pair path (packed expert gate_up/down in DeepSeek-V4)
 /// is safetensors-only — GGUF stores the same expert tensors as standard
 /// blockwise quants (Q4_0/Q4_K/…) handled by `get_tensor_f32` directly.
-pub(super) enum TensorSource {
+pub(crate) enum TensorSource {
     Safetensors {
         shards: Vec<MmapShard>,
         /// hf_key → (shard_idx, safetensors-internal name)
@@ -55,11 +55,11 @@ pub(super) enum TensorSource {
 /// of the HF Linear convention — without correction, `tensor.shape()[0]`
 /// is `hidden_size` instead of `intermediate_size` and downstream
 /// matmul produces NaN).
-pub(super) struct GgufTensorSource {
-    pub(super) gguf: larql_models::loading::gguf::GgufFile,
-    pub(super) shard_mmaps: Vec<memmap2::Mmap>,
+pub(crate) struct GgufTensorSource {
+    pub(crate) gguf: larql_models::loading::gguf::GgufFile,
+    pub(crate) shard_mmaps: Vec<memmap2::Mmap>,
     /// hf_key (after `normalize_gguf_key`) → index into `gguf.tensor_infos`.
-    pub(super) index: HashMap<String, usize>,
+    pub(crate) index: HashMap<String, usize>,
     /// Canonical hidden_size — used to orient ffn tensors to HF Linear shape.
     hidden_size: usize,
     /// Canonical intermediate_size (dense FFN). Some MoE architectures
@@ -112,6 +112,15 @@ impl TensorSource {
         match self {
             TensorSource::Safetensors { index, .. } => Some(index),
             TensorSource::Gguf(_) => None,
+        }
+    }
+
+    /// Borrow the GGUF backend for 1-D tensor access (norm/bias weights
+    /// via `get_vector_f32`). Returns `None` for the safetensors variant.
+    pub(crate) fn gguf_source(&self) -> Option<&GgufTensorSource> {
+        match self {
+            TensorSource::Gguf(g) => Some(g),
+            _ => None,
         }
     }
 }
@@ -209,7 +218,70 @@ impl GgufTensorSource {
         arr
     }
 
-    fn get_tensor_f32(&self, key: &str) -> Result<Option<Array2<f32>>, VindexError> {
+    /// Dequantize a 1-D GGUF tensor (norms, biases) to f32. Returns `Ok(None)`
+    /// if the key is absent or the tensor is not 1-D. Peak memory: one tensor.
+    pub(crate) fn get_vector_f32(&self, key: &str) -> Result<Option<Vec<f32>>, VindexError> {
+        let info_idx = match self.index.get(key) {
+            Some(&i) => i,
+            None => return Ok(None),
+        };
+        let info = &self.gguf.tensor_infos[info_idx];
+        if info.n_dims() != 1 {
+            return Ok(None);
+        }
+
+        let shard_idx = info.shard_idx();
+        let mmap = &self.shard_mmaps[shard_idx];
+        let data_offset = self.gguf.shards[shard_idx].data_offset;
+        let abs_offset = data_offset.checked_add(info.offset()).ok_or_else(|| {
+            VindexError::Parse(format!(
+                "gguf tensor {}: data_offset {data_offset} + offset {} overflows",
+                info.name(),
+                info.offset(),
+            ))
+        })?;
+
+        let dims = info.dims();
+        let n_elements: u64 = dims.iter().product();
+        let n_elements_usize = usize::try_from(n_elements).map_err(|_| {
+            VindexError::Parse(format!(
+                "gguf tensor {}: n_elements {n_elements} exceeds usize",
+                info.name(),
+            ))
+        })?;
+
+        let data_size =
+            larql_models::quant::ggml::tensor_data_size(info.tensor_type(), n_elements_usize)
+                .map_err(|e| VindexError::Parse(e.to_string()))?;
+        let abs_offset_usize = usize::try_from(abs_offset).map_err(|_| {
+            VindexError::Parse(format!(
+                "gguf tensor {}: abs_offset {abs_offset} exceeds usize",
+                info.name(),
+            ))
+        })?;
+        let end = abs_offset_usize.checked_add(data_size).ok_or_else(|| {
+            VindexError::Parse(format!(
+                "gguf tensor {}: offset+size overflows",
+                info.name(),
+            ))
+        })?;
+        if end > mmap.len() {
+            return Err(VindexError::Parse(format!(
+                "gguf tensor {} out of bounds: end {end} > shard len {}",
+                info.name(),
+                mmap.len(),
+            )));
+        }
+
+        let raw = &mmap[abs_offset_usize..end];
+        let floats =
+            larql_models::quant::ggml::dequantize(raw, info.tensor_type(), n_elements_usize)
+                .map_err(|e| VindexError::Parse(e.to_string()))?;
+
+        Ok(Some(floats))
+    }
+
+    pub(crate) fn get_tensor_f32(&self, key: &str) -> Result<Option<Array2<f32>>, VindexError> {
         let info_idx = match self.index.get(key) {
             Some(&i) => i,
             None => return Ok(None),
@@ -283,6 +355,15 @@ impl GgufTensorSource {
             None => arr,
         };
         Ok(Some(arr))
+    }
+
+    /// Normalized keys of all 1-D tensors (norm/bias weights).
+    pub(crate) fn vector_names(&self) -> Vec<String> {
+        self.index
+            .iter()
+            .filter(|(_, &i)| self.gguf.tensor_infos[i].n_dims() == 1)
+            .map(|(k, _)| k.clone())
+            .collect()
     }
 }
 
@@ -767,5 +848,34 @@ mod tests {
     fn normalize_handles_empty_input() {
         let prefixes = ["model."];
         assert_eq!(normalize_key("", &prefixes), "");
+    }
+
+    #[test]
+    fn gguf_get_vector_f32_reads_1d_tensor() {
+        use larql_models::loading::gguf::{GgufFile, GgufTensor, GgufValue, GgufWriter};
+        let vals = [1.0f32, 2.0, 3.0, 4.0];
+        let mut data = Vec::new();
+        for v in vals {
+            data.extend_from_slice(&v.to_le_bytes());
+        }
+        let mut w = GgufWriter::new();
+        w.meta("general.architecture", GgufValue::String("llama".into()));
+        w.tensor(GgufTensor {
+            name: "blk.0.attn_norm.weight".into(),
+            dims: vec![4],
+            ggml_type: 0,
+            data,
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tiny.gguf");
+        w.write_to_file(&path).unwrap();
+        let gguf = GgufFile::open(&path).unwrap();
+        let mut src = GgufTensorSource::from_gguf(gguf, 0, 0).unwrap();
+        src.index = std::collections::HashMap::from([("attn_norm.weight".to_string(), 0usize)]);
+        assert_eq!(
+            src.get_vector_f32("attn_norm.weight").unwrap(),
+            Some(vec![1.0, 2.0, 3.0, 4.0])
+        );
+        assert_eq!(src.get_vector_f32("missing").unwrap(), None);
     }
 }

--- a/crates/larql-vindex/src/format/weights/gguf_source.rs
+++ b/crates/larql-vindex/src/format/weights/gguf_source.rs
@@ -1,0 +1,201 @@
+//! `WeightSource` impl backed by a streaming GGUF tensor source.
+//! Each accessor dequantizes one tensor at a time (bounded RAM).
+
+use crate::extract::streaming::tensor_io::GgufTensorSource;
+use crate::format::weights::write_f32::WeightSource;
+
+pub struct GgufWeightSource<'a> {
+    pub gguf: &'a GgufTensorSource,
+    pub arch: &'a dyn larql_models::ModelArchitecture,
+    pub num_layers: usize,
+}
+
+impl<'a> WeightSource for GgufWeightSource<'a> {
+    fn get_tensor(&self, key: &str) -> Option<(Vec<f32>, usize, usize)> {
+        let arr = self.gguf.get_tensor_f32(key).ok()??;
+        let rows = arr.shape()[0];
+        let cols = arr.shape()[1];
+        let data = arr.as_standard_layout().to_owned().into_raw_vec_and_offset().0;
+        Some((data, rows, cols))
+    }
+
+    fn get_vector(&self, key: &str) -> Option<Vec<f32>> {
+        self.gguf.get_vector_f32(key).ok().flatten()
+    }
+
+    fn arch(&self) -> &dyn larql_models::ModelArchitecture {
+        self.arch
+    }
+
+    fn num_layers(&self) -> usize {
+        self.num_layers
+    }
+
+    fn lm_head(&self) -> Option<(Vec<f32>, usize, usize)> {
+        self.get_tensor("lm_head.weight")
+    }
+
+    fn vector_names(&self) -> Vec<String> {
+        self.gguf.vector_names()
+    }
+
+    fn get_packed_bf16(&self, _key: &str) -> Option<Vec<u8>> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use larql_models::loading::gguf::{GgufFile, GgufTensor, GgufValue, GgufWriter};
+    use crate::extract::streaming::tensor_io::GgufTensorSource;
+
+    fn make_test_gguf_source() -> (tempfile::TempDir, GgufTensorSource) {
+        // 2-D tensor: logical shape (2 rows, 3 cols).
+        // GGUF stores dims innermost-first: dims[0]=cols=3, dims[1]=rows=2.
+        // Values row-major: row0=[1,2,3], row1=[4,5,6].
+        let vals_2d = [1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let mut data_2d = Vec::new();
+        for v in vals_2d {
+            data_2d.extend_from_slice(&v.to_le_bytes());
+        }
+
+        // 1-D tensor: 3 elements.
+        let vals_1d = [7.0f32, 8.0, 9.0];
+        let mut data_1d = Vec::new();
+        for v in vals_1d {
+            data_1d.extend_from_slice(&v.to_le_bytes());
+        }
+
+        let mut w = GgufWriter::new();
+        w.meta("general.architecture", GgufValue::String("llama".into()));
+        // 2-D tensor — dims[3,2] means cols=3, rows=2
+        w.tensor(GgufTensor {
+            name: "blk.0.ffn_up.weight".into(),
+            dims: vec![3, 2],
+            ggml_type: 0, // F32
+            data: data_2d,
+        });
+        // 1-D tensor
+        w.tensor(GgufTensor {
+            name: "blk.0.attn_norm.weight".into(),
+            dims: vec![3],
+            ggml_type: 0, // F32
+            data: data_1d,
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tiny.gguf");
+        w.write_to_file(&path).unwrap();
+        let gguf = GgufFile::open(&path).unwrap();
+        let mut src = GgufTensorSource::from_gguf(gguf, 0, 0).unwrap();
+        // Override index to map our chosen normalized keys → tensor indices.
+        // Tensor 0 = 2-D (blk.0.ffn_up.weight → index 0)
+        // Tensor 1 = 1-D (blk.0.attn_norm.weight → index 1)
+        src.index = std::collections::HashMap::from([
+            ("w2d".to_string(), 0usize),
+            ("n1d".to_string(), 1usize),
+        ]);
+
+        (dir, src)
+    }
+
+    #[test]
+    fn gguf_weight_source_get_tensor_returns_correct_shape_and_data() {
+        let arch = larql_models::detect_from_json(&serde_json::json!({
+            "model_type": "llama",
+            "hidden_size": 16,
+            "num_hidden_layers": 1,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "vocab_size": 32,
+        }));
+        let (_dir, src) = make_test_gguf_source();
+        let ws = GgufWeightSource {
+            gguf: &src,
+            arch: &*arch,
+            num_layers: 1,
+        };
+
+        // 2-D tensor: GGUF dims=[3,2] → rows=2, cols=3
+        let result = ws.get_tensor("w2d");
+        assert!(result.is_some(), "get_tensor('w2d') must return Some");
+        let (data, rows, cols) = result.unwrap();
+        assert_eq!(rows, 2, "rows must be 2");
+        assert_eq!(cols, 3, "cols must be 3");
+        assert_eq!(data, vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0], "data must be row-major");
+
+        // Missing key → None
+        assert!(ws.get_tensor("missing").is_none());
+    }
+
+    #[test]
+    fn gguf_weight_source_get_vector_returns_1d_data() {
+        let arch = larql_models::detect_from_json(&serde_json::json!({
+            "model_type": "llama",
+            "hidden_size": 16,
+            "num_hidden_layers": 1,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "vocab_size": 32,
+        }));
+        let (_dir, src) = make_test_gguf_source();
+        let ws = GgufWeightSource {
+            gguf: &src,
+            arch: &*arch,
+            num_layers: 1,
+        };
+
+        let result = ws.get_vector("n1d");
+        assert_eq!(result, Some(vec![7.0f32, 8.0, 9.0]), "get_vector must return 1-D data");
+
+        assert!(ws.get_vector("missing").is_none());
+    }
+
+    #[test]
+    fn gguf_weight_source_get_packed_bf16_returns_none() {
+        let arch = larql_models::detect_from_json(&serde_json::json!({
+            "model_type": "llama",
+            "hidden_size": 16,
+            "num_hidden_layers": 1,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "vocab_size": 32,
+        }));
+        let (_dir, src) = make_test_gguf_source();
+        let ws = GgufWeightSource {
+            gguf: &src,
+            arch: &*arch,
+            num_layers: 1,
+        };
+
+        assert!(ws.get_packed_bf16("anything").is_none());
+        assert!(ws.get_packed_bf16("w2d").is_none());
+    }
+
+    #[test]
+    fn gguf_weight_source_vector_names_contains_1d_key() {
+        let arch = larql_models::detect_from_json(&serde_json::json!({
+            "model_type": "llama",
+            "hidden_size": 16,
+            "num_hidden_layers": 1,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "vocab_size": 32,
+        }));
+        let (_dir, src) = make_test_gguf_source();
+        let ws = GgufWeightSource {
+            gguf: &src,
+            arch: &*arch,
+            num_layers: 1,
+        };
+
+        let names = ws.vector_names();
+        assert!(names.contains(&"n1d".to_string()), "vector_names must contain 'n1d'; got: {names:?}");
+        assert!(!names.contains(&"w2d".to_string()), "vector_names must NOT contain 2-D key 'w2d'");
+    }
+}

--- a/crates/larql-vindex/src/format/weights/gguf_source.rs
+++ b/crates/larql-vindex/src/format/weights/gguf_source.rs
@@ -5,9 +5,9 @@ use crate::extract::streaming::tensor_io::GgufTensorSource;
 use crate::format::weights::write_f32::WeightSource;
 
 pub struct GgufWeightSource<'a> {
-    pub gguf: &'a GgufTensorSource,
-    pub arch: &'a dyn larql_models::ModelArchitecture,
-    pub num_layers: usize,
+    pub(crate) gguf: &'a GgufTensorSource,
+    pub(crate) arch: &'a dyn larql_models::ModelArchitecture,
+    pub(crate) num_layers: usize,
 }
 
 impl<'a> WeightSource for GgufWeightSource<'a> {
@@ -197,5 +197,75 @@ mod tests {
         let names = ws.vector_names();
         assert!(names.contains(&"n1d".to_string()), "vector_names must contain 'n1d'; got: {names:?}");
         assert!(!names.contains(&"w2d".to_string()), "vector_names must NOT contain 2-D key 'w2d'");
+    }
+
+    /// Fix D: verify that `get_tensor` correctly row-major-flattens a transposed FFN tensor.
+    ///
+    /// `blk.0.ffn_up.weight` normalises to `layers.0.mlp.up_proj.weight`.
+    /// `expected_shape` returns `(intermediate_size=2, hidden_size=3)` = `(rows=2, cols=3)`.
+    /// The GGUF file stores dims=[2, 3] meaning cols=2, rows=3, so the raw array
+    /// has shape (3, 2) — the transpose of the HF convention — and `orient` must
+    /// swap it to (2, 3) before `GgufWeightSource::get_tensor` flattens row-major.
+    #[test]
+    fn gguf_weight_source_get_tensor_orient_transpose_flatten() {
+        // hidden_size=3, intermediate_size=2 so expected up_proj shape = (2, 3).
+        let arch = larql_models::detect_from_json(&serde_json::json!({
+            "model_type": "llama",
+            "hidden_size": 3,
+            "num_hidden_layers": 1,
+            "intermediate_size": 2,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "vocab_size": 32,
+        }));
+
+        // Build GGUF with blk.0.ffn_up.weight stored as dims=[2, 3]
+        // (cols=2=intermediate_size, rows=3=hidden_size) — the PyTorch-transposed layout.
+        // Raw bytes are contiguous along dims[0], so the values fill
+        //   row0: [1.0, 2.0], row1: [3.0, 4.0], row2: [5.0, 6.0]
+        // (shape (3,2) array).  After orient-transpose to (2,3):
+        //   row0: [1.0, 3.0, 5.0], row1: [2.0, 4.0, 6.0]
+        // Row-major flatten: [1.0, 3.0, 5.0, 2.0, 4.0, 6.0].
+        let vals = [1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let mut data = Vec::new();
+        for v in vals {
+            data.extend_from_slice(&v.to_le_bytes());
+        }
+
+        let mut w = GgufWriter::new();
+        w.meta("general.architecture", GgufValue::String("llama".into()));
+        // dims=[2,3]: dims[0]=2 (cols=intermediate), dims[1]=3 (rows=hidden)
+        w.tensor(GgufTensor {
+            name: "blk.0.ffn_up.weight".into(),
+            dims: vec![2, 3],
+            ggml_type: 0, // F32
+            data,
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("orient.gguf");
+        w.write_to_file(&path).unwrap();
+        let gguf = larql_models::loading::gguf::GgufFile::open(&path).unwrap();
+        // hidden_size=3, intermediate_size=2 drive expected_shape / orient.
+        let src = GgufTensorSource::from_gguf(gguf, 3, 2).unwrap();
+
+        let ws = GgufWeightSource {
+            gguf: &src,
+            arch: &*arch,
+            num_layers: 1,
+        };
+
+        // The normalized key for blk.0.ffn_up.weight is layers.0.mlp.up_proj.weight.
+        let result = ws.get_tensor("layers.0.mlp.up_proj.weight");
+        assert!(result.is_some(), "get_tensor must return Some for the FFN key");
+        let (data_out, rows, cols) = result.unwrap();
+        assert_eq!(rows, 2, "rows must equal intermediate_size after orient");
+        assert_eq!(cols, 3, "cols must equal hidden_size after orient");
+        // Row-major flatten of transposed (2,3) array.
+        assert_eq!(
+            data_out,
+            vec![1.0f32, 3.0, 5.0, 2.0, 4.0, 6.0],
+            "data must be the row-major flatten of the oriented (2,3) array"
+        );
     }
 }

--- a/crates/larql-vindex/src/format/weights/gguf_source.rs
+++ b/crates/larql-vindex/src/format/weights/gguf_source.rs
@@ -268,4 +268,147 @@ mod tests {
             "data must be the row-major flatten of the oriented (2,3) array"
         );
     }
+
+    /// Fast gated test: prove that real per-layer weight keys (attn q/k/v/o,
+    /// ffn up/down, layer norms) resolve through `GgufWeightSource` on an
+    /// actual dense GGUF file.
+    ///
+    /// Gate: `LARQL_TEST_GGUF=/path/to/dense.gguf`. Skipped otherwise.
+    ///
+    /// Construction path (mirrors `StreamingContext::new` + `maybe_write_model_weights`):
+    ///   1. `GgufFile::open` on the path.
+    ///   2. `gguf.to_config_json()` → `detect_from_json_validated` → arch + hidden/intermediate.
+    ///   3. `GgufTensorSource::from_gguf(gguf, hidden_size, intermediate_size)` — real index.
+    ///   4. `GgufWeightSource { gguf: &src, arch: &*arch, num_layers }`.
+    ///   5. Check layer 0 keys for attn q/k/v/o, ffn up/down, norms.
+    #[test]
+    fn gguf_weight_source_resolves_real_dense_keys() {
+        let Some(gguf_path) = std::env::var_os("LARQL_TEST_GGUF") else {
+            eprintln!("skip: set LARQL_TEST_GGUF to a dense GGUF");
+            return;
+        };
+
+        // Step 1: open the GGUF file.
+        let gguf = GgufFile::open(std::path::Path::new(&gguf_path))
+            .expect("GgufFile::open must succeed for LARQL_TEST_GGUF");
+
+        // Step 2: detect architecture from GGUF metadata.
+        let cfg_json = gguf.to_config_json();
+        let arch = larql_models::detect_from_json_validated(&cfg_json)
+            .expect("architecture detection must succeed for LARQL_TEST_GGUF");
+        let cfg = arch.config();
+        let hidden_size = cfg.hidden_size;
+        let intermediate_size = cfg.intermediate_size;
+        let num_layers = cfg.num_layers;
+
+        eprintln!(
+            "  arch={} hidden={} intermediate={} layers={}",
+            cfg.model_type, hidden_size, intermediate_size, num_layers,
+        );
+        assert!(num_layers > 0, "model must have at least one layer");
+        assert!(hidden_size > 0, "hidden_size must be > 0");
+        assert!(intermediate_size > 0, "intermediate_size must be > 0");
+
+        // Step 3: build GgufTensorSource with real index (no override).
+        let src = GgufTensorSource::from_gguf(gguf, hidden_size, intermediate_size)
+            .expect("GgufTensorSource::from_gguf must succeed");
+
+        // Step 4: construct GgufWeightSource.
+        let ws = GgufWeightSource {
+            gguf: &src,
+            arch: &*arch,
+            num_layers,
+        };
+
+        // Step 5: verify per-layer keys for layer 0.
+        let mut resolved: Vec<(&str, usize, usize)> = Vec::new();
+        let mut missed: Vec<&str> = Vec::new();
+
+        // Attn q/k/v/o
+        for (label, key) in [
+            ("attn_q", arch.attn_q_key(0)),
+            ("attn_k", arch.attn_k_key(0)),
+            ("attn_v", arch.attn_v_key(0)),
+            ("attn_o", arch.attn_o_key(0)),
+        ] {
+            match ws.get_tensor(&key) {
+                Some((_, rows, cols)) => {
+                    eprintln!("  RESOLVED {label} key={key} shape=({rows},{cols})");
+                    resolved.push((label, rows, cols));
+                }
+                None => {
+                    eprintln!("  MISSED   {label} key={key}");
+                    missed.push(label);
+                }
+            }
+        }
+
+        // FFN up/down (dense path — BitNet is llama-shaped, not MoE)
+        if !arch.is_moe() {
+            for (label, key) in [
+                ("ffn_up", arch.ffn_up_key(0)),
+                ("ffn_down", arch.ffn_down_key(0)),
+            ] {
+                match ws.get_tensor(&key) {
+                    Some((_, rows, cols)) => {
+                        eprintln!("  RESOLVED {label} key={key} shape=({rows},{cols})");
+                        resolved.push((label, rows, cols));
+                    }
+                    None => {
+                        eprintln!("  MISSED   {label} key={key}");
+                        missed.push(label);
+                    }
+                }
+            }
+        } else {
+            eprintln!("  NOTE: arch is MoE — skipping dense ffn_up/ffn_down assertion");
+        }
+
+        // Layer norms (get_vector path)
+        let norm_key_input = arch.input_layernorm_key(0);
+        let norm_key_post_attn = arch.post_attention_layernorm_key(0);
+        let mut norm_resolved = 0usize;
+        for (label, key) in [
+            ("input_layernorm", norm_key_input.as_str()),
+            ("post_attn_layernorm", norm_key_post_attn.as_str()),
+        ] {
+            match ws.get_vector(key) {
+                Some(v) if !v.is_empty() => {
+                    eprintln!("  RESOLVED {label} key={key} len={}", v.len());
+                    norm_resolved += 1;
+                }
+                Some(_) => {
+                    eprintln!("  MISSED   {label} key={key} (empty vec)");
+                }
+                None => {
+                    eprintln!("  MISSED   {label} key={key}");
+                }
+            }
+        }
+
+        // Assertions
+        assert!(
+            missed.is_empty(),
+            "These per-layer keys did NOT resolve through GgufWeightSource: {missed:?}\n\
+             This means GgufTensorSource::index does not contain the normalized HF keys \
+             the weight writer requests. Check normalize_gguf_key output vs arch.*_key(0)."
+        );
+        for (label, rows, cols) in &resolved {
+            assert!(
+                *rows > 0 && *cols > 0,
+                "{label} resolved but has zero dimension: shape=({rows},{cols})"
+            );
+        }
+        assert!(
+            norm_resolved >= 1,
+            "At least one layer norm must resolve via get_vector; got 0. \
+             Check that the GGUF has 1-D norm tensors and normalize_gguf_key maps them."
+        );
+
+        eprintln!(
+            "  PASS: {}/{} 2-D keys resolved; {norm_resolved}/2 norm vectors resolved",
+            resolved.len(),
+            resolved.len() + missed.len(),
+        );
+    }
 }

--- a/crates/larql-vindex/src/format/weights/mod.rs
+++ b/crates/larql-vindex/src/format/weights/mod.rs
@@ -16,6 +16,7 @@
 //!                (`load_model_weights`, `find_tokenizer_path`).
 
 mod capabilities;
+mod gguf_source;
 pub mod load;
 pub mod manifest;
 pub mod mla_absorb;
@@ -25,6 +26,7 @@ pub mod write_kquant;
 pub mod write_layers;
 
 pub(crate) use capabilities::ensure_extract_level_supported;
+pub use gguf_source::GgufWeightSource;
 
 pub use load::{
     find_tokenizer_path, load_model_weights, load_model_weights_kquant,


### PR DESCRIPTION
## Summary
- 1-D GGUF tensor accessor + `gguf_source()` entry point for streaming weight access
- Extracted `raw_slice_for` helper (DRY bounds-checks) with a 1-D guard test
- `GgufWeightSource` — third `WeightSource` impl (per-tensor GGUF dequant), clippy-clean
- Covers the orient-flatten path; adds tests proving real dense GGUF weight-keys resolve through it

Split out of the original `feat/gguf-streaming-weights` branch as the foundational, self-contained piece — no streaming-path wiring yet (that's the next PR, stacked on this one).

## Test plan
- [x] `cargo check -p larql-vindex` — clean
- [ ] CI green