### PR TITLE
feat(extract): stream GGUF weights end-to-end at inference level

### DIFF
--- a/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
@@ -376,15 +376,17 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
 
         // Dispatch:
         //
-        //  - Safetensors (always) and GGUF at browse level go through the
-        //    streaming pipeline — no full model in RAM.
-        //  - GGUF at inference / attention / all levels (or any level
-        //    with `--quant q4k`) still hits the in-memory loader: the
-        //    `StreamingWeights` writer subsystem is safetensors-only,
-        //    and porting it to GGUF is a follow-on PR.
-        let route_gguf_through_streaming = is_gguf_source
-            && matches!(level, larql_vindex::ExtractLevel::Browse)
-            && args.quant == larql_vindex::QuantFormat::None;
+        //  - Safetensors (always) and GGUF + `--quant none` (at ANY level)
+        //    go through the streaming pipeline — no full model in RAM.
+        //    `GgufWeightSource` now writes weights per-tensor at every
+        //    extraction level (bounded RAM, #167).
+        //  - GGUF + `--quant q4k` still hits the in-memory loader: a
+        //    streaming Q4K writer for GGUF is a tracked follow-on.
+        // GGUF streams at ANY level when quant=none — `GgufWeightSource` now writes
+        // weights per-tensor (bounded RAM, #167). q4k GGUF still uses the in-memory
+        // loader (a streaming q4k writer for GGUF is a tracked follow-on).
+        let route_gguf_through_streaming =
+            is_gguf_source && args.quant == larql_vindex::QuantFormat::None;
 
         if is_gguf_source && !route_gguf_through_streaming {
             // GGUF + attention/inference/all (or any level with q4k) →
@@ -438,7 +440,7 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         } else {
-            // Safetensors path (any level) OR GGUF at browse level —
+            // Safetensors path (any level) OR GGUF + quant=none (any level) —
             // streaming mmap, no full model load. For GGUF, point the
             // pipeline at the shard-1 file (or the directory; the
             // pipeline picks the right shard internally).

--- a/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
+++ b/crates/larql-cli/src/commands/extraction/extract_index_cmd.rs
@@ -198,6 +198,48 @@ impl IndexBuildCallbacks for CliBuildCallbacks {
     }
 }
 
+/// Returns `true` when a GGUF source should be routed through the streaming
+/// pipeline (`GgufWeightSource`). Only dense architectures are supported:
+/// MoE expert tensors have no key mapping in `GgufWeightSource` and would be
+/// silently dropped, producing a hollow vindex (#153). MLA attention tensors
+/// are likewise unsupported in the streaming writer.
+///
+/// The function opens the GGUF file header (mmap, no tensors loaded) to
+/// detect the architecture — the cost is metadata-only and bounded.
+///
+/// Returns `false` (→ in-memory path) when:
+///   - `is_gguf` is false (safetensors — callers guard this away before
+///     calling, but it is safe to pass false here),
+///   - the architecture reports `is_moe() == true`, or
+///   - the architecture reports `uses_mla() == true`.
+fn should_stream_dense_gguf(
+    is_gguf: bool,
+    gguf_dir: &Option<std::path::PathBuf>,
+    model_path: &std::path::Path,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    if !is_gguf {
+        return Ok(false);
+    }
+    let entry: std::path::PathBuf = match gguf_dir {
+        Some(p) => p.clone(),
+        None => model_path.to_path_buf(),
+    };
+    let gguf = larql_models::loading::gguf::GgufFile::open(&entry)
+        .map_err(|e| format!("open GGUF for arch detection: {e}"))?;
+    // Use the infallible detect_from_json (not _validated) — routing
+    // must not fail on a validation error; the real pipeline path will
+    // report that with better context.
+    let arch = larql_models::detect_from_json(&gguf.to_config_json());
+    Ok(!arch.is_moe() && !arch.uses_mla())
+}
+
+/// Pure-logic helper exposed for unit tests: given already-resolved
+/// architecture flags, should this GGUF be streamed?
+#[cfg(test)]
+fn streaming_eligible(is_gguf: bool, quant_none: bool, is_moe: bool, uses_mla: bool) -> bool {
+    is_gguf && quant_none && !is_moe && !uses_mla
+}
+
 pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
     let mut callbacks = CliBuildCallbacks::new();
     let build_start = Instant::now();
@@ -376,17 +418,20 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
 
         // Dispatch:
         //
-        //  - Safetensors (always) and GGUF + `--quant none` (at ANY level)
-        //    go through the streaming pipeline — no full model in RAM.
-        //    `GgufWeightSource` now writes weights per-tensor at every
-        //    extraction level (bounded RAM, #167).
+        //  - Safetensors (always) and GGUF + `--quant none` for DENSE
+        //    architectures go through the streaming pipeline — no full
+        //    model in RAM. `GgufWeightSource` writes weights per-tensor at
+        //    every extraction level (bounded RAM, #167).
+        //  - MoE/MLA GGUF + `--quant none` stays on the in-memory loader.
+        //    MoE expert tensors (`blk.N.ffn_*_exps.weight`) have no key
+        //    mapping in `GgufWeightSource` — experts would be silently
+        //    dropped producing a hollow vindex (#153). MoE/MLA GGUF
+        //    streaming is deferred until #153 is resolved.
         //  - GGUF + `--quant q4k` still hits the in-memory loader: a
         //    streaming Q4K writer for GGUF is a tracked follow-on.
-        // GGUF streams at ANY level when quant=none — `GgufWeightSource` now writes
-        // weights per-tensor (bounded RAM, #167). q4k GGUF still uses the in-memory
-        // loader (a streaming q4k writer for GGUF is a tracked follow-on).
-        let route_gguf_through_streaming =
-            is_gguf_source && args.quant == larql_vindex::QuantFormat::None;
+        let route_gguf_through_streaming = is_gguf_source
+            && args.quant == larql_vindex::QuantFormat::None
+            && should_stream_dense_gguf(is_gguf_source, &gguf_dir, &model_path)?;
 
         if is_gguf_source && !route_gguf_through_streaming {
             // GGUF + attention/inference/all (or any level with q4k) →
@@ -543,4 +588,47 @@ pub fn run(args: ExtractIndexArgs) -> Result<(), Box<dyn std::error::Error>> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::streaming_eligible;
+
+    /// Dense GGUF + quant=none must stream.
+    #[test]
+    fn dense_gguf_quant_none_streams() {
+        assert!(streaming_eligible(true, true, false, false));
+    }
+
+    /// MoE GGUF + quant=none must NOT stream (would drop expert tensors → hollow vindex, #153).
+    #[test]
+    fn moe_gguf_quant_none_does_not_stream() {
+        assert!(!streaming_eligible(true, true, true, false));
+    }
+
+    /// MLA GGUF + quant=none must NOT stream (MLA tensors unsupported in writer).
+    #[test]
+    fn mla_gguf_quant_none_does_not_stream() {
+        assert!(!streaming_eligible(true, true, false, true));
+    }
+
+    /// MoE+MLA GGUF + quant=none must NOT stream.
+    #[test]
+    fn moe_mla_gguf_quant_none_does_not_stream() {
+        assert!(!streaming_eligible(true, true, true, true));
+    }
+
+    /// Non-GGUF (safetensors) never goes through this guard — the outer
+    /// caller always routes safetensors to streaming regardless.
+    #[test]
+    fn non_gguf_returns_false() {
+        assert!(!streaming_eligible(false, true, false, false));
+    }
+
+    /// GGUF + quant=q4k always falls to in-memory (q4k streaming not yet implemented).
+    /// The quant guard lives in the caller, not here — quant_none=false simulates it.
+    #[test]
+    fn gguf_q4k_does_not_stream_via_quant_guard() {
+        assert!(!streaming_eligible(true, false, false, false));
+    }
 }

--- a/crates/larql-vindex/src/extract/streaming/stages/model_weights.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/model_weights.rs
@@ -23,7 +23,8 @@ impl<'a> StreamingContext<'a> {
             if self.quant != QuantFormat::None {
                 return Err(VindexError::Parse(
                     "GGUF + --quant q4k weight streaming is not yet implemented; \
-                     re-run with --quant none (q4k GGUF is a tracked follow-on)".to_string(),
+                     re-run with --quant none (q4k GGUF is a tracked follow-on)"
+                        .to_string(),
                 ));
             }
             let src = crate::format::weights::GgufWeightSource {
@@ -34,7 +35,10 @@ impl<'a> StreamingContext<'a> {
             let mut level_opts = self.weight_opts;
             level_opts.level = self.extract_level;
             crate::format::weights::write_model_weights_with_opts(
-                &src, self.output_dir, self.callbacks, level_opts,
+                &src,
+                self.output_dir,
+                self.callbacks,
+                level_opts,
             )?;
             return Ok(());
         }
@@ -45,9 +49,9 @@ impl<'a> StreamingContext<'a> {
             (Some(m), Some(i)) => (m, i),
             _ => {
                 return Err(VindexError::Parse(
-                    "GGUF input + extract-level requiring attention/FFN weights is not yet \
-                     implemented (browse-level GGUF works; inference/Q4K GGUF requires \
-                     per-tensor streaming through ggml::dequantize)"
+                    "weights stage reached with neither GGUF nor safetensors weight \
+                     backing (GGUF quant=none streams above; q4k GGUF errors above) — \
+                     unsupported or inconsistent extraction source"
                         .to_string(),
                 ));
             }

--- a/crates/larql-vindex/src/extract/streaming/stages/model_weights.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/model_weights.rs
@@ -18,13 +18,26 @@ impl<'a> StreamingContext<'a> {
         if !needs_weights {
             return Ok(());
         }
-        // `StreamingWeights` is a safetensors-only writer subsystem
-        // (Q4_K + f32 weight writers walk safetensors crate views
-        // directly). GGUF input is supported at browse level (where
-        // `needs_weights == false`) and below only; inference / Q4K
-        // levels for GGUF need a separate writer pass that streams
-        // per-tensor through `larql_models::quant::ggml::dequantize` —
-        // tracked as a follow-on PR.
+        // GGUF: stream weights per-tensor via GgufWeightSource (bounded RAM, #167).
+        if let Some(gguf) = self.tensor_source.gguf_source() {
+            if self.quant != QuantFormat::None {
+                return Err(VindexError::Parse(
+                    "GGUF + --quant q4k weight streaming is not yet implemented; \
+                     re-run with --quant none (q4k GGUF is a tracked follow-on)".to_string(),
+                ));
+            }
+            let src = crate::format::weights::GgufWeightSource {
+                gguf,
+                arch: &*self.arch,
+                num_layers: self.num_layers,
+            };
+            let mut level_opts = self.weight_opts;
+            level_opts.level = self.extract_level;
+            crate::format::weights::write_model_weights_with_opts(
+                &src, self.output_dir, self.callbacks, level_opts,
+            )?;
+            return Ok(());
+        }
         let (shard_mmaps, tensor_index) = match (
             self.tensor_source.safetensors_mmap_refs(),
             self.tensor_source.safetensors_index(),

--- a/crates/larql-vindex/src/extract/streaming/tensor_io.rs
+++ b/crates/larql-vindex/src/extract/streaming/tensor_io.rs
@@ -121,8 +121,6 @@ impl TensorSource {
 
     /// Borrow the GGUF backend for 1-D tensor access (norm/bias weights
     /// via `get_vector_f32`). Returns `None` for the safetensors variant.
-    // consumed by maybe_write_model_weights GGUF dispatch (next commit, #167)
-    #[allow(dead_code)]
     pub(crate) fn gguf_source(&self) -> Option<&GgufTensorSource> {
         match self {
             TensorSource::Gguf(g) => Some(g),

--- a/crates/larql-vindex/src/extract/streaming/tensor_io.rs
+++ b/crates/larql-vindex/src/extract/streaming/tensor_io.rs
@@ -38,7 +38,11 @@ pub(crate) struct MmapShard {
 /// blockwise quants (Q4_0/Q4_K/…) handled by `get_tensor_f32` directly.
 /// Validated raw bytes + element count + tensor info for one GGUF tensor,
 /// as returned by `GgufTensorSource::raw_slice_for`.
-type GgufRawSlice<'a> = (&'a [u8], usize, &'a larql_models::loading::gguf::GgufTensorInfo);
+type GgufRawSlice<'a> = (
+    &'a [u8],
+    usize,
+    &'a larql_models::loading::gguf::GgufTensorInfo,
+);
 
 pub(crate) enum TensorSource {
     Safetensors {
@@ -293,9 +297,12 @@ impl GgufTensorSource {
         match self.raw_slice_for(key, 1)? {
             None => Ok(None),
             Some((raw, n_elements_usize, info)) => {
-                let floats =
-                    larql_models::quant::ggml::dequantize(raw, info.tensor_type(), n_elements_usize)
-                        .map_err(|e| VindexError::Parse(e.to_string()))?;
+                let floats = larql_models::quant::ggml::dequantize(
+                    raw,
+                    info.tensor_type(),
+                    n_elements_usize,
+                )
+                .map_err(|e| VindexError::Parse(e.to_string()))?;
                 Ok(Some(floats))
             }
         }
@@ -876,8 +883,7 @@ mod tests {
         w.write_to_file(&path).unwrap();
         let gguf = GgufFile::open(&path).unwrap();
         let mut src = GgufTensorSource::from_gguf(gguf, 0, 0).unwrap();
-        src.index =
-            std::collections::HashMap::from([("ffn_gate.weight".to_string(), 0usize)]);
+        src.index = std::collections::HashMap::from([("ffn_gate.weight".to_string(), 0usize)]);
         assert_eq!(
             src.get_vector_f32("ffn_gate.weight").unwrap(),
             None,

--- a/crates/larql-vindex/src/format/weights/gguf_source.rs
+++ b/crates/larql-vindex/src/format/weights/gguf_source.rs
@@ -15,7 +15,11 @@ impl<'a> WeightSource for GgufWeightSource<'a> {
         let arr = self.gguf.get_tensor_f32(key).ok()??;
         let rows = arr.shape()[0];
         let cols = arr.shape()[1];
-        let data = arr.as_standard_layout().to_owned().into_raw_vec_and_offset().0;
+        let data = arr
+            .as_standard_layout()
+            .to_owned()
+            .into_raw_vec_and_offset()
+            .0;
         Some((data, rows, cols))
     }
 
@@ -47,8 +51,8 @@ impl<'a> WeightSource for GgufWeightSource<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use larql_models::loading::gguf::{GgufFile, GgufTensor, GgufValue, GgufWriter};
     use crate::extract::streaming::tensor_io::GgufTensorSource;
+    use larql_models::loading::gguf::{GgufFile, GgufTensor, GgufValue, GgufWriter};
 
     fn make_test_gguf_source() -> (tempfile::TempDir, GgufTensorSource) {
         // 2-D tensor: logical shape (2 rows, 3 cols).
@@ -124,7 +128,11 @@ mod tests {
         let (data, rows, cols) = result.unwrap();
         assert_eq!(rows, 2, "rows must be 2");
         assert_eq!(cols, 3, "cols must be 3");
-        assert_eq!(data, vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0], "data must be row-major");
+        assert_eq!(
+            data,
+            vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "data must be row-major"
+        );
 
         // Missing key → None
         assert!(ws.get_tensor("missing").is_none());
@@ -149,7 +157,11 @@ mod tests {
         };
 
         let result = ws.get_vector("n1d");
-        assert_eq!(result, Some(vec![7.0f32, 8.0, 9.0]), "get_vector must return 1-D data");
+        assert_eq!(
+            result,
+            Some(vec![7.0f32, 8.0, 9.0]),
+            "get_vector must return 1-D data"
+        );
 
         assert!(ws.get_vector("missing").is_none());
     }
@@ -195,8 +207,14 @@ mod tests {
         };
 
         let names = ws.vector_names();
-        assert!(names.contains(&"n1d".to_string()), "vector_names must contain 'n1d'; got: {names:?}");
-        assert!(!names.contains(&"w2d".to_string()), "vector_names must NOT contain 2-D key 'w2d'");
+        assert!(
+            names.contains(&"n1d".to_string()),
+            "vector_names must contain 'n1d'; got: {names:?}"
+        );
+        assert!(
+            !names.contains(&"w2d".to_string()),
+            "vector_names must NOT contain 2-D key 'w2d'"
+        );
     }
 
     /// Fix D: verify that `get_tensor` correctly row-major-flattens a transposed FFN tensor.
@@ -257,7 +275,10 @@ mod tests {
 
         // The normalized key for blk.0.ffn_up.weight is layers.0.mlp.up_proj.weight.
         let result = ws.get_tensor("layers.0.mlp.up_proj.weight");
-        assert!(result.is_some(), "get_tensor must return Some for the FFN key");
+        assert!(
+            result.is_some(),
+            "get_tensor must return Some for the FFN key"
+        );
         let (data_out, rows, cols) = result.unwrap();
         assert_eq!(rows, 2, "rows must equal intermediate_size after orient");
         assert_eq!(cols, 3, "cols must equal hidden_size after orient");

--- a/crates/larql-vindex/tests/gguf_streaming_weights.rs
+++ b/crates/larql-vindex/tests/gguf_streaming_weights.rs
@@ -39,7 +39,12 @@ fn gguf_inference_extract_populates_weight_files() {
     )
     .expect("GGUF streaming extract must succeed");
 
-    for f in ["attn_weights.bin", "up_weights.bin", "down_weights.bin", "norms.bin"] {
+    for f in [
+        "attn_weights.bin",
+        "up_weights.bin",
+        "down_weights.bin",
+        "norms.bin",
+    ] {
         let len = std::fs::metadata(out.path().join(f))
             .map(|m| m.len())
             .unwrap_or(0);

--- a/crates/larql-vindex/tests/gguf_streaming_weights.rs
+++ b/crates/larql-vindex/tests/gguf_streaming_weights.rs
@@ -1,0 +1,48 @@
+//! End-to-end: GGUF extract at --level inference streams weights (no whole-model
+//! RAM load, #167). Gated — set LARQL_TEST_GGUF=/path/to/dense.gguf to run; skipped otherwise.
+use std::path::Path;
+
+#[test]
+fn gguf_inference_extract_populates_weight_files() {
+    let Some(gguf) = std::env::var_os("LARQL_TEST_GGUF") else {
+        eprintln!("skip: set LARQL_TEST_GGUF to a dense GGUF to run");
+        return;
+    };
+
+    let out = tempfile::tempdir().unwrap();
+
+    // Minimal BPE tokenizer — real GGUF models may not ship a tokenizer.json
+    // alongside the .gguf file. The streaming extract writes the tokenizer to
+    // the vindex, but for this test we only assert on weight files; an empty
+    // BPE tokenizer is sufficient.
+    let tok_json =
+        r#"{"version":"1.0","model":{"type":"BPE","vocab":{},"merges":[]},"added_tokens":[]}"#;
+    let tokenizer = larql_vindex::tokenizers::Tokenizer::from_bytes(tok_json.as_bytes())
+        .expect("minimal tokenizer must parse");
+
+    let mut cb = larql_vindex::SilentBuildCallbacks;
+
+    larql_vindex::build_vindex_streaming(
+        Path::new(&gguf),
+        &tokenizer,
+        "test/gguf-inference-streaming",
+        out.path(),
+        5, // down_top_k
+        0, // summary_features_per_expert (off)
+        larql_vindex::ExtractLevel::Inference,
+        larql_vindex::StorageDtype::F32,
+        larql_vindex::QuantFormat::None,
+        larql_vindex::WriteWeightsOptions::default(),
+        larql_vindex::KquantWriteOptions::default(),
+        false, // drop_gate_vectors
+        &mut cb,
+    )
+    .expect("GGUF streaming extract must succeed");
+
+    for f in ["attn_weights.bin", "up_weights.bin", "down_weights.bin", "norms.bin"] {
+        let len = std::fs::metadata(out.path().join(f))
+            .map(|m| m.len())
+            .unwrap_or(0);
+        assert!(len > 0, "{f} should be non-empty, got {len}");
+    }
+}

--- a/docs/superpowers/specs/2026-06-15-extract-completeness-audit.md
+++ b/docs/superpowers/specs/2026-06-15-extract-completeness-audit.md
@@ -1,0 +1,124 @@
+# larql extract → vindex: completeness & resource audit (2026-06-15)
+
+Goal (north star): every supported **architecture × source toolchain** must produce a
+**complete** vindex — all declared weight classes populated + required auxiliary files —
+**isomorphic** to the HF model (no *silent* drops; any intentional lossy transform documented).
+
+Repo audited: fresh clone `/home/metavacua/larql-extract` @ `origin/main` d9b761f6 (chrishayuk).
+Method: 5 parallel read-only subagent audits (safetensors loader, gguf/ggml loader, extract
+pipeline completeness, resource/resumability, arch registry + source cmds). Every claim is
+file:line-cited in the agent transcripts of session; this doc is the synthesis.
+
+Existing fork issues that this confirms/extends: #147 (silent hollow safetensors), #148 (no
+safetensors ternary decoder), #149 (no bitnet.rs arch), #150 (2B+ RAM/time → streaming/resumable),
+#151 (clustering silently no-ops), #152 (feature_labels.json no extract writer).
+
+NEW fork issues filed 2026-06-15 (metavacua/larql-to-sparql), each with upstream cross-refs:
+- **#153** = A1+A2 GGUF fused 3-D MoE expert drop (intro chrishayuk@c54875db / PR#145,#139; precedent chrishayuk#49)
+- **#154** = A3 silent GenericArch fallback (chrishayuk@dccf08d7 / #22)
+- **#155** = A9 verify can't detect hollow (chrishayuk@ce3ef489)
+- **#156** = B1+B2 resume no-op + dead Weights/Q4kWeights checkpoint (chrishayuk@571e139e, @a0d77d09)
+- **#157** = B4+B5+B8 embedding RAM dup + O(layers²) down_meta rewrite (chrishayuk@fd6f0b43/PR#139)
+- **#158** = A11+A12+A5 safetensors silent drops: I8 mis-decode, 3-D drop, skipped_tensors unsurfaced (chrishayuk@b8f4bcf4)
+- **#159** = C3 phi/phi2/phi3 arch mapping (chrishayuk@dccf08d7)
+- **#160** = C4 GGUF Q2_K half-wired (chrishayuk@c54875db)
+- **#161** = C5+C6 BitNet ternary follow-ups: TQ1_0 unvalidated + I2_S scaling undoc'd (chrishayuk PR#148)
+
+---
+
+## 1. Real on-disk fixtures (resource & resumability testbed)
+
+| artifact | state | use |
+|---|---|---|
+| `~/bitnet-gguf.vindex` | **PARTIAL** — `.extract_checkpoint.json completed:["gate"]`, gate_vectors.bin 1.06 GB + embeddings.bin 656 MB present; **died mid-`down_meta`**; no weights/index.json | **resumability + down_meta resource-cost fixture** (source `~/bitnet-gguf/ggml-model-i2_s.gguf` 1.19 GB present) |
+| `~/bitnet-default.vindex` | **HOLLOW** — gate/up/down/attn = 0 bytes, embeddings+norms+index.json+tokenizer present | the #147 silent-hollow safetensors symptom, frozen |
+| `~/larql-vindexes/smollm2-360m.vindex` | COMPLETE (32 layers, GQA) | known-good reference / regression baseline |
+
+bitnet sources: `~/bitnet-gguf` (gguf i2_s) and `~/bitnet-default` (packed safetensors) — KEEP as fixtures.
+
+---
+
+## 2. Coverage matrix (architecture × source toolchain)
+
+Toolchains: **ST** = safetensors load path; **GGUF** = gguf/ggml path; **HF** = `larql … hf`
+(download/publish only, no extract); **CONV** = `larql convert` (gguf/st → build_vindex);
+**BUILD** = `larql build` (Vindexfile, not model extract).
+
+- **HF cmd** runs NO extraction (copy + checksum only) — not a completeness surface.
+- **BUILD cmd** emits only gate_vectors+down_meta — by design, not a full extract.
+- **CONV** = alias for extract (default level `browse` → partial by default).
+
+Per-architecture (registry maps dense classes via trait defaults; MoE/MLA must be overridden):
+
+| arch | dense | MoE experts | MLA | ST | GGUF |
+|---|---|---|---|---|---|
+| llama, mistral, gemma2/3/4*, granite, starcoder2, gpt2, tinymodel | ✔ | n/a | n/a | ✔ | ✔ (dense) |
+| mixtral, qwen(-MoE), gpt_oss, deepseek(v2/v3) | ✔ | ✔ (per-expert keys) | ✔ (deepseek) | ✔ | **✘ fused 3D experts dropped** |
+| deepseek_v4 | ✔ | ✔ | partial | browse-tier only | ✘ fused |
+| **bitnet** | via *generic* (Llama-shaped) | n/a | n/a | **hollow (ternary undecoded)** | ✔ (TQ2_0/I2_S) |
+| **phi/phi2/phi3** | via *generic* | n/a | n/a | generic fallback | generic fallback |
+| any unknown model_type | via *generic*, **silently** | dropped if actually MoE | dropped | silent-incomplete | silent-incomplete |
+
+\*gemma3/gemma4 large files sampled, not line-audited end-to-end (high confidence complete).
+
+---
+
+## 3. Consolidated gap list (deduped across agents)
+
+### THEME A — silent incomplete/hollow output reported as success (exit 0)
+| # | gap | sev | issue | branch |
+|---|---|---|---|---|
+| A1 | **GGUF fused 3D MoE expert tensors silently dropped** (`gguf/loader.rs:130 _ => {}`); modern Mixtral/Qwen3-MoE/DeepSeek GGUF lose ALL experts, load returns Ok | **HIGH** | NEW | `fix-gguf-fused-moe-expert-load` |
+| A2 | No GGUF→HF key map for `*_exps`/`*_shexp`; arch layer only resolves un-fused per-expert names a GGUF never emits | HIGH | NEW | `gguf-moe-expert-key-normalization` |
+| A3 | **Unknown `model_type` → silent `GenericArch` fallback** (`detect/mod.rs:138`); MoE/MLA models become dense-only, no warn/error | **HIGH** | NEW | `feat/strict-arch-fallback-warn` |
+| A4 | **No post-extraction completeness validation**; extract returns Ok with 0-byte weights / 0 features | **HIGH** | #147 | `fix-extract-validate-nonempty-output` |
+| A5 | `skipped_tensors` collected but never surfaced (safetensors) / hard-coded empty (gguf) — the silent-loss mechanism | HIGH | #147 | `feat/error-on-skipped-tensors` |
+| A6 | **Streaming path (ALL safetensors) never runs clustering**; only in-memory/GGUF path clusters → relation_clusters absent silently | HIGH | #151 | `streaming-extract-run-clustering` |
+| A7 | MoE models always collect **zero cluster directions** (gate_top gated on `!is_moe`) → clustering early-returns | MED | #151 | `moe-relation-cluster-directions` |
+| A8 | `feature_labels.json` has **no extract-path writer** (separate probe pass only); undocumented | MED | #152 | `extract-emit-feature-labels-or-doc` |
+| A9 | **`verify` cannot detect hollow/incomplete** — checksum-only; passes 0-byte files; no-ops (exit 0) when checksums absent | HIGH | NEW | `verify-completeness-and-nonempty` |
+| A10 | `compute_checksums` has no non-empty assertion — legitimizes 0-byte outputs | MED | #147 | `checksums-reject-empty` |
+| A11 | bare I8 weight (no `.scale`) silently mis-decoded as raw signed bytes (safetensors) | MED | NEW | `fix/i8-requires-scale-guard` |
+| A12 | 3-D+ non-packed safetensors tensors dropped via `_ => {}` w/o even a skipped record | MED | NEW | `fix/record-dropped-nd-tensors` |
+
+### THEME B — resource (RAM/time) & resumability  (#150)
+| # | gap | sev | issue | branch |
+|---|---|---|---|---|
+| B1 | **`--resume` flag defined but NEVER read** (no-op; auto-resume always on; doc comment misdescribes) | **HIGH** | NEW | `fix-extract-resume-flag-noop` |
+| B2 | **`Weights`/`Q4kWeights` checkpoint phases are dead code** — longest/heaviest stage can't resume; OOM/timeout restarts whole weight pass | **HIGH** | #150 | `wire-weights-checkpoint-resume` |
+| B3 | GGUF at attention/inference/all or `--quant q4k` → **full in-memory `ModelWeights` load** (not streaming) → OOM on 2B+/6 GB host, ungated | HIGH | #150 | `gguf-streaming-or-memory-gate` |
+| B4 | full embedding `[vocab,hidden]` f32 (~2 GB) resident across gate→down_meta; could release/f16/mmap | MED | #150 | `bound-embedding-residency` |
+| B5 | `build_whole_word_vocab` allocates a **second embedding-sized array then discards it** (`_ww_*`) — ~2 GB wasted transient | MED | NEW | `drop-dead-whole-word-vocab-in-down-meta` |
+| B6 | kquant MoE writer materializes whole layer's expert block + per-expert f32 copies at once | MED | #150 | `stream-kquant-moe-per-expert` |
+| B7 | layer-level resume unimplemented (phase-level only) — kill mid-phase wastes hours | MED | #150 | `layer-level-resume-manifest` |
+| B8 | down_meta re-serializes whole-model meta after every layer → O(layers²) write volume | LOW | NEW | `down-meta-append-not-rewrite` |
+
+### THEME C — decoder/format coverage
+| # | gap | sev | issue | branch |
+|---|---|---|---|---|
+| C1 | safetensors has **no ternary (BitNet 1.58) decoder**; U8-packed dropped, I8-packed mis-decoded; ternary lives only in `quant/ggml/tq.rs` (GGUF-only) | HIGH | #148 | `feat/safetensors-ternary-decoder` |
+| C2 | no `bitnet.rs` arch mapping / no detect arm (falls to generic) | MED | #149 | `feat/bitnet-arch-mapping` |
+| C3 | `phi/phi2/phi3` GGUF normalized to `phi` but no detect arm → generic (fused-QKV/partial-rotary unhandled) | MED | NEW | `feat/phi-arch-mapping` |
+| C4 | GGUF `Q2_K` half-wired (type-id + name, no decoder/size arm) → whole load errors | MED | NEW | `add-q2k-dequant` |
+| C5 | GGUF `TQ1_0` decoder unvalidated vs real BitNet GGUF (round-trip tests `#[ignore]`d) | MED | NEW | `verify-tq1-0-against-bitnet-gguf` |
+| C6 | GGUF `I2_S` decodes at unit scale; per-channel `*_sub_norm` scale applied by undocumented downstream contract | LOW (doc) | NEW | `document-i2s-subnorm-scaling` |
+| C7 | default extract level `browse` yields partial vindex by default — UX/doc | LOW (doc) | NEW | `docs/extract-level-completeness` |
+
+---
+
+## 4. Recommended branch ordering (independent → parallelizable)
+
+Highest leverage, lowest blast radius first; each is its own branch off fresh `origin/main`,
+pushed to `fork`, PR → chrishayuk/larql main (licensing block in PR body; no Co-Authored-By trailer).
+
+1. **A4+A5+A9+A10 — "fail loud, never silent"** guardrail PR (post-extract completeness check +
+   surface skipped_tensors + verify completeness). Architecture-agnostic; protects every model.
+   This is the keystone — it would have turned both bitnet fixtures into loud errors.
+2. **A1+A2 — GGUF fused MoE expert load.** Biggest *coverage* hole (all modern MoE GGUF).
+3. **B1+B2 — resume flag + weights checkpoint.** Validate against `~/bitnet-gguf.vindex` partial.
+4. **A3 — strict arch fallback** (warn/opt-in on generic for MoE/MLA).
+5. **C1(+C2) — safetensors ternary decoder + bitnet arch.** Closes the bitnet-safetensors hollow.
+6. **A6/A7, B4/B5, C3/C4 …** as follow-ons.
+
+Open question for B-track: a memory-budget guard (B3) that refuses/streams instead of OOMing —
+needs a design decision (hard cap? auto-downgrade level? `--max-ram`?).


### PR DESCRIPTION
## Summary
- Stacked on #257 — do not merge before it.
- Wires `GgufWeightSource` into the inference-level streaming path (`stages/model_weights.rs`)
- Routes `quant=none` GGUF through streaming at all levels — fixes the inference-level OOM (#167)
- Restricts GGUF streaming to dense archs; MoE/MLA stay on the in-memory path (#167/#153)
- Adds the gated end-to-end test (`tests/gguf_streaming_weights.rs`, opt-in via `LARQL_TEST_GGUF`) — updated its `build_vindex_streaming` call for the `summary_features_per_expert` parameter `main` has gained since this test was written
- Includes the 2026-06-15 extract completeness audit (all-archs×toolchains gap synthesis)

## Test plan
- [x] `cargo check -p larql-vindex` — clean
- [x] `cargo test -p larql-vindex --lib` — 1111 passed, 0 failed
- [x] `cargo test -p larql-vindex --test gguf_streaming_weights` — compiles and passes (self-skips at runtime, LARQL_TEST_GGUF unset)
- [ ] CI green
- [ ] Retarget base to `main` once #257 merges