### PR TITLE
fix(extract): run relation clustering in the streaming path (#151)

### DIFF
--- a/crates/larql-vindex/docs/adr/009-extract-relation-confined-constructive.md
+++ b/crates/larql-vindex/docs/adr/009-extract-relation-confined-constructive.md
@@ -1,0 +1,31 @@
+# ADR-009: Extract is a typed Input→Output relation that runs confined and constructively witnesses totality
+
+**Status**: Proposed
+**Date**: 2026-06-16
+**Context**: `larql extract` is two positional procedures (`build_vindex`, `build_vindex_streaming`) returning `Result<(), VindexError>` — no output value, with strategy routing scattered in the CLI. Two defects share a root: (1) the host can be CPU-saturated (no thread governance: OpenBLAS + rayon uncapped); (2) tensors can be silently dropped, yielding a hollow vindex with exit 0 (#147/#153/#158). Defect (2) is a non-constructivity: the code *assumes* every source tensor is handled (`∀t. written(t) ∨ skipped(t)`) without *constructing* the witness, so dropped tensors fall into a truth-value gap.
+
+## Decision
+
+Model extraction as a single typed relation, not a procedure:
+
+```rust
+fn extract(input: ExtractInput, io: &mut dyn IndexBuildCallbacks)
+    -> Result<ExtractOutput, VindexError>;
+```
+
+with `ExtractInput` carrying the source, level, shaping, and `resources` (governance), and `ExtractOutput` carrying `components`, `skipped`, `completeness ∈ {Complete, Partial, Hollow, Unverified}`, and `resources` used. The relation `R ⊆ ExtractInput × ExtractOutput` has four clauses: **Confinement** (run ≤ `resources` threads), **Totality** (`components ⊎ skipped` partitions source tensors at `level`), **Level-completeness** (`Complete ⟺` no level-required tensor skipped), **Faithfulness** (each component decodes isomorphic to source modulo shaping).
+
+Two principles bind the implementation:
+- **Confined execution**: one thread budget `N` set before any matmul, applied to *both* OpenBLAS (`openblas_set_num_threads` + `OMP_NUM_THREADS`) and rayon, default never all-cores. Working memory is bounded *independent of model size* — `O(largest tensor + fixed scratch)` via streaming, or a refusal where a path cannot stream — so a model's extractability is determined by **disk** (source + output must fit), not RAM, and the host never crashes. In-memory fallback paths whose footprint cannot be bounded **hard-error** (constructive refusal) rather than estimate.
+- **Constructive totality**: `completeness` is a *constructed* value. Code that does not enumerate-and-decide each source tensor reports `Unverified` — it must **not assert `Complete`**. `skipped` is the constructive witness of the partition.
+
+## Consequences
+
+- **Good**: governance and completeness become *post-conditions of one relation* the unit can be verified against, rather than ad-hoc command bodies.
+- **Good**: silently-hollow vindexes become impossible to *claim* — absent a built witness the output is `Unverified`, not `Complete`.
+- **Good**: bounded working set makes peak RAM sublinear in model size (evidence: 360M → 0.88 GB, 2B → ~2.9 GB peak under a 4-thread cap), so any model that fits on disk is extractable given time, on memory-constrained hosts, without crashing.
+- **Good**: CLI strategy routing (`should_stream_*`) moves into `extract()`, shrinking the command to input-construction.
+- **Good**: `down_meta` becomes an optional, confined stage (skippable at inference level since inference does not consume it; thread-capped and peak-bounded when run) — so the verification run completes without the 98%-wall-time projection that is the crash-adjacent hot stage.
+- **Trade-off**: an implementation that does not build the partition emits `Unverified`; `Complete`/`Partial` population may be added later without changing the signature.
+- **Trade-off**: the joint thread budget assumes extract's BLAS and rayon phases are disjoint; nested BLAS-in-rayon must scope BLAS to 1 (invariant).
+- **Trade-off**: `rayon::build_global()` is process-set-once (first call wins); REPL/server apply once at startup.

--- a/crates/larql-vindex/src/extract/build/down_meta.rs
+++ b/crates/larql-vindex/src/extract/build/down_meta.rs
@@ -4,10 +4,8 @@
 use larql_models::{TopKEntry, WeightArray};
 
 use crate::error::VindexError;
-use crate::extract::build_helpers::{
-    build_whole_word_vocab, compute_gate_top_tokens, compute_offset_direction,
-};
-use crate::extract::constants::{FEATURE_PROJECTION_BATCH, FIRST_CONTENT_TOKEN_ID};
+use crate::extract::build_helpers::{build_whole_word_vocab, compute_gate_top_tokens};
+use crate::extract::constants::FEATURE_PROJECTION_BATCH;
 use crate::extract::stage_labels::*;
 
 use super::{knowledge_layer_range, BuildContext};
@@ -159,27 +157,19 @@ impl<'a> BuildContext<'a> {
                         // the RELATION between what activates the feature (entity)
                         // and what it outputs (target). France→Paris and
                         // Germany→Berlin share the same offset = "capital-of".
-                        if is_knowledge_layer
-                            && (top_token_id as usize) >= FIRST_CONTENT_TOKEN_ID
-                            && !gate_top_tokens.is_empty()
-                        {
-                            let gate_tok = &gate_top_tokens[feat];
-                            if let Some(offset) = compute_offset_direction(
-                                gate_tok,
-                                top_token_id as usize,
-                                self.weights,
+                        if is_knowledge_layer && !gate_top_tokens.is_empty() {
+                            self.cluster.collect(
+                                layer,
+                                feat,
+                                &gate_top_tokens[feat],
+                                top_token_id,
+                                &top_token,
+                                &top_k_entries,
+                                self.weights.embed.view(),
                                 self.tokenizer,
                                 self.hidden_size,
                                 self.vocab_size,
-                            ) {
-                                self.cluster_directions.extend_from_slice(&offset);
-                                self.cluster_features.push((layer, feat));
-                                let all_tokens: Vec<String> =
-                                    top_k_entries.iter().map(|e| e.token.clone()).collect();
-                                self.cluster_top_tokens.push(all_tokens.join("|"));
-                                self.cluster_input_tokens.push(gate_tok.clone());
-                                self.cluster_output_tokens.push(top_token.clone());
-                            }
+                            );
                         }
 
                         let feat_idx = feature_offset + feat;

--- a/crates/larql-vindex/src/extract/build/mod.rs
+++ b/crates/larql-vindex/src/extract/build/mod.rs
@@ -26,7 +26,7 @@ use crate::extract::stage_labels::*;
 use std::io::BufWriter;
 use std::path::Path;
 
-use larql_models::{FfnType, ModelWeights};
+use larql_models::{FfnType, ModelArchitecture, ModelWeights};
 
 use crate::config::dtype::{write_floats, StorageDtype};
 use crate::config::VindexLayerInfo;
@@ -43,6 +43,19 @@ pub(super) fn knowledge_layer_range(family: &str, num_layers: usize) -> Option<(
         let end = bands.knowledge.1.saturating_add(1).min(num_layers);
         (start, end)
     })
+}
+
+/// Tensor key for the matrix that defines each feature's input
+/// direction — the "what activates this feature" side of the gate→down
+/// relation. Gated FFN routes through `ffn_gate`; non-gated FFN (GPT-2,
+/// StarCoder2) reuses `ffn_up` for the same role. Used by both the
+/// gate-vectors writer and the clustering gate-top-token computation,
+/// on both the in-memory and streaming paths.
+pub(super) fn clustering_gate_key(arch: &dyn ModelArchitecture, layer: usize) -> String {
+    match arch.ffn_type() {
+        FfnType::Gated => arch.ffn_gate_key(layer),
+        FfnType::Standard => arch.ffn_up_key(layer),
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -74,11 +87,7 @@ pub(super) struct BuildContext<'a> {
     pub(super) layer_infos: Vec<VindexLayerInfo>,
 
     // Stage 3 collects → Stage 4 drains (`run_clustering`).
-    pub(super) cluster_directions: Vec<f32>,
-    pub(super) cluster_features: Vec<(usize, usize)>,
-    pub(super) cluster_top_tokens: Vec<String>,
-    pub(super) cluster_input_tokens: Vec<String>,
-    pub(super) cluster_output_tokens: Vec<String>,
+    pub(super) cluster: ClusterData,
 
     /// Dense-only BitNet build: when set, `write_index_json` writes
     /// the weight manifest with attention + FFN projections skipped
@@ -111,11 +120,7 @@ impl<'a> BuildContext<'a> {
             dtype,
             down_top_k,
             layer_infos: Vec::new(),
-            cluster_directions: Vec::new(),
-            cluster_features: Vec::new(),
-            cluster_top_tokens: Vec::new(),
-            cluster_input_tokens: Vec::new(),
-            cluster_output_tokens: Vec::new(),
+            cluster: ClusterData::default(),
             dense_only: false,
         }
     }
@@ -177,12 +182,7 @@ impl<'a> BuildContext<'a> {
                 }
             } else {
                 // Dense: single feature-input-direction matrix per layer.
-                // Gated FFN routes through `ffn_gate`; non-gated FFN (GPT-2,
-                // StarCoder2) reuses `ffn_up` for the same role.
-                let gate_key = match self.weights.arch.ffn_type() {
-                    FfnType::Gated => self.weights.arch.ffn_gate_key(layer),
-                    FfnType::Standard => self.weights.arch.ffn_up_key(layer),
-                };
+                let gate_key = clustering_gate_key(self.weights.arch.as_ref(), layer);
                 let w_gate = match self.weights.tensors.get(&gate_key) {
                     Some(w) => w,
                     None => continue,
@@ -223,15 +223,9 @@ impl<'a> BuildContext<'a> {
     /// Drains the `cluster_*` accumulators.
     fn run_clustering(&mut self) -> Result<(), VindexError> {
         run_clustering_pipeline(
-            ClusterData {
-                directions: std::mem::take(&mut self.cluster_directions),
-                features: std::mem::take(&mut self.cluster_features),
-                top_tokens: std::mem::take(&mut self.cluster_top_tokens),
-                input_tokens: std::mem::take(&mut self.cluster_input_tokens),
-                output_tokens: std::mem::take(&mut self.cluster_output_tokens),
-            },
+            std::mem::take(&mut self.cluster),
             self.hidden_size,
-            self.weights,
+            self.weights.embed.view(),
             self.tokenizer,
             self.output_dir,
             self.callbacks,

--- a/crates/larql-vindex/src/extract/build_helpers/clustering.rs
+++ b/crates/larql-vindex/src/extract/build_helpers/clustering.rs
@@ -4,15 +4,20 @@
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-use larql_models::ModelWeights;
-
 use crate::error::VindexError;
 use crate::extract::callbacks::IndexBuildCallbacks;
-use crate::extract::constants::{MAX_RELATION_CLUSTERS, RELATION_KMEANS_ITERS};
+use crate::extract::constants::{
+    FIRST_CONTENT_TOKEN_ID, MAX_RELATION_CLUSTERS, RELATION_KMEANS_ITERS,
+};
 use crate::extract::stage_labels::STAGE_RELATION_CLUSTERS;
 use crate::format::filenames::{FEATURE_CLUSTERS_JSONL, RELATION_CLUSTERS_JSON};
 
 /// Collected data for relation clustering.
+///
+/// Both extract paths hold one of these in their context and append to
+/// it per knowledge-band feature via [`ClusterData::collect`]; the
+/// orchestrator then drains it into [`run_clustering_pipeline`].
+#[derive(Default)]
 pub(crate) struct ClusterData {
     pub directions: Vec<f32>,
     pub features: Vec<(usize, usize)>,
@@ -22,12 +27,57 @@ pub(crate) struct ClusterData {
     pub output_tokens: Vec<String>,
 }
 
+impl ClusterData {
+    /// Collect the gate→down offset direction for one knowledge-band
+    /// feature. Shared by the in-memory and streaming down-meta stages
+    /// so the relation-clustering input is byte-identical across paths.
+    ///
+    /// `offset = normalize(target_embed - input_embed)` captures the
+    /// RELATION between what activates the feature (entity) and what it
+    /// outputs (target). France→Paris and Germany→Berlin share the same
+    /// offset = "capital-of". No-op when `top_token_id` is a special
+    /// token or `compute_offset_direction` rejects the pair.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn collect(
+        &mut self,
+        layer: usize,
+        feat: usize,
+        gate_token: &str,
+        top_token_id: u32,
+        top_token: &str,
+        top_k_entries: &[larql_models::TopKEntry],
+        embed: ndarray::ArrayView2<f32>,
+        tokenizer: &tokenizers::Tokenizer,
+        hidden_size: usize,
+        vocab_size: usize,
+    ) {
+        if (top_token_id as usize) < FIRST_CONTENT_TOKEN_ID {
+            return;
+        }
+        if let Some(offset) = super::compute_offset_direction(
+            gate_token,
+            top_token_id as usize,
+            embed,
+            tokenizer,
+            hidden_size,
+            vocab_size,
+        ) {
+            self.directions.extend_from_slice(&offset);
+            self.features.push((layer, feat));
+            let all_tokens: Vec<String> = top_k_entries.iter().map(|e| e.token.clone()).collect();
+            self.top_tokens.push(all_tokens.join("|"));
+            self.input_tokens.push(gate_token.to_string());
+            self.output_tokens.push(top_token.to_string());
+        }
+    }
+}
+
 /// Run the clustering and labeling pipeline on collected cluster data.
 /// Writes `relation_clusters.json` and `feature_clusters.jsonl`.
 pub(crate) fn run_clustering_pipeline(
     data: ClusterData,
     hidden_size: usize,
-    weights: &ModelWeights,
+    embed: ndarray::ArrayView2<f32>,
     tokenizer: &tokenizers::Tokenizer,
     output_dir: &Path,
     callbacks: &mut dyn IndexBuildCallbacks,
@@ -75,7 +125,7 @@ pub(crate) fn run_clustering_pipeline(
     let (embed_labels, top_tokens_per_cluster) =
         crate::clustering::auto_label_clusters_from_embeddings(
             &centres,
-            &weights.embed,
+            &embed,
             tokenizer,
             &assignments,
             &data.top_tokens,
@@ -152,7 +202,7 @@ mod tests {
                 output_tokens: Vec::new(),
             },
             4,
-            &weights,
+            weights.embed.view(),
             &toks,
             tmp.path(),
             &mut cb,
@@ -206,7 +256,7 @@ mod tests {
                 output_tokens,
             },
             hidden,
-            &weights,
+            weights.embed.view(),
             &toks,
             tmp.path(),
             &mut cb,
@@ -252,7 +302,7 @@ mod tests {
                 output_tokens: vec!["a".into(), "b".into(), "c".into()],
             },
             4,
-            &weights,
+            weights.embed.view(),
             &toks,
             tmp.path(),
             &mut cb,

--- a/crates/larql-vindex/src/extract/build_helpers/gate_tops.rs
+++ b/crates/larql-vindex/src/extract/build_helpers/gate_tops.rs
@@ -1,7 +1,7 @@
 //! Per-feature top whole-word token — the "what activates this
 //! feature" label used downstream by clustering.
 
-use larql_models::{FfnType, ModelWeights};
+use larql_models::ModelWeights;
 use ndarray::Array2;
 
 use crate::extract::constants::GATE_TOP_TOKEN_BATCH;
@@ -16,18 +16,25 @@ pub(crate) fn compute_gate_top_tokens(
     ww_ids: &[usize],
     ww_embed: &Array2<f32>,
 ) -> Vec<String> {
-    // Gated FFN routes through `ffn_gate`; non-gated FFN (GPT-2,
-    // StarCoder2) reuses `ffn_up` for the same per-feature input
-    // direction.
-    let gate_key = match weights.arch.ffn_type() {
-        FfnType::Gated => weights.arch.ffn_gate_key(layer),
-        FfnType::Standard => weights.arch.ffn_up_key(layer),
-    };
+    let gate_key = crate::extract::build::clustering_gate_key(weights.arch.as_ref(), layer);
     let w_gate = match weights.tensors.get(&gate_key) {
         Some(w) => w,
         None => return vec![String::new(); num_features],
     };
+    compute_gate_top_tokens_from_matrix(w_gate.view(), tokenizer, num_features, ww_ids, ww_embed)
+}
 
+/// Same as [`compute_gate_top_tokens`] but takes a view of the gate
+/// matrix directly (rows = features, cols = hidden). Used by the
+/// streaming extract path, which loads the gate matrix per-layer via
+/// its `tensor_source` rather than holding a full `ModelWeights`.
+pub(crate) fn compute_gate_top_tokens_from_matrix(
+    w_gate: ndarray::ArrayView2<f32>,
+    tokenizer: &tokenizers::Tokenizer,
+    num_features: usize,
+    ww_ids: &[usize],
+    ww_embed: &Array2<f32>,
+) -> Vec<String> {
     let mut tokens = vec![String::new(); num_features];
     let gbatch = GATE_TOP_TOKEN_BATCH;
     for gstart in (0..num_features).step_by(gbatch) {

--- a/crates/larql-vindex/src/extract/build_helpers/mod.rs
+++ b/crates/larql-vindex/src/extract/build_helpers/mod.rs
@@ -34,7 +34,7 @@ mod vocab;
 
 // Re-exports preserving the pre-split path (`super::build_helpers::*`).
 pub(crate) use clustering::{run_clustering_pipeline, ClusterData};
-pub(crate) use gate_tops::compute_gate_top_tokens;
+pub(crate) use gate_tops::{compute_gate_top_tokens, compute_gate_top_tokens_from_matrix};
 pub(crate) use offset::compute_offset_direction;
 pub(crate) use timestamp::chrono_now;
 pub(crate) use vocab::build_whole_word_vocab;

--- a/crates/larql-vindex/src/extract/build_helpers/offset.rs
+++ b/crates/larql-vindex/src/extract/build_helpers/offset.rs
@@ -1,16 +1,20 @@
 //! Offset direction — normalised `embed[output] - embed[input]`,
 //! the relation vector for clustering.
 
-use larql_models::ModelWeights;
-
 use crate::extract::constants::FIRST_CONTENT_TOKEN_ID;
 
 /// Compute the offset direction for a gate→down feature pair.
 /// Returns normalized(output_embed − input_embed) or None if invalid.
+///
+/// Takes a view of the embedding table directly (rather than a full
+/// `ModelWeights`) so both the in-memory and the streaming extract
+/// paths can call it — streaming never materializes a `ModelWeights`.
+/// A view lets the in-memory path pass its `ArcArray2` and streaming
+/// its owned `Array2` with no copy.
 pub(crate) fn compute_offset_direction(
     gate_token: &str,
     output_token_id: usize,
-    weights: &ModelWeights,
+    embed: ndarray::ArrayView2<f32>,
     tokenizer: &tokenizers::Tokenizer,
     hidden_size: usize,
     vocab_size: usize,
@@ -36,7 +40,7 @@ pub(crate) fn compute_offset_direction(
 
     let mut input_avg = vec![0.0f32; hidden_size];
     for &id in &valid {
-        for (j, &v) in weights.embed.row(id).iter().enumerate() {
+        for (j, &v) in embed.row(id).iter().enumerate() {
             input_avg[j] += v;
         }
     }
@@ -45,7 +49,7 @@ pub(crate) fn compute_offset_direction(
         *v /= n;
     }
 
-    let output_embed = weights.embed.row(output_token_id);
+    let output_embed = embed.row(output_token_id);
     let offset: Vec<f32> = output_embed
         .iter()
         .zip(input_avg.iter())
@@ -88,8 +92,8 @@ mod tests {
             .assign(&ndarray::array![0.0, 1.0, 0.0, 0.0]);
         let weights = weights_with_embed(embed, 5);
 
-        let dir =
-            compute_offset_direction("France", 3, &weights, &toks, 4, 5).expect("offset computed");
+        let dir = compute_offset_direction("France", 3, weights.embed.view(), &toks, 4, 5)
+            .expect("offset computed");
         let expected_neg = -1.0_f32 / 2.0_f32.sqrt();
         let expected_pos = 1.0_f32 / 2.0_f32.sqrt();
         assert!((dir[0] - expected_neg).abs() < 1e-6);
@@ -103,7 +107,7 @@ mod tests {
         let toks = vocab_tokenizer(&["x"]);
         let embed = ndarray::Array2::<f32>::zeros((2, 4));
         let weights = weights_with_embed(embed, 2);
-        assert!(compute_offset_direction("", 3, &weights, &toks, 4, 5).is_none());
+        assert!(compute_offset_direction("", 3, weights.embed.view(), &toks, 4, 5).is_none());
     }
 
     #[test]
@@ -113,7 +117,8 @@ mod tests {
         let weights = weights_with_embed(embed, 5);
         for special_id in 0..3 {
             assert!(
-                compute_offset_direction("hello", special_id, &weights, &toks, 4, 5).is_none(),
+                compute_offset_direction("hello", special_id, weights.embed.view(), &toks, 4, 5)
+                    .is_none(),
                 "id {special_id} must be rejected"
             );
         }
@@ -124,7 +129,7 @@ mod tests {
         let toks = vocab_tokenizer(&["hello"]);
         let embed = ndarray::Array2::<f32>::zeros((5, 4));
         let weights = weights_with_embed(embed, 5);
-        assert!(compute_offset_direction("hello", 99, &weights, &toks, 4, 5).is_none());
+        assert!(compute_offset_direction("hello", 99, weights.embed.view(), &toks, 4, 5).is_none());
     }
 
     #[test]
@@ -132,7 +137,10 @@ mod tests {
         let toks = vocab_tokenizer(&["hello"]);
         let embed = ndarray::Array2::<f32>::zeros((5, 4));
         let weights = weights_with_embed(embed, 5);
-        assert!(compute_offset_direction("unknown_word", 3, &weights, &toks, 4, 5).is_none());
+        assert!(
+            compute_offset_direction("unknown_word", 3, weights.embed.view(), &toks, 4, 5)
+                .is_none()
+        );
     }
 
     #[test]
@@ -146,6 +154,6 @@ mod tests {
             .row_mut(4)
             .assign(&ndarray::array![1.0, 0.0, 0.0, 0.0]);
         let weights = weights_with_embed(embed, 5);
-        assert!(compute_offset_direction("hello", 3, &weights, &toks, 4, 5).is_none());
+        assert!(compute_offset_direction("hello", 3, weights.embed.view(), &toks, 4, 5).is_none());
     }
 }

--- a/crates/larql-vindex/src/extract/streaming/context.rs
+++ b/crates/larql-vindex/src/extract/streaming/context.rs
@@ -69,6 +69,12 @@ pub(super) struct StreamingContext<'a> {
     /// Set by the embeddings stage; read by the down-meta stage. Held
     /// in an `Option` so down-meta can `take()` it if it ever needs to.
     pub(super) embed: Option<Array2<f32>>,
+
+    /// Relation-clustering accumulator. The down-meta stage collects
+    /// per-feature offset directions for knowledge-band features (dense
+    /// only); the orchestrator drains it into `run_clustering_pipeline`
+    /// after down-meta completes. Mirrors `BuildContext::cluster`.
+    pub(super) cluster: crate::extract::build_helpers::ClusterData,
 }
 
 impl<'a> StreamingContext<'a> {
@@ -223,6 +229,7 @@ impl<'a> StreamingContext<'a> {
             layer_infos: Vec::new(),
             vocab_size: 0,
             embed: None,
+            cluster: crate::extract::build_helpers::ClusterData::default(),
         })
     }
 

--- a/crates/larql-vindex/src/extract/streaming/mod.rs
+++ b/crates/larql-vindex/src/extract/streaming/mod.rs
@@ -105,6 +105,7 @@ pub fn build_vindex_streaming(
     ctx.write_router_weights()?;
     ctx.write_embeddings()?;
     ctx.write_down_meta()?;
+    ctx.run_clustering()?;
     ctx.write_tokenizer()?;
     ctx.write_index_json()?;
     ctx.maybe_write_model_weights()?;

--- a/crates/larql-vindex/src/extract/streaming/stages/down_meta.rs
+++ b/crates/larql-vindex/src/extract/streaming/stages/down_meta.rs
@@ -3,6 +3,8 @@
 use ndarray::Array2;
 
 use crate::error::VindexError;
+use crate::extract::build::{clustering_gate_key, knowledge_layer_range};
+use crate::extract::build_helpers::compute_gate_top_tokens_from_matrix;
 use crate::extract::constants::FEATURE_PROJECTION_BATCH;
 use crate::extract::stage_labels::*;
 use crate::extract::streaming::context::StreamingContext;
@@ -37,13 +39,19 @@ impl<'a> StreamingContext<'a> {
             .as_ref()
             .expect("embeddings stage must run before down_meta stage");
 
-        // Build whole-word vocab once
-        let (_ww_ids, _ww_embed) = crate::extract::build_helpers::build_whole_word_vocab(
-            self.tokenizer,
-            embed,
-            self.vocab_size,
-            self.hidden_size,
-        );
+        // Build whole-word vocab once — shared across knowledge layers for
+        // the gate→down clustering collection (mirrors the in-memory path).
+        let (ww_ids_shared, ww_embed_shared) =
+            crate::extract::build_helpers::build_whole_word_vocab(
+                self.tokenizer,
+                embed,
+                self.vocab_size,
+                self.hidden_size,
+            );
+
+        // Knowledge-band range drives which layers contribute relation
+        // directions, exactly as the in-memory path computes it.
+        let knowledge_layers = knowledge_layer_range(self.arch.family(), self.num_layers);
 
         let prefixes: Vec<&str> = self.prefixes.iter().map(|s| s.as_str()).collect();
         let down_layer_count = if resumed_down { 0 } else { self.num_layers };
@@ -146,6 +154,32 @@ impl<'a> StreamingContext<'a> {
                 continue;
             }
 
+            let is_knowledge_layer = knowledge_layers
+                .map(|(start, end)| layer >= start && layer < end)
+                .unwrap_or(false);
+
+            // Dense knowledge layers contribute relation directions for
+            // clustering. Pre-compute the gate top token per feature (the
+            // "what activates this feature" label) at full width, exactly
+            // as the in-memory path does. (MoE: skip — too many features.)
+            let gate_top_tokens: Vec<String> = if is_knowledge_layer && !self.is_moe {
+                let num_features = down_matrices[0].shape()[1];
+                let gate_key = clustering_gate_key(self.arch.as_ref(), layer);
+                let nk = normalize_key(&gate_key, &prefixes);
+                match self.tensor_source.get_tensor_f32(&nk)? {
+                    Some(w_gate) => compute_gate_top_tokens_from_matrix(
+                        w_gate.view(),
+                        self.tokenizer,
+                        num_features,
+                        &ww_ids_shared,
+                        &ww_embed_shared,
+                    ),
+                    None => vec![],
+                }
+            } else {
+                vec![]
+            };
+
             // The `--summary-features-per-expert` cap (which gates the
             // gate-vectors SVD path) also caps how many down_proj feature
             // columns we compute meta for. Without this cap, many-experts
@@ -218,6 +252,26 @@ impl<'a> StreamingContext<'a> {
                                 (String::new(), 0, 0.0)
                             };
 
+                        // Collect gate→down offset direction for relation
+                        // clustering — identical to the in-memory path
+                        // (`build::down_meta`). Dense knowledge layers only;
+                        // `feature_offset == 0` there, so `feat` is the
+                        // absolute feature index and indexes `gate_top_tokens`.
+                        if is_knowledge_layer && !gate_top_tokens.is_empty() {
+                            self.cluster.collect(
+                                layer,
+                                feat,
+                                &gate_top_tokens[feat],
+                                top_token_id,
+                                &top_token,
+                                &top_k_entries,
+                                embed.view(),
+                                self.tokenizer,
+                                self.hidden_size,
+                                self.vocab_size,
+                            );
+                        }
+
                         let feat_idx = feature_offset + feat;
                         if layer_down_meta.is_none() {
                             *layer_down_meta = Some(Vec::new());
@@ -269,5 +323,29 @@ impl<'a> StreamingContext<'a> {
             )?;
         }
         Ok(())
+    }
+
+    /// Stage 3b — k-means + label the relation directions the down-meta
+    /// stage collected, writing `relation_clusters.json` /
+    /// `feature_clusters.jsonl`. Mirrors `BuildContext::run_clustering`.
+    ///
+    /// Drains the `cluster_*` accumulators. No-op when nothing was
+    /// collected (e.g. a model with no knowledge band, an MoE model, or
+    /// a resumed run that skipped the down-meta loop) — the pipeline
+    /// early-returns on empty directions.
+    pub(in crate::extract::streaming) fn run_clustering(&mut self) -> Result<(), VindexError> {
+        let data = std::mem::take(&mut self.cluster);
+        let embed = match self.embed.as_ref() {
+            Some(e) => e,
+            None => return Ok(()),
+        };
+        crate::extract::build_helpers::run_clustering_pipeline(
+            data,
+            self.hidden_size,
+            embed.view(),
+            self.tokenizer,
+            self.output_dir,
+            self.callbacks,
+        )
     }
 }

--- a/crates/larql-vindex/tests/streaming_relation_clusters.rs
+++ b/crates/larql-vindex/tests/streaming_relation_clusters.rs
@@ -1,0 +1,219 @@
+//! Regression for fork bug #151 — `build_vindex_streaming` must produce
+//! relation clusters.
+//!
+//! Before the fix, the streaming extract path never collected gate→down
+//! offset directions and never invoked the clustering pipeline, so a
+//! streaming-extracted vindex had an EMPTY knowledge graph:
+//! `relation_clusters.json` and `feature_clusters.jsonl` were never
+//! written (`STATS` → "no relation clusters found"). The in-memory
+//! `build_vindex` path wrote them; streaming did not.
+//!
+//! This test builds a tiny synthetic safetensors model with enough
+//! layers to have a knowledge band (llama/32 → layers 13..=25) and a
+//! WordLevel tokenizer whose content words live at ids ≥
+//! FIRST_CONTENT_TOKEN_ID. It drives `build_vindex_streaming` and
+//! asserts the two cluster artifacts exist and are non-empty.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use larql_vindex::{
+    build_vindex_streaming, ExtractLevel, KquantWriteOptions, QuantFormat, SilentBuildCallbacks,
+    StorageDtype, WriteWeightsOptions,
+};
+
+static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+struct TempDir(PathBuf);
+impl TempDir {
+    fn new(label: &str) -> Self {
+        let pid = std::process::id();
+        let n = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let p = std::env::temp_dir().join(format!("larql_relclusters_{label}_{pid}_{n}"));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        Self(p)
+    }
+}
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+const NUM_LAYERS: usize = 32; // llama/32 → knowledge band layers 13..=25
+const HIDDEN: usize = 8;
+const INTERMEDIATE: usize = 4;
+// vocab: [UNK]=0 [PAD]=1 [BOS]=2 paris=3 france=4 berlin=5 germany=6
+const VOCAB: usize = 7;
+const CONTENT: [usize; 4] = [3, 4, 5, 6];
+
+/// Write a small synthetic safetensors model + WordLevel tokenizer.
+///
+/// The embeddings are (near-)standard-basis rows so the down/gate
+/// matrices we craft deterministically steer top tokens:
+///   - `embed[id, id] = 1.0` for id < HIDDEN (one-hot in hidden space).
+///   - down_proj feature `f` outputs content token `CONTENT[f]`.
+///   - gate_proj feature `f` is activated by content token
+///     `CONTENT[(f + 1) % 4]` — distinct from the output so the
+///     offset = embed[out] - embed[in] is non-zero.
+fn write_synth_model(model_dir: &Path) {
+    let config = serde_json::json!({
+        "model_type": "llama",
+        "hidden_size": HIDDEN,
+        "num_hidden_layers": NUM_LAYERS,
+        "intermediate_size": INTERMEDIATE,
+        "num_attention_heads": 1,
+        "num_key_value_heads": 1,
+        "head_dim": HIDDEN,
+        "rope_theta": 10000.0,
+        "vocab_size": VOCAB,
+    });
+    std::fs::write(
+        model_dir.join("config.json"),
+        serde_json::to_string(&config).unwrap(),
+    )
+    .unwrap();
+
+    let mut metadata: Vec<(String, Vec<usize>)> = Vec::new();
+    let mut tensors: HashMap<String, Vec<f32>> = HashMap::new();
+
+    // embed: row-major [VOCAB, HIDDEN], one-hot embed[id, id] for id<HIDDEN.
+    let mut embed = vec![0.0f32; VOCAB * HIDDEN];
+    for id in 0..VOCAB {
+        embed[id * HIDDEN + id] = 1.0;
+    }
+    tensors.insert("model.embed_tokens.weight".into(), embed);
+    metadata.push(("model.embed_tokens.weight".into(), vec![VOCAB, HIDDEN]));
+
+    for layer in 0..NUM_LAYERS {
+        // gate_proj: [INTERMEDIATE, HIDDEN]. gate[f, h]=1 → feature f's
+        // top whole-word is the token whose embedding is axis h.
+        let mut gate = vec![0.0f32; INTERMEDIATE * HIDDEN];
+        for f in 0..INTERMEDIATE {
+            let in_id = CONTENT[(f + 1) % 4];
+            gate[f * HIDDEN + in_id] = 1.0;
+        }
+        tensors.insert(format!("model.layers.{layer}.mlp.gate_proj.weight"), gate);
+        metadata.push((
+            format!("model.layers.{layer}.mlp.gate_proj.weight"),
+            vec![INTERMEDIATE, HIDDEN],
+        ));
+
+        // down_proj: [HIDDEN, INTERMEDIATE]. down[out_id, f]=10 →
+        // embed @ down[:,f] is maximal at vocab row out_id.
+        let mut down = vec![0.0f32; HIDDEN * INTERMEDIATE];
+        for f in 0..INTERMEDIATE {
+            let out_id = CONTENT[f];
+            down[out_id * INTERMEDIATE + f] = 10.0;
+        }
+        tensors.insert(format!("model.layers.{layer}.mlp.down_proj.weight"), down);
+        metadata.push((
+            format!("model.layers.{layer}.mlp.down_proj.weight"),
+            vec![HIDDEN, INTERMEDIATE],
+        ));
+    }
+
+    let tensor_bytes: Vec<(String, Vec<u8>, Vec<usize>)> = metadata
+        .iter()
+        .map(|(name, shape)| {
+            let data = &tensors[name];
+            let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+            (name.clone(), bytes, shape.clone())
+        })
+        .collect();
+    let views: Vec<(String, safetensors::tensor::TensorView<'_>)> = tensor_bytes
+        .iter()
+        .map(|(name, bytes, shape)| {
+            (
+                name.clone(),
+                safetensors::tensor::TensorView::new(safetensors::Dtype::F32, shape.clone(), bytes)
+                    .unwrap(),
+            )
+        })
+        .collect();
+    let serialized = safetensors::tensor::serialize(views, None).unwrap();
+    std::fs::write(model_dir.join("model.safetensors"), &serialized).unwrap();
+
+    // WordLevel tokenizer with content words at ids ≥ 3 so
+    // `compute_offset_direction` (which filters ids < 3) keeps them.
+    let tok_json = r#"{
+        "version": "1.0",
+        "model": {
+            "type": "WordLevel",
+            "vocab": {"[UNK]": 0, "[PAD]": 1, "[BOS]": 2,
+                      "paris": 3, "france": 4, "berlin": 5, "germany": 6},
+            "unk_token": "[UNK]"
+        },
+        "pre_tokenizer": {"type": "Whitespace"},
+        "added_tokens": []
+    }"#;
+    std::fs::write(model_dir.join("tokenizer.json"), tok_json).unwrap();
+}
+
+fn run_extract(model_dir: &Path, output_dir: &Path) {
+    let tok_bytes = std::fs::read(model_dir.join("tokenizer.json")).unwrap();
+    let tokenizer = larql_vindex::tokenizers::Tokenizer::from_bytes(&tok_bytes).unwrap();
+    let mut cb = SilentBuildCallbacks;
+    build_vindex_streaming(
+        model_dir,
+        &tokenizer,
+        "test/relation-clusters",
+        output_dir,
+        5,
+        0, // summary_features_per_expert (off)
+        ExtractLevel::Browse,
+        StorageDtype::F32,
+        QuantFormat::None,
+        WriteWeightsOptions::default(),
+        KquantWriteOptions::default(),
+        false,
+        &mut cb,
+    )
+    .unwrap();
+}
+
+#[test]
+fn streaming_extract_writes_relation_clusters() {
+    let model = TempDir::new("model");
+    write_synth_model(&model.0);
+
+    let out = TempDir::new("out");
+    run_extract(&model.0, &out.0);
+
+    let clusters = out.0.join("relation_clusters.json");
+    let feature_clusters = out.0.join("feature_clusters.jsonl");
+
+    assert!(
+        clusters.exists(),
+        "relation_clusters.json must exist after streaming extract (#151)"
+    );
+    assert!(
+        feature_clusters.exists(),
+        "feature_clusters.jsonl must exist after streaming extract (#151)"
+    );
+
+    // Non-empty: the clustering pipeline early-returns (writing nothing)
+    // when zero directions were collected, so a present-but-empty file
+    // would mean the collection didn't actually run.
+    let clusters_text = std::fs::read_to_string(&clusters).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&clusters_text).unwrap();
+    let k = parsed["k"].as_u64().expect("k field present");
+    assert!(
+        k >= 1,
+        "relation_clusters.json must have ≥1 cluster, got k={k}"
+    );
+
+    let jsonl = std::fs::read_to_string(&feature_clusters).unwrap();
+    let lines: Vec<_> = jsonl.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(
+        !lines.is_empty(),
+        "feature_clusters.jsonl must have ≥1 feature assignment"
+    );
+    for line in &lines {
+        let r: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert!(r.get("l").is_some(), "feature record has layer");
+        assert!(r.get("f").is_some(), "feature record has feature index");
+        assert!(r.get("c").is_some(), "feature record has cluster id");
+    }
+}


### PR DESCRIPTION
## Summary
- `build_vindex_streaming` now collects gate→down offset directions during the down_meta stage and invokes `run_clustering_pipeline`, so streaming-extracted vindexes (safetensors, dense GGUF) produce `relation_clusters.json` and `feature_clusters.jsonl`. Previously only the in-memory `build_vindex` path ran clustering (chrishayuk/larql#154).
- Both extract paths now share one `ClusterData::collect` and a `clustering_gate_key` helper.
- Rebased onto current `main`: this branch's original base predated two independent upstream changes — `BuildContext::dense_only` (a new field, kept alongside the `cluster: ClusterData` consolidation) and a `summary_features_per_expert` parameter added to `build_vindex_streaming` (the new regression test's call site updated accordingly).
- Includes ADR-009 (extract relation — confined execution + constructive totality).

## Test plan
- [x] `cargo test -p larql-vindex --lib` — 1103 passed, 0 failed
- [x] `cargo test -p larql-vindex --test streaming_relation_clusters` — passes (synthetic model, no real GGUF load)
- [ ] CI green