### PR TITLE
feat(query): surface absent feature_labels.json in STATS/DESCRIBE

### DIFF
--- a/crates/larql-lql/src/executor/lifecycle/stats.rs
+++ b/crates/larql-lql/src/executor/lifecycle/stats.rs
@@ -155,6 +155,9 @@ impl Session {
                             num_probes,
                             format_number(total_features),
                         ));
+                        if num_probes == 0 {
+                            out.push("    (no feature_labels.json — per-feature probe labels come from a separate labeling pass, not larql extract; cluster labels are used as fallback)".into());
+                        }
                         out.push(format!(
                             "    Cluster-labelled:  {:.0}% of clusters ({} / {})",
                             cluster_pct, mapped_clusters, num_clusters,

--- a/crates/larql-lql/src/executor/query/describe/exec.rs
+++ b/crates/larql-lql/src/executor/query/describe/exec.rs
@@ -74,6 +74,12 @@ impl Session {
         let mut out = vec![entity.to_string()];
         if edges.is_empty() {
             out.push("  (no edges found)".into());
+            let has_probe_labels = self
+                .relation_classifier()
+                .is_some_and(|rc| rc.num_probe_labels() > 0);
+            if !has_probe_labels {
+                out.push("  (no feature_labels.json — per-feature probe labels not present; this vindex has only cluster-level labels)".into());
+            }
             return Ok(out);
         }
 

--- a/crates/larql-lql/src/executor/tests.rs
+++ b/crates/larql-lql/src/executor/tests.rs
@@ -3513,6 +3513,37 @@ fn stats_with_relation_classifier_renders_coverage_breakdown() {
 }
 
 #[test]
+fn stats_without_feature_labels_notes_missing_probe_layer() {
+    // Classifier present (relation_clusters + feature_clusters) so the
+    // Coverage block renders, but NO feature_labels.json → num_probes == 0.
+    // STATS must surface a note that the probe-label layer is absent.
+    let dir = make_test_vindex_dir("stats_no_feature_labels");
+    std::fs::write(
+        dir.join(larql_vindex::format::filenames::RELATION_CLUSTERS_JSON),
+        r#"{"k":2,"centres":[[1.0,0.0,0.0,0.0],[0.0,1.0,0.0,0.0]],"labels":["capital","language"],"counts":[5,3],"top_tokens":[["paris"],["english"]]}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join(larql_vindex::format::filenames::FEATURE_CLUSTERS_JSONL),
+        "{\"l\":0,\"f\":0,\"c\":0}\n{\"l\":1,\"f\":2,\"c\":1}\n",
+    )
+    .unwrap();
+    // Deliberately NO feature_labels.json.
+
+    let mut session = Session::new();
+    let stmt = parser::parse(&format!(r#"USE "{}";"#, lql_path(&dir))).unwrap();
+    session.execute(&stmt).expect("USE without feature_labels");
+    let stmt = parser::parse("STATS;").unwrap();
+    let out = session.execute(&stmt).expect("STATS");
+    let joined = out.join("\n");
+    assert!(
+        joined.contains("no feature_labels.json"),
+        "expected missing-probe-layer note, got: {joined}",
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn stats_with_explicit_path_runs() {
     // STATS "<path>" form — explicit vindex path argument.
     let (mut session, dir) = vindex_session("stats_path");

--- a/crates/larql-vindex/docs/format-spec.md
+++ b/crates/larql-vindex/docs/format-spec.md
@@ -136,7 +136,7 @@ model.vindex/
 ├── index.json                # VindexConfig: layers, sizes, checksums, provenance
 ├── tokenizer.json            # HuggingFace tokenizer
 ├── relation_clusters.json    # Cluster centres, labels, counts
-├── feature_labels.json       # Probe-confirmed labels
+├── feature_labels.json       # Probe-confirmed labels (optional; from a separate labeling pass, NOT larql extract)
 └── weight_manifest.json      # Weight file → offset mapping
 ```
 
@@ -623,7 +623,10 @@ Discovered relation clusters from offset-direction clustering:
 
 ### feature_labels.json
 
-Probe-confirmed labels (from the larql-knowledge pipeline):
+Probe-confirmed per-feature labels, produced by a SEPARATE labeling/probe pass
+(the larql-knowledge Python pipeline — `knowledge/build_feature_labels.py`, see
+`knowledge/README.md`), NOT by `larql extract`. Optional — when absent, `STATS` /
+`DESCRIBE` say so and queries fall back to cluster-level labels.
 ```json
 {
   "26:9515": "capital",

--- a/crates/larql-vindex/src/format/filenames.rs
+++ b/crates/larql-vindex/src/format/filenames.rs
@@ -23,6 +23,10 @@ pub const MODEL_WEIGHTS_BIN: &str = "model_weights.bin";
 // ── Labels / clustering sidecars ───────────────────────────────────────
 pub const RELATION_CLUSTERS_JSON: &str = "relation_clusters.json";
 pub const FEATURE_CLUSTERS_JSONL: &str = "feature_clusters.jsonl";
+/// Probe-confirmed per-feature labels (key format `"layer:feature"`), the
+/// highest-priority label source at query time. Produced by a SEPARATE
+/// labeling/probe pass (the larql-knowledge pipeline), NOT by `larql extract`.
+/// Optional: when absent, queries fall back to cluster-level labels.
 pub const FEATURE_LABELS_JSON: &str = "feature_labels.json";
 
 // ── Embeddings + norms (always present) ────────────────────────────────


### PR DESCRIPTION
## Summary
- STATS/DESCRIBE now surface when `feature_labels.json` is absent, with provenance documented in the format spec
- Independent of the GGUF-streaming work — split out as its own reviewable unit

## Test plan
- [x] `cargo test -p larql-lql --lib` — 727 passed, 0 failed
- [ ] CI green