### PR TITLE
LQL strategy matrix: discovery harness + source×recipe×level expansion + CI conformance layer

### DIFF
--- a/.github/workflows/lql-matrix-smoke.yml
+++ b/.github/workflows/lql-matrix-smoke.yml
@@ -83,6 +83,11 @@ jobs:
           print("SMOKE PASSED")
           PY
 
+      - name: Conformance oracle unit tests
+        run: |
+          python -m pip install --quiet pytest
+          python -m pytest scripts/lql_matrix/conformance_test.py -v
+
       - name: Upload smoke artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lql-matrix-smoke.yml
+++ b/.github/workflows/lql-matrix-smoke.yml
@@ -85,8 +85,8 @@ jobs:
 
       - name: Conformance oracle unit tests
         run: |
-          python -m pip install --quiet pytest
-          python -m pytest scripts/lql_matrix/conformance_test.py -v
+          python3 -m pip install --quiet pytest
+          python3 -m pytest scripts/lql_matrix/conformance_test.py -v
 
       - name: Upload smoke artifacts
         if: always()

--- a/.github/workflows/lql-matrix-smoke.yml
+++ b/.github/workflows/lql-matrix-smoke.yml
@@ -1,0 +1,95 @@
+# Smoke test for the lql-matrix HARNESS ITSELF (run_matrix.py + aggregate.py) on
+# a real GitHub runner — validates the CI-specific I/O the local box can't:
+# /usr/bin/time -v peak-RSS capture, err-signal overlay, provenance, full-log
+# artifacting, and aggregate rendering. Uses a STUB `larql` so it needs no
+# workspace build and no model — runs in ~1 min. Scoped to its own branch so it
+# never triggers the heavy extraction matrix (that's lql-strategy-matrix).
+name: lql-matrix-smoke
+
+on:
+  push:
+    branches: [lql-matrix-smoke]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install GNU time
+        run: sudo apt-get update && sudo apt-get install -y time
+
+      - name: Build stub larql + tiny corpus
+        run: |
+          mkdir -p stub out
+          cat > stub/larql <<'STUB'
+          #!/usr/bin/env bash
+          # Minimal stand-in for `larql`: handles `--version` and `lql <stmt>`.
+          if [ "$1" = "--version" ]; then echo "larql 0.0.0-smoke"; exit 0; fi
+          stmt="$2"
+          echo "Using: stub.vindex (smoke)"
+          case "$stmt" in
+            *FOOBAR*) echo "Error: Parse error: unknown verb" ;;  # exit 0 + error text
+            *BOOM*)   echo "kaboom" >&2; exit 3 ;;                 # hard non-zero exit
+            *)        echo "ok output line" ;;
+          esac
+          exit 0
+          STUB
+          chmod +x stub/larql
+          cat > stub/corpus.jsonl <<'CORPUS'
+          {"id":"ok.cell","cat":"browse","lql":"USE \"{{VINDEX}}\"; STATS;"}
+          {"id":"errtext.cell","cat":"negative","lql":"USE \"{{VINDEX}}\"; FOOBAR;"}
+          {"id":"err.cell","cat":"negative","lql":"USE \"{{VINDEX}}\"; BOOM;"}
+          CORPUS
+
+      - name: Run harness against stub
+        env:
+          LARQL_BIN: stub/larql
+          MODEL_ID: smoke-model
+          CELL_TIMEOUT: "60"
+        run: |
+          scripts/lql_matrix/run_matrix.sh smoke stub.vindex stub/corpus.jsonl out/results-smoke.jsonl
+
+      - name: Aggregate
+        run: python3 scripts/lql_matrix/aggregate.py "out/results-smoke.jsonl" smoke.md
+
+      - name: Assert harness I/O (RSS, err-signal, buckets, provenance, logs)
+        run: |
+          echo "=== results-smoke.jsonl ==="; cat out/results-smoke.jsonl
+          echo "=== smoke.md ==="; cat smoke.md
+          cat smoke.md >> "$GITHUB_STEP_SUMMARY"
+          python3 - <<'PY'
+          import json, os
+          rows = [json.loads(l) for l in open("out/results-smoke.jsonl")]
+          meta = next(r for r in rows if r.get("type") == "meta")
+          cells = {r["id"]: r for r in rows if r.get("type") != "meta"}
+
+          def check(name, cond):
+              assert cond, f"FAIL: {name}"
+              print(f"ok: {name}")
+
+          check("ok.cell clean",     cells["ok.cell"]["bucket"] == "ok" and cells["ok.cell"]["err_signal"] == 0)
+          check("errtext exit0+err", cells["errtext.cell"]["bucket"] == "ok" and cells["errtext.cell"]["err_signal"] == 1)
+          check("errtext err_line",  cells["errtext.cell"]["err_line"].startswith("Error:"))
+          check("err bucket exit3",  cells["err.cell"]["bucket"] == "err" and cells["err.cell"]["exit_code"] == 3)
+          check("peak_rss captured",  all(isinstance(cells[c]["peak_rss_kb"], int) and cells[c]["peak_rss_kb"] > 0 for c in cells))
+          check("stderr_tail present", all("stderr_tail" in cells[c] for c in cells))
+          check("provenance commit",  "commit" in meta and "larql_version" in meta)
+          check("full logs persisted", os.path.isfile("out/cells/smoke.err.cell.err") and os.path.isfile("out/cells/smoke.ok.cell.out"))
+          print("SMOKE PASSED")
+          PY
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke
+          retention-days: 1
+          path: |
+            out/results-smoke.jsonl
+            smoke.md
+            out/cells/

--- a/.github/workflows/lql-strategy-matrix.yml
+++ b/.github/workflows/lql-strategy-matrix.yml
@@ -1,65 +1,53 @@
-# LQL Strategy Matrix — empirical extraction × command experiment.
+# LQL Strategy Matrix — empirical (source × produce-recipe × level) × command experiment.
 #
-# Extracts one real model (Qwen2.5-Coder-0.5B-Instruct) at EACH extraction
-# level (browse / attention / inference / all) on GitHub-hosted runners, then
-# runs the full LQL command corpus against each level's vindex and records the
-# RAW MECHANICAL OUTCOME of every cell (exit code, wall time, stdout/stderr,
-# ok/err/timeout/crash). It is a DISCOVERY experiment, not a pass/fail gate:
-# nothing here asserts output correctness or fails the build on a broken cell
-# — the data (especially the breakage) is the deliverable. Runs on the hosted
-# runner precisely so a dev box's RAM/time limits are irrelevant.
-#
-# Manual (workflow_dispatch) + weekly. One model to start; add models by
-# extending the matrix later.
-#
-# Build is factored into a single `build` job that compiles larql-cli once and
-# publishes the binary as an artifact; the four matrix legs download it instead
-# of each cold-compiling the workspace (4× redundant on a fresh cache). The
-# legs still apt-install the OpenBLAS runtime the binary dynamically links.
+# For every CLI-invokable leg (a model + a produce recipe: extract at a level,
+# extract with a quant flag, gguf-to-vindex, or post-hoc quantize), the workflow
+# PRODUCES a vindex on the current binary, records its structural descriptor
+# (family/dtype/quant vs expected — so extraction/convert breakage or silent
+# dequant is observed, not assumed), then runs the full LQL command corpus against
+# it and records the RAW MECHANICAL OUTCOME of every cell. Discovery experiment,
+# not a pass/fail gate: the breakage is the deliverable. Legs are enumerated by
+# scripts/lql_matrix/gen_legs.py (no prediction-pruning — see that file).
 
 name: lql-strategy-matrix
 
 on:
-  # Push-triggered on the experiment branch so a CI run starts without the
-  # workflow having to land on the default branch first (workflow_dispatch's
-  # constraint). Scoped to the branch so unrelated pushes never fire it.
   push:
     branches: [lql-strategy-matrix]
-  workflow_dispatch:
-    inputs:
-      model:
-        description: "HF model id to extract/exhaust"
-        default: "Qwen/Qwen2.5-Coder-0.5B-Instruct"
+  workflow_dispatch: {}
   schedule:
     - cron: "0 6 * * 1"   # Mondays 06:00 UTC
 
-# Least privilege: this workflow only reads the repo, builds, shuttles artifacts,
-# and writes the job summary. It never pushes, comments, or cuts releases, so the
-# token is dropped to read-only. (upload/download-artifact@v4 use the Actions
-# runtime backend, not GITHUB_TOKEN scopes, so they need nothing added here.)
 permissions:
   contents: read
 
-# Serialize runs per ref so repeated pushes — or the weekly schedule overlapping a
-# manual run — can't stack multiple 4×(≤350 min) matrices. cancel-in-progress:false
-# queues the newer run instead of killing an expensive in-flight data run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 env:
-  MODEL_ID: ${{ github.event.inputs.model || 'Qwen/Qwen2.5-Coder-0.5B-Instruct' }}
-  # larql is Rust; without this a panic prints only "run with RUST_BACKTRACE=1"
-  # and nothing else. The matrix's deliverable is breakage — capture the trace.
   RUST_BACKTRACE: "1"
 
 jobs:
-  # Compile larql-cli ONCE and hand the release binary to every matrix leg.
+  # Enumerate every leg as JSON → consumed by the matrix via fromJSON. A malformed
+  # plan fails here in seconds, before any leg runs.
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      legs: ${{ steps.gen.outputs.legs }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: gen
+        run: |
+          legs=$(python3 scripts/lql_matrix/gen_legs.py)
+          echo "legs=$legs" >> "$GITHUB_OUTPUT"
+          echo "$legs" | python3 -c "import json,sys; d=json.load(sys.stdin); print(f'{len(d)} legs planned')"
+
+  # Compile larql-cli ONCE; every leg downloads the binary.
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
       - name: Cache cargo deps
         uses: actions/cache@v5
         with:
@@ -69,74 +57,82 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-lqlmatrix-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-lqlmatrix-
-
       - name: Install BLAS (build)
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
-
       - name: Build larql-cli (release)
         run: cargo build --release -p larql-cli
-
       - name: Upload larql binary
         uses: actions/upload-artifact@v4
         with:
           name: larql-bin
           path: target/release/larql
-          retention-days: 1        # ephemeral: consumed by the matrix legs this run
+          retention-days: 1
           if-no-files-found: error
 
   matrix:
-    needs: build
+    needs: [plan, build]
     strategy:
-      fail-fast: false        # we WANT every cell run even when one breaks
+      fail-fast: false          # every leg runs even when one breaks — breakage is data
+      max-parallel: 12
       matrix:
-        level: [browse, attention, inference, all]
+        leg: ${{ fromJSON(needs.plan.outputs.legs) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 350       # under the 6h hard cap; extraction+compile is slow by design
+    timeout-minutes: 350
+    env:
+      NAME: ${{ matrix.leg.name }}
+      HF: ${{ matrix.leg.hf }}
+      OP: ${{ matrix.leg.op }}
+      LEVEL: ${{ matrix.leg.level }}
+      FLAGS: ${{ matrix.leg.flags }}
+      EXPECT_QUANT: ${{ matrix.leg.expect_quant }}
+      CORPUS_MODEL: ${{ matrix.leg.corpus_model }}
     steps:
       - uses: actions/checkout@v6
-
       - name: Download larql binary
         uses: actions/download-artifact@v4
         with:
           name: larql-bin
           path: bin
-
-      - name: Make binary executable
-        run: chmod +x bin/larql
-
-      # The release binary dynamically links OpenBLAS — install the runtime lib
-      # (seconds) so it can load. This is NOT the workspace build (done once
-      # above). `time` = GNU /usr/bin/time -v for per-cell peak-RSS capture.
-      - name: Install BLAS runtime + GNU time
-        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev time
-
-      - name: Cache HF model snapshot
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/huggingface/hub
-          key: ${{ runner.os }}-hf-${{ env.MODEL_ID }}
-          restore-keys: ${{ runner.os }}-hf-
-
+      - name: Prep
+        run: |
+          chmod +x bin/larql scripts/lql_matrix/run_matrix.sh
+          sudo apt-get update && sudo apt-get install -y libopenblas-dev time
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-
-      - name: Pre-download HF model snapshot
+      - name: Pre-download source snapshot (${{ matrix.leg.hf }})
         run: |
           python -m pip install --quiet huggingface_hub
-          python -c "from huggingface_hub import snapshot_download; snapshot_download('${MODEL_ID}')"
+          python -c "from huggingface_hub import snapshot_download; snapshot_download('${HF}')"
 
-      - name: Extract at level=${{ matrix.level }} (raw outcome captured)
+      - name: Produce vindex (${{ matrix.leg.op }})
         run: |
           set +e
           mkdir -p out
-          VINDEX="out/qwen-${{ matrix.level }}.vindex"
-          TIMEF="out/extract-${{ matrix.level }}.time"
+          LARQL=./bin/larql
+          VINDEX="out/${NAME}.vindex"
+          TIMEF="out/produce-${NAME}.time"
+          O="out/produce-${NAME}.out"; E="out/produce-${NAME}.err"
           start=$(date +%s%3N)
-          /usr/bin/time -v -o "$TIMEF" \
-            timeout 18000 ./bin/larql extract "${MODEL_ID}" -o "$VINDEX" --level ${{ matrix.level }} \
-            > "out/extract-${{ matrix.level }}.stdout.log" 2> "out/extract-${{ matrix.level }}.stderr.log"
+          case "$OP" in
+            extract)
+              /usr/bin/time -v -o "$TIMEF" timeout 18000 \
+                $LARQL extract "$HF" -o "$VINDEX" ${LEVEL:+--level $LEVEL} $FLAGS >"$O" 2>"$E" ;;
+            gguf-to-vindex)
+              GGUF=$(find ~/.cache/huggingface -name '*.gguf' | head -1)
+              echo "gguf source: $GGUF"
+              /usr/bin/time -v -o "$TIMEF" timeout 18000 \
+                $LARQL convert gguf-to-vindex "$GGUF" -o "$VINDEX" ${LEVEL:+--level $LEVEL} $FLAGS >"$O" 2>"$E" ;;
+            quantize-q4k)
+              $LARQL extract "$HF" -o "${VINDEX}.src" --level inference >"$O" 2>"$E"
+              /usr/bin/time -v -o "$TIMEF" timeout 18000 \
+                $LARQL convert quantize q4k --input "${VINDEX}.src" --output "$VINDEX" >>"$O" 2>>"$E" ;;
+            quantize-fp4)
+              $LARQL extract "$HF" -o "${VINDEX}.src" --level inference >"$O" 2>"$E"
+              /usr/bin/time -v -o "$TIMEF" timeout 18000 \
+                $LARQL convert quantize fp4 --input "${VINDEX}.src" --output "$VINDEX" >>"$O" 2>>"$E" ;;
+          esac
           ec=$?
           end=$(date +%s%3N)
           case "$ec" in
@@ -144,58 +140,40 @@ jobs:
           esac
           rss=$(grep 'Maximum resident' "$TIMEF" 2>/dev/null | grep -oE '[0-9]+' | head -1)
           vmb=$(du -sm "$VINDEX" 2>/dev/null | cut -f1)
-          printf '{"level":"%s","exit_code":%d,"bucket":"%s","duration_ms":%d,"peak_rss_kb":%s,"vindex_mb":%s}\n' \
-            "${{ matrix.level }}" "$ec" "$bucket" "$((end-start))" "${rss:-0}" "${vmb:-0}" \
-            > "out/extract-${{ matrix.level }}.json"
-          echo "extraction ${{ matrix.level }}: exit=$ec bucket=$bucket rss=${rss:-?}kb vindex=${vmb:-?}MB"
-
-          # --- structural data we need: which weight classes did THIS level produce? ---
-          # Proves e.g. whether the attention level actually omits FFN weights (the
-          # sparse_compute.rs:85 unwrap panic). index.json + weight_manifest.json are
-          # tiny; also derive a layer-collapsed key-family inventory for quick diffing.
-          MDIR="out/manifest-${{ matrix.level }}"; mkdir -p "$MDIR"
+          printf '{"name":"%s","op":"%s","level":"%s","flags":"%s","exit_code":%d,"bucket":"%s","duration_ms":%d,"peak_rss_kb":%s,"vindex_mb":%s}\n' \
+            "$NAME" "$OP" "$LEVEL" "$FLAGS" "$ec" "$bucket" "$((end-start))" "${rss:-0}" "${vmb:-0}" \
+            > "out/produce-${NAME}.json"
+          echo "produce ${NAME}: exit=$ec bucket=$bucket rss=${rss:-?}kb vindex=${vmb:-?}MB"
+          # descriptor: what did we actually get vs what we expected?
+          python3 scripts/lql_matrix/descriptor.py "$VINDEX" "$NAME" "$EXPECT_QUANT" \
+            > "out/descriptor-${NAME}.json" 2>/dev/null || echo '{"name":"'"$NAME"'","error":"descriptor failed"}' > "out/descriptor-${NAME}.json"
+          echo "descriptor:"; cat "out/descriptor-${NAME}.json"
+          # weight-family inventory (which classes the recipe produced)
+          MDIR="out/manifest-${NAME}"; mkdir -p "$MDIR"
           cp "$VINDEX/index.json" "$VINDEX/weight_manifest.json" "$MDIR/" 2>/dev/null || true
-          python3 - "$VINDEX/weight_manifest.json" > "$MDIR/weight_families.txt" 2>/dev/null <<'PY' || true
-          import json, sys, re, collections
-          try:
-              m = json.load(open(sys.argv[1]))
-          except Exception:
-              sys.exit(0)
-          fam = collections.Counter()
-          for t in (m if isinstance(m, list) else m.get("tensors", [])):
-              fam[re.sub(r"\d+", "*", t.get("key", ""))] += 1
-          for k, c in sorted(fam.items()):
-              print(f"{c}\t{k}")
-          PY
-          echo "weight families @ ${{ matrix.level }}:"; cat "$MDIR/weight_families.txt" 2>/dev/null || echo "  (none)"
-          # continue regardless — command cells against a partial/missing vindex are themselves data
 
-      - name: Run LQL command corpus at level=${{ matrix.level }}
+      - name: Run LQL command corpus (${{ matrix.leg.name }})
         run: |
-          chmod +x scripts/lql_matrix/run_matrix.sh
+          VINDEX="out/${NAME}.vindex"
           LARQL_BIN=./bin/larql \
-          MODEL_ID="${MODEL_ID}" \
+          MODEL_ID="${CORPUS_MODEL}" \
           TMPROOT="$(mktemp -d)" \
           CELL_TIMEOUT=900 \
           scripts/lql_matrix/run_matrix.sh \
-            ${{ matrix.level }} \
-            "out/qwen-${{ matrix.level }}.vindex" \
-            scripts/lql_matrix/commands.jsonl \
-            "out/results-${{ matrix.level }}.jsonl"
+            "${NAME}" "$VINDEX" scripts/lql_matrix/commands.jsonl "out/results-${NAME}.jsonl"
 
-      - name: Upload level results
+      - name: Upload leg results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: results-${{ matrix.level }}
-          retention-days: 1        # discovery data — retain 24h, then auto-expire
+          name: results-${{ matrix.leg.name }}
+          retention-days: 1
           path: |
-            out/results-${{ matrix.level }}.jsonl
-            out/extract-${{ matrix.level }}.json
-            out/extract-${{ matrix.level }}.stdout.log
-            out/extract-${{ matrix.level }}.stderr.log
-            out/extract-${{ matrix.level }}.time
-            out/manifest-${{ matrix.level }}/
+            out/results-${{ matrix.leg.name }}.jsonl
+            out/produce-${{ matrix.leg.name }}.json
+            out/produce-${{ matrix.leg.name }}.err
+            out/descriptor-${{ matrix.leg.name }}.json
+            out/manifest-${{ matrix.leg.name }}/
             out/cells/
 
   aggregate:
@@ -207,14 +185,15 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
-      - name: Build matrix table
+      - name: Build matrix report
         run: |
-          cp artifacts/results-*/extract-*.json . 2>/dev/null || true
+          cp artifacts/results-*/descriptor-*.json . 2>/dev/null || true
+          cp artifacts/results-*/produce-*.json . 2>/dev/null || true
           python3 scripts/lql_matrix/aggregate.py "artifacts/results-*/results-*.jsonl" lql-matrix.md
           cat lql-matrix.md >> "$GITHUB_STEP_SUMMARY"
       - name: Upload combined matrix
         uses: actions/upload-artifact@v4
         with:
           name: lql-matrix
-          retention-days: 1        # also mirrored into the job summary (the log)
+          retention-days: 1
           path: lql-matrix.md

--- a/.github/workflows/lql-strategy-matrix.yml
+++ b/.github/workflows/lql-strategy-matrix.yml
@@ -74,6 +74,54 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  quality:
+    # Loud, obviously-directed signal on the LQL command stack: fmt + clippy +
+    # tests, run ALONGSIDE the matrix (NOT a dependency of it) so a red check
+    # never skips the matrix — we want both signals on the same run to compare
+    # "unit test passed" against "matrix cell crashed" and localise the defect.
+    # No exemptions: the backlog is included on purpose. The alarm stays on.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Ensure clippy + rustfmt (runner ships stable rust already)
+        run: rustup component add clippy rustfmt
+      - name: Install BLAS
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+      - name: Cache cargo deps
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-lqlmatrix-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-lqlmatrix-
+      - name: fmt (loud)
+        id: fmt
+        continue-on-error: true
+        run: cargo fmt --all -- --check
+      - name: clippy — LQL stack (loud, no exemption)
+        id: clippy
+        continue-on-error: true
+        run: cargo clippy -p larql-lql -p larql-cli -p larql-inference -p larql-vindex -p larql-core -p larql-kv -p larql-models --no-default-features -- -D warnings
+      - name: test — LQL stack (comparative signal for the matrix)
+        id: test
+        continue-on-error: true
+        run: cargo test -p larql-lql -p larql-cli -p larql-inference -p larql-vindex -p larql-core -p larql-kv -p larql-models --no-default-features
+      - name: Report + fail loud if any check failed
+        run: |
+          {
+            echo "## Quality — LQL command stack"
+            echo "| check | outcome |"
+            echo "|---|---|"
+            echo "| fmt    | ${{ steps.fmt.outcome }} |"
+            echo "| clippy | ${{ steps.clippy.outcome }} |"
+            echo "| test   | ${{ steps.test.outcome }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          [ "${{ steps.fmt.outcome }}" = success ] \
+            && [ "${{ steps.clippy.outcome }}" = success ] \
+            && [ "${{ steps.test.outcome }}" = success ]
+
   matrix:
     needs: [plan, build]
     strategy:

--- a/.github/workflows/lql-strategy-matrix.yml
+++ b/.github/workflows/lql-strategy-matrix.yml
@@ -11,6 +11,11 @@
 #
 # Manual (workflow_dispatch) + weekly. One model to start; add models by
 # extending the matrix later.
+#
+# Build is factored into a single `build` job that compiles larql-cli once and
+# publishes the binary as an artifact; the four matrix legs download it instead
+# of each cold-compiling the workspace (4× redundant on a fresh cache). The
+# legs still apt-install the OpenBLAS runtime the binary dynamically links.
 
 name: lql-strategy-matrix
 
@@ -28,17 +33,27 @@ on:
   schedule:
     - cron: "0 6 * * 1"   # Mondays 06:00 UTC
 
+# Least privilege: this workflow only reads the repo, builds, shuttles artifacts,
+# and writes the job summary. It never pushes, comments, or cuts releases, so the
+# token is dropped to read-only. (upload/download-artifact@v4 use the Actions
+# runtime backend, not GITHUB_TOKEN scopes, so they need nothing added here.)
+permissions:
+  contents: read
+
+# Serialize runs per ref so repeated pushes — or the weekly schedule overlapping a
+# manual run — can't stack multiple 4×(≤350 min) matrices. cancel-in-progress:false
+# queues the newer run instead of killing an expensive in-flight data run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   MODEL_ID: ${{ github.event.inputs.model || 'Qwen/Qwen2.5-Coder-0.5B-Instruct' }}
 
 jobs:
-  matrix:
-    strategy:
-      fail-fast: false        # we WANT every cell run even when one breaks
-      matrix:
-        level: [browse, attention, inference, all]
+  # Compile larql-cli ONCE and hand the release binary to every matrix leg.
+  build:
     runs-on: ubuntu-latest
-    timeout-minutes: 350       # under the 6h hard cap; extraction+compile is slow by design
     steps:
       - uses: actions/checkout@v6
 
@@ -52,18 +67,51 @@ jobs:
           key: ${{ runner.os }}-cargo-lqlmatrix-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-lqlmatrix-
 
+      - name: Install BLAS (build)
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+
+      - name: Build larql-cli (release)
+        run: cargo build --release -p larql-cli
+
+      - name: Upload larql binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: larql-bin
+          path: target/release/larql
+          retention-days: 5
+          if-no-files-found: error
+
+  matrix:
+    needs: build
+    strategy:
+      fail-fast: false        # we WANT every cell run even when one breaks
+      matrix:
+        level: [browse, attention, inference, all]
+    runs-on: ubuntu-latest
+    timeout-minutes: 350       # under the 6h hard cap; extraction+compile is slow by design
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download larql binary
+        uses: actions/download-artifact@v4
+        with:
+          name: larql-bin
+          path: bin
+
+      - name: Make binary executable
+        run: chmod +x bin/larql
+
+      # The release binary dynamically links OpenBLAS — install the runtime lib
+      # (seconds) so it can load. This is NOT the workspace build (done once above).
+      - name: Install BLAS (runtime)
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+
       - name: Cache HF model snapshot
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface/hub
           key: ${{ runner.os }}-hf-${{ env.MODEL_ID }}
           restore-keys: ${{ runner.os }}-hf-
-
-      - name: Install BLAS
-        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
-
-      - name: Build larql-cli (release)
-        run: cargo build --release -p larql-cli
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -81,7 +129,7 @@ jobs:
           mkdir -p out
           VINDEX="out/qwen-${{ matrix.level }}.vindex"
           start=$(date +%s%3N)
-          timeout 18000 ./target/release/larql extract "${MODEL_ID}" -o "$VINDEX" --level ${{ matrix.level }} \
+          timeout 18000 ./bin/larql extract "${MODEL_ID}" -o "$VINDEX" --level ${{ matrix.level }} \
             > "out/extract-${{ matrix.level }}.stdout.log" 2> "out/extract-${{ matrix.level }}.stderr.log"
           ec=$?
           end=$(date +%s%3N)
@@ -97,7 +145,7 @@ jobs:
       - name: Run LQL command corpus at level=${{ matrix.level }}
         run: |
           chmod +x scripts/lql_matrix/run_matrix.sh
-          LARQL_BIN=./target/release/larql \
+          LARQL_BIN=./bin/larql \
           MODEL_ID="${MODEL_ID}" \
           TMPROOT="$(mktemp -d)" \
           CELL_TIMEOUT=900 \

--- a/.github/workflows/lql-strategy-matrix.yml
+++ b/.github/workflows/lql-strategy-matrix.yml
@@ -91,6 +91,7 @@ jobs:
       FLAGS: ${{ matrix.leg.flags }}
       EXPECT_QUANT: ${{ matrix.leg.expect_quant }}
       CORPUS_MODEL: ${{ matrix.leg.corpus_model }}
+      TOKENIZER_REPO: ${{ matrix.leg.tokenizer_repo }}
     steps:
       - uses: actions/checkout@v6
       - name: Download larql binary
@@ -127,6 +128,13 @@ jobs:
             gguf-to-vindex)
               GGUF=$(find ~/.cache/huggingface -name '*.gguf' | head -1)
               echo "gguf source: $GGUF"
+              # Stage the tokenizer from the base repo beside the .gguf — the -gguf repo
+              # ships none, so gguf-to-vindex fails late without it (#180/#277).
+              if [ -n "$TOKENIZER_REPO" ]; then
+                TOKDIR=$(python3 -c "from huggingface_hub import snapshot_download; print(snapshot_download('${TOKENIZER_REPO}', allow_patterns=['tokenizer*','*special_tokens*','config.json','generation_config.json']))")
+                cp "$TOKDIR"/tokenizer*.json "$TOKDIR"/special_tokens_map.json "$(dirname "$GGUF")/" 2>/dev/null || true
+                echo "staged tokenizer from $TOKENIZER_REPO into $(dirname "$GGUF")"
+              fi
               /usr/bin/time -v -o "$TIMEF" timeout 18000 \
                 $LARQL convert gguf-to-vindex "$GGUF" -o "$VINDEX" ${LEVEL:+--level $LEVEL} $FLAGS >"$O" 2>"$E" ;;
             quantize-q4k)
@@ -179,6 +187,63 @@ jobs:
             out/produce-${{ matrix.leg.name }}.err
             out/descriptor-${{ matrix.leg.name }}.json
             out/manifest-${{ matrix.leg.name }}/
+            out/cells/
+
+  # Model-level lifecycle cells (EXTRACT MODEL / USE MODEL) don't read a produced
+  # vindex — run them ONCE per model instead of once per leg (removes the biggest
+  # duplicated extraction: the per-leg re-extract). Separate `lifecycle-*` artifacts
+  # so the conformance/aggregate `results-*` globs ignore them.
+  model-lifecycle:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        model:
+          - { id: qwen05,    hf: "Qwen/Qwen2.5-Coder-0.5B-Instruct" }
+          - { id: smol135,   hf: "HuggingFaceTB/SmolLM2-135M-Instruct" }
+          - { id: smol360,   hf: "HuggingFaceTB/SmolLM2-360M-Instruct" }
+          - { id: qwen15,    hf: "Qwen/Qwen2.5-1.5B-Instruct" }
+          - { id: granite1b, hf: "ibm-granite/granite-3.0-1b-a400m-instruct" }
+          - { id: bitnet2b,  hf: "microsoft/bitnet-b1.58-2B-4T" }
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download larql binary
+        uses: actions/download-artifact@v4
+        with:
+          name: larql-bin
+          path: bin
+      - name: Prep
+        run: |
+          chmod +x bin/larql scripts/lql_matrix/run_matrix.sh
+          sudo apt-get update && sudo apt-get install -y libopenblas-dev time
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Pre-download snapshot (${{ matrix.model.hf }})
+        run: |
+          python -m pip install --quiet huggingface_hub
+          python -c "from huggingface_hub import snapshot_download; snapshot_download('${{ matrix.model.hf }}')"
+      - name: Run model-level lifecycle corpus (${{ matrix.model.id }})
+        run: |
+          mkdir -p out
+          LARQL_BIN=./bin/larql \
+          MODEL_ID="${{ matrix.model.hf }}" \
+          TMPROOT="$(mktemp -d)" \
+          CELL_TIMEOUT=900 \
+          scripts/lql_matrix/run_matrix.sh \
+            "${{ matrix.model.id }}-lifecycle" "unused.vindex" \
+            scripts/lql_matrix/commands-model.jsonl "out/lifecycle-${{ matrix.model.id }}.jsonl"
+      - name: Upload lifecycle results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lifecycle-${{ matrix.model.id }}
+          retention-days: 1
+          path: |
+            out/lifecycle-${{ matrix.model.id }}.jsonl
             out/cells/
 
   aggregate:

--- a/.github/workflows/lql-strategy-matrix.yml
+++ b/.github/workflows/lql-strategy-matrix.yml
@@ -164,6 +164,9 @@ jobs:
           # weight-family inventory (which classes the recipe produced)
           MDIR="out/manifest-${NAME}"; mkdir -p "$MDIR"
           cp "$VINDEX/index.json" "$VINDEX/weight_manifest.json" "$MDIR/" 2>/dev/null || true
+          # tensor-presence witness (Q8): filename -> size for every vindex file
+          python3 -c "import json,os,sys; d=sys.argv[1]; print(json.dumps({f: os.path.getsize(os.path.join(d,f)) for f in os.listdir(d)}) if os.path.isdir(d) else '{}')" \
+            "$VINDEX" > "$MDIR/listing.json" 2>/dev/null || echo '{}' > "$MDIR/listing.json"
 
       - name: Run LQL command corpus (${{ matrix.leg.name }})
         run: |
@@ -296,3 +299,50 @@ jobs:
           path: |
             conformance.md
             conformance.json
+
+  inventory:
+    needs: [matrix, conformance]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Tensor-presence + Q8 resolution
+        run: |
+          python3 scripts/lql_matrix/tensor_presence.py \
+            "artifacts/results-*/manifest-*/listing.json" presence.json
+          python3 - <<'PY'
+          import json, glob, sys
+          sys.path.insert(0, "scripts/lql_matrix")
+          import tensor_presence as T
+          pres = json.load(open("presence.json"))
+          # panic := any no-crash (SIGKILL/panic, ec=101) violation on the leg
+          cj = glob.glob("artifacts/conformance/conformance.json")
+          viol = json.load(open(cj[0]))["violations"] if cj else []
+          panicked = {v["leg"] for v in viol if v["invariant"] == "no-crash"}
+          # Q8 / M3(a) is the *native attention-level* asymmetry (granite panics, bitnet refuses).
+          # Scope the biconditional to native legs; q4k legs panic by the distinct K6 hollow mechanism.
+          native = {k: v for k, v in pres.items() if ".native." in k}
+          panic = {leg: (leg in panicked) for leg in native}
+          res = T.resolve_q8(native, panic)
+          json.dump(res, open("q8.json", "w"), indent=2)
+          L = ["# Q8 — panic ⟺ (has_attn ∧ ¬has_ffn)?", "",
+               f"biconditional holds: **{res['biconditional_holds']}** · counterexamples: {len(res['counterexamples'])}", "",
+               "| leg | ffn_unwrap_risk | panic | agree |", "|---|---|---|---|"]
+          for r in res["rows"]:
+              L.append(f"| `{r['leg']}` | {r['ffn_unwrap_risk']} | {r['panic']} | {'✅' if r['agree'] else '❌'} |")
+          open("q8.md","w").write("\n".join(L)+"\n")
+          print("\n".join(L))
+          PY
+          cat q8.md >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: inventory
+          retention-days: 1
+          path: |
+            presence.json
+            q8.json
+            q8.md

--- a/.github/workflows/lql-strategy-matrix.yml
+++ b/.github/workflows/lql-strategy-matrix.yml
@@ -49,6 +49,9 @@ concurrency:
 
 env:
   MODEL_ID: ${{ github.event.inputs.model || 'Qwen/Qwen2.5-Coder-0.5B-Instruct' }}
+  # larql is Rust; without this a panic prints only "run with RUST_BACKTRACE=1"
+  # and nothing else. The matrix's deliverable is breakage — capture the trace.
+  RUST_BACKTRACE: "1"
 
 jobs:
   # Compile larql-cli ONCE and hand the release binary to every matrix leg.
@@ -78,7 +81,7 @@ jobs:
         with:
           name: larql-bin
           path: target/release/larql
-          retention-days: 5
+          retention-days: 1        # ephemeral: consumed by the matrix legs this run
           if-no-files-found: error
 
   matrix:
@@ -102,9 +105,10 @@ jobs:
         run: chmod +x bin/larql
 
       # The release binary dynamically links OpenBLAS — install the runtime lib
-      # (seconds) so it can load. This is NOT the workspace build (done once above).
-      - name: Install BLAS (runtime)
-        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+      # (seconds) so it can load. This is NOT the workspace build (done once
+      # above). `time` = GNU /usr/bin/time -v for per-cell peak-RSS capture.
+      - name: Install BLAS runtime + GNU time
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev time
 
       - name: Cache HF model snapshot
         uses: actions/cache@v5
@@ -128,18 +132,42 @@ jobs:
           set +e
           mkdir -p out
           VINDEX="out/qwen-${{ matrix.level }}.vindex"
+          TIMEF="out/extract-${{ matrix.level }}.time"
           start=$(date +%s%3N)
-          timeout 18000 ./bin/larql extract "${MODEL_ID}" -o "$VINDEX" --level ${{ matrix.level }} \
+          /usr/bin/time -v -o "$TIMEF" \
+            timeout 18000 ./bin/larql extract "${MODEL_ID}" -o "$VINDEX" --level ${{ matrix.level }} \
             > "out/extract-${{ matrix.level }}.stdout.log" 2> "out/extract-${{ matrix.level }}.stderr.log"
           ec=$?
           end=$(date +%s%3N)
           case "$ec" in
             0) bucket=ok ;; 124) bucket=timeout ;; 137|139|134) bucket=crash ;; *) bucket=err ;;
           esac
-          printf '{"level":"%s","exit_code":%d,"bucket":"%s","duration_ms":%d}\n' \
-            "${{ matrix.level }}" "$ec" "$bucket" "$((end-start))" \
+          rss=$(grep 'Maximum resident' "$TIMEF" 2>/dev/null | grep -oE '[0-9]+' | head -1)
+          vmb=$(du -sm "$VINDEX" 2>/dev/null | cut -f1)
+          printf '{"level":"%s","exit_code":%d,"bucket":"%s","duration_ms":%d,"peak_rss_kb":%s,"vindex_mb":%s}\n' \
+            "${{ matrix.level }}" "$ec" "$bucket" "$((end-start))" "${rss:-0}" "${vmb:-0}" \
             > "out/extract-${{ matrix.level }}.json"
-          echo "extraction ${{ matrix.level }}: exit=$ec bucket=$bucket"
+          echo "extraction ${{ matrix.level }}: exit=$ec bucket=$bucket rss=${rss:-?}kb vindex=${vmb:-?}MB"
+
+          # --- structural data we need: which weight classes did THIS level produce? ---
+          # Proves e.g. whether the attention level actually omits FFN weights (the
+          # sparse_compute.rs:85 unwrap panic). index.json + weight_manifest.json are
+          # tiny; also derive a layer-collapsed key-family inventory for quick diffing.
+          MDIR="out/manifest-${{ matrix.level }}"; mkdir -p "$MDIR"
+          cp "$VINDEX/index.json" "$VINDEX/weight_manifest.json" "$MDIR/" 2>/dev/null || true
+          python3 - "$VINDEX/weight_manifest.json" > "$MDIR/weight_families.txt" 2>/dev/null <<'PY' || true
+          import json, sys, re, collections
+          try:
+              m = json.load(open(sys.argv[1]))
+          except Exception:
+              sys.exit(0)
+          fam = collections.Counter()
+          for t in (m if isinstance(m, list) else m.get("tensors", [])):
+              fam[re.sub(r"\d+", "*", t.get("key", ""))] += 1
+          for k, c in sorted(fam.items()):
+              print(f"{c}\t{k}")
+          PY
+          echo "weight families @ ${{ matrix.level }}:"; cat "$MDIR/weight_families.txt" 2>/dev/null || echo "  (none)"
           # continue regardless — command cells against a partial/missing vindex are themselves data
 
       - name: Run LQL command corpus at level=${{ matrix.level }}
@@ -160,10 +188,15 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: results-${{ matrix.level }}
+          retention-days: 1        # discovery data — retain 24h, then auto-expire
           path: |
             out/results-${{ matrix.level }}.jsonl
             out/extract-${{ matrix.level }}.json
+            out/extract-${{ matrix.level }}.stdout.log
             out/extract-${{ matrix.level }}.stderr.log
+            out/extract-${{ matrix.level }}.time
+            out/manifest-${{ matrix.level }}/
+            out/cells/
 
   aggregate:
     needs: matrix
@@ -183,4 +216,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lql-matrix
+          retention-days: 1        # also mirrored into the job summary (the log)
           path: lql-matrix.md

--- a/.github/workflows/lql-strategy-matrix.yml
+++ b/.github/workflows/lql-strategy-matrix.yml
@@ -186,11 +186,13 @@ jobs:
               /usr/bin/time -v -o "$TIMEF" timeout 18000 \
                 $LARQL convert gguf-to-vindex "$GGUF" -o "$VINDEX" ${LEVEL:+--level $LEVEL} $FLAGS >"$O" 2>"$E" ;;
             quantize-q4k)
-              $LARQL extract "$HF" -o "${VINDEX}.src" --level inference >"$O" 2>"$E"
+              /usr/bin/time -v -o "${TIMEF}.src" timeout 18000 \
+                $LARQL extract "$HF" -o "${VINDEX}.src" --level inference >"$O" 2>"$E"
               /usr/bin/time -v -o "$TIMEF" timeout 18000 \
                 $LARQL convert quantize q4k --input "${VINDEX}.src" --output "$VINDEX" >>"$O" 2>>"$E" ;;
             quantize-fp4)
-              $LARQL extract "$HF" -o "${VINDEX}.src" --level inference >"$O" 2>"$E"
+              /usr/bin/time -v -o "${TIMEF}.src" timeout 18000 \
+                $LARQL extract "$HF" -o "${VINDEX}.src" --level inference >"$O" 2>"$E"
               /usr/bin/time -v -o "$TIMEF" timeout 18000 \
                 $LARQL convert quantize fp4 --input "${VINDEX}.src" --output "$VINDEX" >>"$O" 2>>"$E" ;;
           esac
@@ -199,7 +201,9 @@ jobs:
           case "$ec" in
             0) bucket=ok ;; 124) bucket=timeout ;; 137|139|134) bucket=crash ;; *) bucket=err ;;
           esac
-          rss=$(grep 'Maximum resident' "$TIMEF" 2>/dev/null | grep -oE '[0-9]+' | head -1)
+          # peak RSS = MAX across every command's time file (extract .src + quantize),
+          # not just the last — a fast-failing quantize must not hide a multi-GB extract.
+          rss=$(python3 scripts/lql_matrix/peak_rss.py "${TIMEF}.src" "$TIMEF" 2>/dev/null)
           vmb=$(du -sm "$VINDEX" 2>/dev/null | cut -f1)
           printf '{"name":"%s","op":"%s","level":"%s","flags":"%s","exit_code":%d,"bucket":"%s","duration_ms":%d,"peak_rss_kb":%s,"vindex_mb":%s}\n' \
             "$NAME" "$OP" "$LEVEL" "$FLAGS" "$ec" "$bucket" "$((end-start))" "${rss:-0}" "${vmb:-0}" \

--- a/.github/workflows/lql-strategy-matrix.yml
+++ b/.github/workflows/lql-strategy-matrix.yml
@@ -1,0 +1,138 @@
+# LQL Strategy Matrix — empirical extraction × command experiment.
+#
+# Extracts one real model (Qwen2.5-Coder-0.5B-Instruct) at EACH extraction
+# level (browse / attention / inference / all) on GitHub-hosted runners, then
+# runs the full LQL command corpus against each level's vindex and records the
+# RAW MECHANICAL OUTCOME of every cell (exit code, wall time, stdout/stderr,
+# ok/err/timeout/crash). It is a DISCOVERY experiment, not a pass/fail gate:
+# nothing here asserts output correctness or fails the build on a broken cell
+# — the data (especially the breakage) is the deliverable. Runs on the hosted
+# runner precisely so a dev box's RAM/time limits are irrelevant.
+#
+# Manual (workflow_dispatch) + weekly. One model to start; add models by
+# extending the matrix later.
+
+name: lql-strategy-matrix
+
+on:
+  # Push-triggered on the experiment branch so a CI run starts without the
+  # workflow having to land on the default branch first (workflow_dispatch's
+  # constraint). Scoped to the branch so unrelated pushes never fire it.
+  push:
+    branches: [lql-strategy-matrix]
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "HF model id to extract/exhaust"
+        default: "Qwen/Qwen2.5-Coder-0.5B-Instruct"
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+
+env:
+  MODEL_ID: ${{ github.event.inputs.model || 'Qwen/Qwen2.5-Coder-0.5B-Instruct' }}
+
+jobs:
+  matrix:
+    strategy:
+      fail-fast: false        # we WANT every cell run even when one breaks
+      matrix:
+        level: [browse, attention, inference, all]
+    runs-on: ubuntu-latest
+    timeout-minutes: 350       # under the 6h hard cap; extraction+compile is slow by design
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache cargo deps
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-lqlmatrix-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-lqlmatrix-
+
+      - name: Cache HF model snapshot
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/huggingface/hub
+          key: ${{ runner.os }}-hf-${{ env.MODEL_ID }}
+          restore-keys: ${{ runner.os }}-hf-
+
+      - name: Install BLAS
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+
+      - name: Build larql-cli (release)
+        run: cargo build --release -p larql-cli
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Pre-download HF model snapshot
+        run: |
+          python -m pip install --quiet huggingface_hub
+          python -c "from huggingface_hub import snapshot_download; snapshot_download('${MODEL_ID}')"
+
+      - name: Extract at level=${{ matrix.level }} (raw outcome captured)
+        run: |
+          set +e
+          mkdir -p out
+          VINDEX="out/qwen-${{ matrix.level }}.vindex"
+          start=$(date +%s%3N)
+          timeout 18000 ./target/release/larql extract "${MODEL_ID}" -o "$VINDEX" --level ${{ matrix.level }} \
+            > "out/extract-${{ matrix.level }}.stdout.log" 2> "out/extract-${{ matrix.level }}.stderr.log"
+          ec=$?
+          end=$(date +%s%3N)
+          case "$ec" in
+            0) bucket=ok ;; 124) bucket=timeout ;; 137|139|134) bucket=crash ;; *) bucket=err ;;
+          esac
+          printf '{"level":"%s","exit_code":%d,"bucket":"%s","duration_ms":%d}\n' \
+            "${{ matrix.level }}" "$ec" "$bucket" "$((end-start))" \
+            > "out/extract-${{ matrix.level }}.json"
+          echo "extraction ${{ matrix.level }}: exit=$ec bucket=$bucket"
+          # continue regardless — command cells against a partial/missing vindex are themselves data
+
+      - name: Run LQL command corpus at level=${{ matrix.level }}
+        run: |
+          chmod +x scripts/lql_matrix/run_matrix.sh
+          LARQL_BIN=./target/release/larql \
+          MODEL_ID="${MODEL_ID}" \
+          TMPROOT="$(mktemp -d)" \
+          CELL_TIMEOUT=900 \
+          scripts/lql_matrix/run_matrix.sh \
+            ${{ matrix.level }} \
+            "out/qwen-${{ matrix.level }}.vindex" \
+            scripts/lql_matrix/commands.jsonl \
+            "out/results-${{ matrix.level }}.jsonl"
+
+      - name: Upload level results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: results-${{ matrix.level }}
+          path: |
+            out/results-${{ matrix.level }}.jsonl
+            out/extract-${{ matrix.level }}.json
+            out/extract-${{ matrix.level }}.stderr.log
+
+  aggregate:
+    needs: matrix
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Build matrix table
+        run: |
+          cp artifacts/results-*/extract-*.json . 2>/dev/null || true
+          python3 scripts/lql_matrix/aggregate.py "artifacts/results-*/results-*.jsonl" lql-matrix.md
+          cat lql-matrix.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload combined matrix
+        uses: actions/upload-artifact@v4
+        with:
+          name: lql-matrix
+          path: lql-matrix.md

--- a/.github/workflows/lql-strategy-matrix.yml
+++ b/.github/workflows/lql-strategy-matrix.yml
@@ -318,23 +318,13 @@ jobs:
           sys.path.insert(0, "scripts/lql_matrix")
           import tensor_presence as T
           pres = json.load(open("presence.json"))
-          # panic := any no-crash (SIGKILL/panic, ec=101) violation on the leg
           cj = glob.glob("artifacts/conformance/conformance.json")
-          viol = json.load(open(cj[0]))["violations"] if cj else []
-          panicked = {v["leg"] for v in viol if v["invariant"] == "no-crash"}
-          # Q8 / M3(a) is the *native attention-level* asymmetry (granite panics, bitnet refuses).
-          # Scope the biconditional to native legs; q4k legs panic by the distinct K6 hollow mechanism.
-          native = {k: v for k, v in pres.items() if ".native." in k}
-          panic = {leg: (leg in panicked) for leg in native}
-          res = T.resolve_q8(native, panic)
+          violations = json.load(open(cj[0]))["violations"] if cj else None
+          res = T.render_q8(pres, violations, native_only=True)
           json.dump(res, open("q8.json", "w"), indent=2)
-          L = ["# Q8 — panic ⟺ (has_attn ∧ ¬has_ffn)?", "",
-               f"biconditional holds: **{res['biconditional_holds']}** · counterexamples: {len(res['counterexamples'])}", "",
-               "| leg | ffn_unwrap_risk | panic | agree |", "|---|---|---|---|"]
-          for r in res["rows"]:
-              L.append(f"| `{r['leg']}` | {r['ffn_unwrap_risk']} | {r['panic']} | {'✅' if r['agree'] else '❌'} |")
-          open("q8.md","w").write("\n".join(L)+"\n")
-          print("\n".join(L))
+          md = T.q8_markdown(res)
+          open("q8.md", "w", encoding="utf-8").write(md)
+          print(md)
           PY
           cat q8.md >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/lql-strategy-matrix.yml
+++ b/.github/workflows/lql-strategy-matrix.yml
@@ -14,7 +14,12 @@ name: lql-strategy-matrix
 on:
   push:
     branches: [lql-strategy-matrix]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: "Fail the run if any conformance invariant is violated"
+        type: boolean
+        default: false
   schedule:
     - cron: "0 6 * * 1"   # Mondays 06:00 UTC
 
@@ -197,3 +202,32 @@ jobs:
           name: lql-matrix
           retention-days: 1
           path: lql-matrix.md
+
+  conformance:
+    needs: matrix
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Run conformance oracle
+        env:
+          STRICT_INPUT: ${{ github.event.inputs.strict }}
+        run: |
+          STRICT=""
+          [ "$STRICT_INPUT" = "true" ] && STRICT="--strict"
+          python3 scripts/lql_matrix/conformance.py \
+            "artifacts/results-*/results-*.jsonl" conformance.md conformance.json $STRICT
+          echo "=== conformance.md ==="; cat conformance.md
+          cat conformance.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload conformance report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance
+          retention-days: 1
+          path: |
+            conformance.md
+            conformance.json

--- a/docs/superpowers/plans/2026-07-10-ci-conformance-layer.md
+++ b/docs/superpowers/plans/2026-07-10-ci-conformance-layer.md
@@ -1,0 +1,822 @@
+# CI Conformance Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the lql-strategy-matrix from a pure discovery experiment into an empirical V&V oracle: a `conformance.py` + peer CI job that asserts principled no-expected-output invariants over the already-captured artifacts, plus a transformation/consumability coverage report that surfaces interface gaps (e.g. no compiled→GGUF/Ollama path, no cross-arch qwen↔bitnet transform).
+
+**Architecture:** A standalone `scripts/lql_matrix/conformance.py` loads each leg's `results-*.jsonl` + `descriptor-*.json` + `produce-*.json`, runs an invariant registry (Completeness, No-crash, Descriptor self-match, Cross-check, Diagnostic), emits `conformance.md` + `conformance.json`, and exits non-zero only under `--strict`. `aggregate.py` stays descriptive; a peer `conformance` CI job (strict via `workflow_dispatch` input) runs the checker. A Transformation/Consumability coverage section (descriptive) surfaces gaps without running a server.
+
+**Tech Stack:** Python 3.12 stdlib only (matches `run_matrix.py`/`aggregate.py`); pytest 7.2.1 for tests; GitHub Actions YAML.
+
+## Global Constraints
+
+- Python: **stdlib only** — no third-party imports in `conformance.py` (json, re, glob, sys, dataclasses, pathlib). `pytest` is test-only.
+- **No larql code changes.** Harness/CI only. Read only the existing artifact fields.
+- **Discovery preserved:** default run stays green; violations gate the run **only** under `--strict` (a `workflow_dispatch` boolean input). Resolves tracker #247.
+- **No new capture:** `feature_count` is parsed from the `(L layers, F features` banner present in every cell's `stdout_head`; recipe `op`/`level`/`flags` come from `produce-<leg>.json`.
+- Artifacts retention: **1 day** (`retention-days: 1`), consistent with the rest of the workflow.
+- Encoding: always `encoding="utf-8"`; tolerant of missing/malformed artifacts (never crash the checker).
+- Out of scope for v1: runtime `larql serve` + `/v1/chat` drive (Phase 2); model quality / output correctness; T3 browser/web-llm.
+
+---
+
+## File Structure
+
+- Create: `scripts/lql_matrix/conformance.py` — the invariant registry, coverage report, gate. One responsibility: the oracle.
+- Create: `scripts/lql_matrix/conformance_test.py` — pytest tests over synthetic in-memory `Leg` fixtures (no file I/O except the `load()` test).
+- Modify: `.github/workflows/lql-strategy-matrix.yml` — add a peer `conformance` job + a `strict` `workflow_dispatch` input.
+- Modify: `.github/workflows/lql-matrix-smoke.yml` — run `conformance_test.py` (fast, no larql) so the oracle is validated on a runner.
+
+`descriptor.py`, `aggregate.py`, `run_matrix.py`, `gen_legs.py` are **unchanged** — `conformance.py` reads their existing outputs.
+
+---
+
+### Task 1: conformance.py skeleton — data model, loader, empty registry, CLI
+
+**Files:**
+- Create: `scripts/lql_matrix/conformance.py`
+- Test: `scripts/lql_matrix/conformance_test.py`
+
+**Interfaces:**
+- Produces: `Leg` (dataclass: `name:str, meta:dict, cells:dict, descriptor:dict, produce:dict`); `Violation` (dataclass: `invariant:str, leg:str, cell:str, detail:str`); `load(results_glob:str)->dict[str,Leg]`; `INVARIANTS:list[callable]` (each `callable(dict[str,Leg])->list[Violation]`); `run(results_glob:str, out_md:str, out_json:str, strict:bool)->int`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# scripts/lql_matrix/conformance_test.py
+import json, os, sys
+sys.path.insert(0, os.path.dirname(__file__))
+import conformance as C
+
+
+def make_leg(name="lg", cells=None, descriptor=None, produce=None, meta=None):
+    return C.Leg(name=name, meta=meta or {"level": name},
+                 cells=cells or {}, descriptor=descriptor or {},
+                 produce=produce or {})
+
+
+def test_load_reads_meta_cells_descriptor_produce(tmp_path):
+    d = tmp_path / "results-lgA"
+    d.mkdir()
+    (d / "results-lgA.jsonl").write_text(
+        json.dumps({"type": "meta", "level": "lgA"}) + "\n" +
+        json.dumps({"level": "lgA", "id": "stats", "bucket": "ok",
+                    "exit_code": 0, "stdout_head": "(24 layers, 5K features, m)"}) + "\n",
+        encoding="utf-8")
+    (d / "descriptor-lgA.json").write_text(json.dumps({"name": "lgA", "family": "qwen2"}), encoding="utf-8")
+    (d / "produce-lgA.json").write_text(json.dumps({"name": "lgA", "op": "extract", "bucket": "ok"}), encoding="utf-8")
+    legs = C.load(str(tmp_path / "results-*/results-*.jsonl"))
+    assert set(legs) == {"lgA"}
+    assert legs["lgA"].cells["stats"]["bucket"] == "ok"
+    assert legs["lgA"].descriptor["family"] == "qwen2"
+    assert legs["lgA"].produce["op"] == "extract"
+
+
+def test_run_with_empty_registry_is_green(tmp_path, monkeypatch):
+    monkeypatch.setattr(C, "INVARIANTS", [])
+    legs = {"lg": make_leg()}
+    monkeypatch.setattr(C, "load", lambda g: legs)
+    code = C.run("x", str(tmp_path / "c.md"), str(tmp_path / "c.json"), strict=True)
+    assert code == 0
+    assert json.loads((tmp_path / "c.json").read_text())["violations"] == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'conformance'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# scripts/lql_matrix/conformance.py
+"""Conformance oracle for the lql-strategy-matrix. Evaluates principled,
+no-expected-output invariants over already-captured artifacts and emits a
+report. Default exit 0 (discovery preserved); non-zero only under --strict."""
+import glob
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Leg:
+    name: str
+    meta: dict = field(default_factory=dict)
+    cells: dict = field(default_factory=dict)       # id -> row
+    descriptor: dict = field(default_factory=dict)
+    produce: dict = field(default_factory=dict)
+
+
+@dataclass
+class Violation:
+    invariant: str
+    leg: str
+    cell: str
+    detail: str
+
+
+def _read_json(path):
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def load(results_glob):
+    legs = {}
+    for rf in sorted(glob.glob(results_glob)):
+        d = Path(rf).parent
+        for line in Path(rf).read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            name = r.get("level")
+            if not name:
+                continue
+            lg = legs.setdefault(name, Leg(name=name))
+            if r.get("type") == "meta":
+                lg.meta = r
+            else:
+                lg.cells[r.get("id", "?")] = r
+        # sidecars: descriptor-<name>.json / produce-<name>.json in the same dir
+        for name, lg in legs.items():
+            dp = d / f"descriptor-{name}.json"
+            pp = d / f"produce-{name}.json"
+            if dp.exists():
+                lg.descriptor = _read_json(dp)
+            if pp.exists():
+                lg.produce = _read_json(pp)
+    return legs
+
+
+INVARIANTS = []
+
+
+def run(results_glob, out_md, out_json, strict):
+    legs = load(results_glob)
+    violations = [v for inv in INVARIANTS for v in inv(legs)]
+    Path(out_json).write_text(json.dumps(
+        {"violations": [v.__dict__ for v in violations]}, indent=2), encoding="utf-8")
+    Path(out_md).write_text(render(legs, violations), encoding="utf-8")
+    print(f"conformance: {len(violations)} violation(s) across {len(legs)} legs "
+          f"(strict={strict})")
+    return 1 if (strict and violations) else 0
+
+
+def render(legs, violations):
+    L = ["# LQL Matrix — Conformance", "",
+         f"Legs: {len(legs)} · Violations: {len(violations)}", ""]
+    if violations:
+        L += ["| invariant | leg | cell | detail |", "|---|---|---|---|"]
+        for v in violations:
+            L.append(f"| {v.invariant} | `{v.leg}` | {v.cell or '-'} | {v.detail} |")
+    else:
+        L.append("No invariant violations.")
+    return "\n".join(L) + "\n"
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    strict = "--strict" in sys.argv[1:]
+    results_glob = args[0] if args else "artifacts/results-*/results-*.jsonl"
+    out_md = args[1] if len(args) > 1 else "conformance.md"
+    out_json = args[2] if len(args) > 2 else "conformance.json"
+    sys.exit(run(results_glob, out_md, out_json, strict))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lql_matrix/conformance.py scripts/lql_matrix/conformance_test.py
+git commit -m "feat(conformance): skeleton — Leg/Violation model, loader, empty registry, gate"
+```
+
+---
+
+### Task 2: Completeness invariant (feature_count > 0)
+
+**Files:**
+- Modify: `scripts/lql_matrix/conformance.py`
+- Test: `scripts/lql_matrix/conformance_test.py`
+
+**Interfaces:**
+- Produces: `feature_count(leg:Leg)->int|None` (parses the `(L layers, F features` banner from any cell's `stdout_head`; `K`/`M` suffix expanded); `inv_completeness(dict[str,Leg])->list[Violation]`. Appends `inv_completeness` to `INVARIANTS`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to conformance_test.py
+def _cell(cid, stdout="", bucket="ok", exit_code=0, err_signal=0, err_line="", stderr=""):
+    return {"id": cid, "bucket": bucket, "exit_code": exit_code, "err_signal": err_signal,
+            "err_line": err_line, "stdout_head": stdout, "stderr_head": stderr}
+
+
+def test_feature_count_parses_banner_with_suffix():
+    lg = make_leg(cells={"stats": _cell("stats", "Using: x (24 layers, 116.7K features, m)")})
+    assert C.feature_count(lg) == 116700
+    lg0 = make_leg(cells={"stats": _cell("stats", "Using: x (24 layers, 0 features, m)")})
+    assert C.feature_count(lg0) == 0
+
+
+def test_completeness_flags_hollow_vindex():
+    hollow = make_leg("granite", cells={"stats": _cell("stats", "(24 layers, 0 features, m)")})
+    healthy = make_leg("qwen", cells={"stats": _cell("stats", "(24 layers, 5K features, m)")})
+    vs = C.inv_completeness({"granite": hollow, "qwen": healthy})
+    assert [v.leg for v in vs] == ["granite"]
+    assert vs[0].invariant == "completeness"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -k "feature_count or completeness" -v`
+Expected: FAIL — `AttributeError: module 'conformance' has no attribute 'feature_count'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to conformance.py (above `INVARIANTS = []`)
+_FEAT = re.compile(r"\(\s*\d+\s+layers?,\s*([\d.]+)\s*([KM]?)\s+features", re.I)
+
+
+def feature_count(leg):
+    for row in leg.cells.values():
+        m = _FEAT.search(row.get("stdout_head", "") or "")
+        if m:
+            n = float(m.group(1))
+            n *= {"K": 1e3, "M": 1e6, "": 1}[m.group(2).upper()]
+            return int(round(n))
+    return None
+
+
+def inv_completeness(legs):
+    out = []
+    for name, lg in legs.items():
+        fc = feature_count(lg)
+        if fc is None:
+            out.append(Violation("completeness", name, "",
+                                 "feature_count unknown (no STATS/banner — produce may have failed)"))
+        elif fc == 0:
+            out.append(Violation("completeness", name, "",
+                                 "hollow vindex: 0 features (silent-incomplete extraction, cf #183)"))
+    return out
+```
+
+Then change the registry line:
+
+```python
+INVARIANTS = [inv_completeness]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lql_matrix/conformance.py scripts/lql_matrix/conformance_test.py
+git commit -m "feat(conformance): completeness invariant — flag hollow (0-feature) vindexes"
+```
+
+---
+
+### Task 3: No-crash invariant (panic/crash in produce or any cell)
+
+**Files:**
+- Modify: `scripts/lql_matrix/conformance.py`
+- Test: `scripts/lql_matrix/conformance_test.py`
+
+**Interfaces:**
+- Produces: `inv_no_crash(dict[str,Leg])->list[Violation]`. A cell/produce is a crash iff `bucket == "crash"` or `exit_code in (101, 134, 137, 139)`. Graceful in-band error (exit 0) or clean non-zero (e.g. 3) is NOT a crash. Appends to `INVARIANTS`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to conformance_test.py
+def test_no_crash_flags_panic_and_crash_not_graceful():
+    legs = {
+        "panic": make_leg("panic", cells={"infer.top5": _cell("infer.top5", bucket="err", exit_code=101)}),
+        "crash": make_leg("crash", cells={"x": _cell("x", bucket="crash", exit_code=137)}),
+        "graceful": make_leg("graceful", cells={"infer.top5": _cell("infer.top5", bucket="ok", exit_code=0, err_signal=1, err_line="Error: requires model weights")}),
+        "cleanerr": make_leg("cleanerr", cells={"y": _cell("y", bucket="err", exit_code=3)}),
+        "produce_panic": make_leg("pp", produce={"bucket": "crash", "exit_code": 139}),
+    }
+    vs = C.inv_no_crash(legs)
+    flagged = sorted({v.leg for v in vs})
+    assert flagged == ["crash", "panic", "produce_panic"]
+    assert all(v.invariant == "no-crash" for v in vs)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -k no_crash -v`
+Expected: FAIL — `AttributeError: ... 'inv_no_crash'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to conformance.py
+_CRASH_CODES = {101, 134, 137, 139}
+
+
+def _is_crash(row):
+    return row.get("bucket") == "crash" or row.get("exit_code") in _CRASH_CODES
+
+
+def inv_no_crash(legs):
+    out = []
+    for name, lg in legs.items():
+        if lg.produce and _is_crash(lg.produce):
+            out.append(Violation("no-crash", name, "produce",
+                                 f"produce crashed (exit {lg.produce.get('exit_code')})"))
+        for cid, row in lg.cells.items():
+            if _is_crash(row):
+                out.append(Violation("no-crash", name, cid,
+                                     f"panic/crash (exit {row.get('exit_code')})"))
+    return out
+```
+
+Then extend the registry:
+
+```python
+INVARIANTS = [inv_completeness, inv_no_crash]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lql_matrix/conformance.py scripts/lql_matrix/conformance_test.py
+git commit -m "feat(conformance): no-crash invariant — panic/crash in produce or corpus is a violation"
+```
+
+---
+
+### Task 4: Descriptor self-match invariant (produced == declared intent)
+
+**Files:**
+- Modify: `scripts/lql_matrix/conformance.py`
+- Test: `scripts/lql_matrix/conformance_test.py`
+
+**Interfaces:**
+- Produces: `inv_descriptor_match(dict[str,Leg])->list[Violation]`. Violation when `descriptor.quant_match` is falsy, OR `descriptor.family` is falsy/`"generic"` (silent GenericArch fallback, cf #154). Legs with no descriptor (produce failed) are skipped here — No-crash/Completeness cover them. Appends to `INVARIANTS`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to conformance_test.py
+def test_descriptor_match_flags_quant_mismatch_and_generic_fallback():
+    legs = {
+        "ok": make_leg("ok", descriptor={"name": "ok", "quant_match": True, "family": "qwen2"}),
+        "dequant": make_leg("dequant", descriptor={"name": "dequant", "quant_match": False,
+                            "observed_quant": "none", "expect_quant": "q4k", "family": "qwen2"}),
+        "generic": make_leg("generic", descriptor={"name": "generic", "quant_match": True, "family": "generic"}),
+        "nodesc": make_leg("nodesc", descriptor={}),
+    }
+    vs = C.inv_descriptor_match(legs)
+    assert sorted({v.leg for v in vs}) == ["dequant", "generic"]
+    assert all(v.invariant == "descriptor-match" for v in vs)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -k descriptor_match -v`
+Expected: FAIL — `AttributeError: ... 'inv_descriptor_match'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to conformance.py
+def inv_descriptor_match(legs):
+    out = []
+    for name, lg in legs.items():
+        d = lg.descriptor
+        if not d or not d.get("produced", True) or d.get("error"):
+            continue  # produce-side failure — covered by completeness/no-crash
+        if not d.get("quant_match", True):
+            out.append(Violation("descriptor-match", name, "",
+                                 f"quant mismatch: produced {d.get('observed_quant')} != "
+                                 f"expected {d.get('expect_quant')}"))
+        fam = (d.get("family") or "").lower()
+        if fam in ("", "generic"):
+            out.append(Violation("descriptor-match", name, "",
+                                 f"unrecognized/generic arch fallback (family={d.get('family')!r}, cf #154)"))
+    return out
+```
+
+Then extend the registry:
+
+```python
+INVARIANTS = [inv_completeness, inv_no_crash, inv_descriptor_match]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lql_matrix/conformance.py scripts/lql_matrix/conformance_test.py
+git commit -m "feat(conformance): descriptor self-match — quant mismatch + generic-arch fallback"
+```
+
+---
+
+### Task 5: Cross-check invariant (SHOW LAYERS count == STATS count)
+
+**Files:**
+- Modify: `scripts/lql_matrix/conformance.py`
+- Test: `scripts/lql_matrix/conformance_test.py`
+
+**Interfaces:**
+- Produces: `show_layers_total(leg:Leg)->int|None` (sums the per-layer feature column from the `show.layers` cell stdout); `inv_cross_check(dict[str,Leg])->list[Violation]`. Violation when `show_layers_total == 0` while `feature_count > 0` (the mmap SHOW LAYERS bug S1). Appends to `INVARIANTS`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to conformance_test.py
+SHOW_LAYERS_HOLLOW = ("Layer      Features  With Meta       Top Token\n"
+                      "------------------------------------------------\n"
+                      "L0                0          0\n"
+                      "L1                0          0\n")
+SHOW_LAYERS_OK = ("Layer      Features  With Meta       Top Token\n"
+                  "------------------------------------------------\n"
+                  "L0             2560          0\n"
+                  "L1             2560          0\n")
+
+
+def test_cross_check_flags_show_layers_zero_vs_stats_nonzero():
+    bad = make_leg("bad", cells={
+        "stats": _cell("stats", "(24 layers, 5K features, m)"),
+        "show.layers": _cell("show.layers", SHOW_LAYERS_HOLLOW)})
+    good = make_leg("good", cells={
+        "stats": _cell("stats", "(24 layers, 5K features, m)"),
+        "show.layers": _cell("show.layers", SHOW_LAYERS_OK)})
+    vs = C.inv_cross_check({"bad": bad, "good": good})
+    assert [v.leg for v in vs] == ["bad"]
+    assert vs[0].invariant == "cross-check"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -k cross_check -v`
+Expected: FAIL — `AttributeError: ... 'show_layers_total'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to conformance.py
+_LAYER_ROW = re.compile(r"^L\d+\s+(\d+)\s+\d+", re.M)
+
+
+def show_layers_total(leg):
+    row = leg.cells.get("show.layers")
+    if not row:
+        return None
+    counts = _LAYER_ROW.findall(row.get("stdout_head", "") or "")
+    return sum(int(c) for c in counts) if counts else None
+
+
+def inv_cross_check(legs):
+    out = []
+    for name, lg in legs.items():
+        sl = show_layers_total(lg)
+        fc = feature_count(lg)
+        if sl is not None and fc and sl == 0:
+            out.append(Violation("cross-check", name, "show.layers",
+                                 f"SHOW LAYERS reports 0 features but STATS reports {fc} "
+                                 "(mmap heap-only accessor, cf SHOW LAYERS bug)"))
+    return out
+```
+
+Then extend the registry:
+
+```python
+INVARIANTS = [inv_completeness, inv_no_crash, inv_descriptor_match, inv_cross_check]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lql_matrix/conformance.py scripts/lql_matrix/conformance_test.py
+git commit -m "feat(conformance): cross-check — SHOW LAYERS count must equal STATS count"
+```
+
+---
+
+### Task 6: Diagnostic invariant (flag-honored + message-attribution)
+
+**Files:**
+- Modify: `scripts/lql_matrix/conformance.py`
+- Test: `scripts/lql_matrix/conformance_test.py`
+
+**Interfaces:**
+- Produces: `inv_diagnostic(dict[str,Leg])->list[Violation]` with two checks: (R-2 flag-honored) a `q4k` extract leg with `level in {browse,attention,inference}` whose `produce` output contains no warn/override/ignore text → the `--level` was silently overridden (S2); (R-3 message-attribution) any cell whose `err_line` names `--compact` while the recipe `flags` do not contain `compact` → misattribution (B2). Appends to `INVARIANTS`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to conformance_test.py
+def test_diagnostic_flag_honored_and_message_attribution():
+    silent_override = make_leg("q4kbrowse",
+        produce={"op": "extract", "level": "browse", "flags": "--quant q4k",
+                 "stdout_head": "Extracting…", "stderr_head": ""})
+    honored = make_leg("q4kall",
+        produce={"op": "extract", "level": "all", "flags": "--quant q4k",
+                 "stdout_head": "Extracting…", "stderr_head": ""})
+    misattrib = make_leg("mis", produce={"op": "extract", "level": "all", "flags": ""},
+        cells={"infer.top5": _cell("infer.top5", bucket="err", exit_code=101,
+               err_line="panicked: FFN weight tensor missing — this is a `--compact` vindex")})
+    vs = C.inv_diagnostic({"q4kbrowse": silent_override, "q4kall": honored, "mis": misattrib})
+    invs = sorted((v.leg, v.invariant) for v in vs)
+    assert ("mis", "diagnostic") in invs
+    assert ("q4kbrowse", "diagnostic") in invs
+    assert not any(v.leg == "q4kall" for v in vs)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -k diagnostic -v`
+Expected: FAIL — `AttributeError: ... 'inv_diagnostic'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to conformance.py
+_WARN = re.compile(r"warn|overrid|ignor", re.I)
+
+
+def inv_diagnostic(legs):
+    out = []
+    for name, lg in legs.items():
+        p = lg.produce
+        # R-2: --quant q4k silently overrides a non-all --level
+        if (p.get("op") == "extract" and "--quant q4k" in (p.get("flags") or "")
+                and p.get("level") in {"browse", "attention", "inference"}):
+            txt = (p.get("stdout_head", "") or "") + (p.get("stderr_head", "") or "")
+            if not _WARN.search(txt):
+                out.append(Violation("diagnostic", name, "produce",
+                                     f"--level {p.get('level')} silently ignored under --quant q4k "
+                                     "(no warn/override text; cf #208)"))
+        # R-3: error text blames --compact but the recipe never passed it
+        flags = (p.get("flags") or "")
+        if "compact" not in flags:
+            for cid, row in lg.cells.items():
+                if "--compact" in (row.get("err_line", "") or ""):
+                    out.append(Violation("diagnostic", name, cid,
+                                         "error text misattributes to `--compact` (not in recipe flags)"))
+                    break
+    return out
+```
+
+Then extend the registry:
+
+```python
+INVARIANTS = [inv_completeness, inv_no_crash, inv_descriptor_match, inv_cross_check, inv_diagnostic]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lql_matrix/conformance.py scripts/lql_matrix/conformance_test.py
+git commit -m "feat(conformance): diagnostic invariant — silent --level override + --compact misattribution"
+```
+
+---
+
+### Task 7: Transformation & Consumability coverage report + strict gate wiring
+
+**Files:**
+- Modify: `scripts/lql_matrix/conformance.py`
+- Test: `scripts/lql_matrix/conformance_test.py`
+
+**Interfaces:**
+- Produces: `transformation_report(dict[str,Leg])->list[str]` (markdown lines): a `source → produced` table (`op`/source-format → produced `family`/`quant`) and a declared-consumer reachability line that SURFACES gaps — larql-cli/larql-server reach any produced vindex; Ollama needs GGUF and there is **no compiled→GGUF export** (gap); cross-arch (produced family always == source) → no arch transform (gap). `render()` appends this section. This is descriptive (not a gating violation — no oracle for "should this transform exist"), per the gap-surfacing intent.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to conformance_test.py
+def test_transformation_report_surfaces_gaps():
+    legs = {
+        "qwen.q4k": make_leg("qwen.q4k",
+            produce={"op": "extract", "flags": "--quant q4k"},
+            descriptor={"family": "qwen2", "observed_quant": "q4k"}),
+        "bitnet.gguf": make_leg("bitnet.gguf",
+            produce={"op": "gguf-to-vindex", "flags": ""},
+            descriptor={"family": "bitnet", "observed_quant": "none"}),
+    }
+    md = "\n".join(C.transformation_report(legs))
+    assert "Transformation" in md
+    assert "qwen2" in md and "bitnet" in md
+    # gaps surfaced verbatim
+    assert "Ollama" in md and "GGUF" in md
+    assert "no compiled" in md.lower() or "gap" in md.lower()
+
+
+def test_run_strict_fails_on_violation(tmp_path, monkeypatch):
+    monkeypatch.setattr(C, "INVARIANTS", [lambda legs: [C.Violation("x", "lg", "", "boom")]])
+    monkeypatch.setattr(C, "load", lambda g: {"lg": make_leg()})
+    assert C.run("x", str(tmp_path/"c.md"), str(tmp_path/"c.json"), strict=True) == 1
+    assert C.run("x", str(tmp_path/"c.md"), str(tmp_path/"c.json"), strict=False) == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -k "transformation or strict" -v`
+Expected: FAIL — `AttributeError: ... 'transformation_report'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to conformance.py
+_SRC_FMT = {"extract": "safetensors", "gguf-to-vindex": "gguf",
+            "quantize-q4k": "safetensors", "quantize-fp4": "safetensors"}
+
+
+def transformation_report(legs):
+    L = ["## Transformation & consumability coverage", "",
+         "| leg | source fmt | produced arch | produced quant |",
+         "|---|---|---|---|"]
+    for name in sorted(legs):
+        lg = legs[name]
+        src = _SRC_FMT.get(lg.produce.get("op"), "?")
+        L.append(f"| `{name}` | {src} | {lg.descriptor.get('family','?')} | "
+                 f"{lg.descriptor.get('observed_quant','?')} |")
+    L += ["",
+          "**Consumer reachability & gaps (static):**",
+          "- larql-cli / larql-server (`/v1/chat`): reach any produced vindex directly.",
+          "- **Ollama:** needs GGUF; larql `compile` emits safetensors and there is **no "
+          "compiled→GGUF export** — Ollama is a **gap** (cf #181/N11).",
+          "- **Cross-arch transform** (e.g. qwen↔bitnet): produced arch equals source arch in "
+          "every leg — larql changes quant/format, **not architecture** — a **gap** for the "
+          "'transform one arch into another' use case.", ""]
+    return L
+```
+
+Then extend `render()` to append the section — replace the existing `render` body's final `return` with:
+
+```python
+def render(legs, violations):
+    L = ["# LQL Matrix — Conformance", "",
+         f"Legs: {len(legs)} · Violations: {len(violations)}", ""]
+    if violations:
+        L += ["| invariant | leg | cell | detail |", "|---|---|---|---|"]
+        for v in violations:
+            L.append(f"| {v.invariant} | `{v.leg}` | {v.cell or '-'} | {v.detail} |")
+    else:
+        L.append("No invariant violations.")
+    L += [""] + transformation_report(legs)
+    return "\n".join(L) + "\n"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lql_matrix/conformance.py scripts/lql_matrix/conformance_test.py
+git commit -m "feat(conformance): transformation/consumability coverage report — surface Ollama/GGUF + cross-arch gaps"
+```
+
+---
+
+### Task 8: Wire the conformance CI job + strict input; run tests in smoke
+
+**Files:**
+- Modify: `.github/workflows/lql-strategy-matrix.yml`
+- Modify: `.github/workflows/lql-matrix-smoke.yml`
+
+**Interfaces:**
+- Consumes: `conformance.py` (`main()` CLI: `<results_glob> <out_md> <out_json> [--strict]`), `conformance_test.py`.
+
+- [ ] **Step 1: Add the `strict` input to the strategy-matrix `workflow_dispatch`**
+
+In `.github/workflows/lql-strategy-matrix.yml`, replace `workflow_dispatch: {}` with:
+
+```yaml
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: "Fail the run if any conformance invariant is violated"
+        type: boolean
+        default: false
+```
+
+- [ ] **Step 2: Add the peer `conformance` job**
+
+In `.github/workflows/lql-strategy-matrix.yml`, after the `aggregate` job, add:
+
+```yaml
+  conformance:
+    needs: matrix
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Run conformance oracle
+        run: |
+          STRICT=""
+          [ "${{ github.event.inputs.strict }}" = "true" ] && STRICT="--strict"
+          python3 scripts/lql_matrix/conformance.py \
+            "artifacts/results-*/results-*.jsonl" conformance.md conformance.json $STRICT
+          echo "=== conformance.md ==="; cat conformance.md
+          cat conformance.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload conformance report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance
+          retention-days: 1
+          path: |
+            conformance.md
+            conformance.json
+```
+
+- [ ] **Step 3: Run the oracle's unit tests in the smoke workflow**
+
+In `.github/workflows/lql-matrix-smoke.yml`, add this step before `Upload smoke artifacts`:
+
+```yaml
+      - name: Conformance oracle unit tests
+        run: |
+          python -m pip install --quiet pytest
+          python -m pytest scripts/lql_matrix/conformance_test.py -v
+```
+
+- [ ] **Step 4: Validate both workflows parse**
+
+Run:
+```bash
+python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/lql-strategy-matrix.yml','.github/workflows/lql-matrix-smoke.yml']]; print('both workflows valid')"
+cd scripts/lql_matrix && python3 -m pytest conformance_test.py -q
+```
+Expected: `both workflows valid` and pytest all-pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/lql-strategy-matrix.yml .github/workflows/lql-matrix-smoke.yml
+git commit -m "ci(conformance): peer conformance job + strict dispatch input; oracle unit tests in smoke"
+```
+
+---
+
+## Verification (end-to-end, before pushing)
+
+1. `cd scripts/lql_matrix && python3 -m pytest conformance_test.py -v` → all pass.
+2. Run the oracle against the **already-downloaded** expanded-run artifacts to confirm it catches the real findings:
+   ```bash
+   python3 scripts/lql_matrix/conformance.py \
+     "/tmp/claude-1000/.../ci-expanded/results-*/results-*.jsonl" /tmp/conf.md /tmp/conf.json
+   grep -E "granite.*hollow|attention.*panic|SHOW LAYERS|q4k.*silently|Ollama|cross-arch" /tmp/conf.md
+   ```
+   Expected: completeness violations for granite/bitnet legs, no-crash for `*.attention` + q4k-MoE legs, cross-check for the SHOW LAYERS case, diagnostic for q4k-browse + the `--compact` message, and the transformation report surfacing the Ollama/GGUF + cross-arch gaps.
+3. Push the smoke branch first (`lql-matrix-smoke`) → confirm the oracle unit tests pass on a runner, then the real branch.
+
+## v1 scope notes (deferred registry extensions — not silent drops)
+The invariant registry is deliberately extensible; two spec-listed checks are deferred past v1 and slot in as additional functions later:
+- **Cross-check structural equalities** — `q4k-inline ≡ q4k-posthoc` and `safetensors-to-vindex ≡ extract` (cross-leg descriptor equality). v1 ships only the internal-consistency cross-check (SHOW LAYERS == STATS, Task 5), which catches a real bug now; the cross-leg equalities are lower-value and need leg-pairing logic.
+- **Diagnostic R-1 (exit-0-with-error)** — larql `lql` exits 0 even on in-band errors (#206). This is pervasive (fires on every graceful refusal) so it is NOT a gating invariant in v1; surface it as a descriptive count in a later report iteration rather than alarm on every refusal. "Success-honesty" (exit 0 + hollow) is already covered by the Completeness invariant.
+
+## Phase 2 (follow-on, NOT this plan)
+Runtime T1 consumability: a job that boots `larql serve <produced-vindex>` and drives `/v1/chat` (+ tool-call schema, SSE), asserting *boots→serves→well-formed response* (probes #245/#253/#266/#268). Separate subsystem (server-in-CI, containment) — its own spec/plan. web-llm/T3 remains parked on Q5/Q7.

--- a/docs/superpowers/plans/2026-07-11-sigma-inventory.md
+++ b/docs/superpowers/plans/2026-07-11-sigma-inventory.md
@@ -1,0 +1,415 @@
+# σ-expansion Stage 1: Tensor-Presence Inventory (W₃ / Q8) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Append the *tensor-presence* column to the CI's observable algebra σ so the panic response becomes σ-measurable — i.e. observe, per `(model, level)`, which weight classes (attention vs FFN) the produced vindex actually contains, and prove `panic ⟺ (has_attn ∧ ¬has_ffn)`.
+
+**Architecture:** A stdlib-only `tensor_presence.py` turns a produced vindex's file listing into a presence vector `{has_attn, has_ffn, ffn_unwrap_risk, …}`. The produce step captures a `listing.json` per leg (cheap; the manifest dir is already uploaded). A peer `inventory` CI job joins the presence vectors with the conformance panic outcomes and asserts the biconditional `ffn_unwrap_risk ⟺ panic@infer`, resolving the M3(a) duplicate-row (granite@attention panics; bitnet@attention refuses).
+
+**Tech Stack:** Python 3.12 stdlib only; pytest 7.2.1; GitHub Actions YAML.
+
+## Global Constraints
+
+- `tensor_presence.py`: **Python 3.12 stdlib only** (`glob, json, re, sys, os, pathlib`). `pytest` is test-only.
+- **No larql code changes.** Harness/CI only; the inventory consumes already-produced artifacts.
+- Runs on **GitHub-hosted runners only** (isolated VMs) — no self-hosted, no local-device resource assumptions.
+- Always `encoding="utf-8"`; tolerant of missing/malformed artifacts (never crash the checker).
+- Vindex weight files (the presence witnesses): `attn_weights.bin` (attn), `up_weights.bin` + `down_weights.bin` (ffn), `gate_vectors.bin` (gate), `embeddings.bin`, `norms.bin`, `down_meta.bin`, `interleaved_kquant.bin` (q4k).
+- `has_ffn := (up_weights.bin present ∧ down_weights.bin present)`; `ffn_unwrap_risk := has_attn ∧ ¬has_ffn`.
+- Artifacts `retention-days: 1`.
+
+---
+
+## File Structure
+
+- Create: `scripts/lql_matrix/tensor_presence.py` — the presence witness (pure `presence()` + `listing_of()` + `main()` + `resolve_q8()`).
+- Create: `scripts/lql_matrix/tensor_presence_test.py` — pytest over synthetic listings.
+- Modify: `.github/workflows/lql-strategy-matrix.yml` — capture `listing.json` in the produce step + add a peer `inventory` job.
+
+`descriptor.py`/`conformance.py`/`gen_legs.py` are unchanged.
+
+---
+
+### Task 1: `presence()` + `listing_of()`
+
+**Files:**
+- Create: `scripts/lql_matrix/tensor_presence.py`
+- Test: `scripts/lql_matrix/tensor_presence_test.py`
+
+**Interfaces:**
+- Produces: `presence(listing: dict) -> dict` (keys: `n_files:int, classes:dict, has_attn:bool, has_ffn:bool, has_gate:bool, ffn_unwrap_risk:bool`); `listing_of(vindex_dir: str) -> dict` (`{filename: size_bytes}`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# scripts/lql_matrix/tensor_presence_test.py
+import json, os, sys
+sys.path.insert(0, os.path.dirname(__file__))
+import tensor_presence as T
+
+ATTN_ONLY = {"attn_weights.bin": 1000, "gate_vectors.bin": 500, "embeddings.bin": 200, "index.json": 10}
+FULL      = {"attn_weights.bin": 1000, "up_weights.bin": 800, "down_weights.bin": 800,
+             "gate_vectors.bin": 500, "embeddings.bin": 200}
+EMPTY     = {"index.json": 10, "gate_vectors.bin": 0}   # 0-byte gate = absent
+
+
+def test_presence_attention_only_flags_ffn_unwrap_risk():
+    p = T.presence(ATTN_ONLY)
+    assert p["has_attn"] is True and p["has_ffn"] is False
+    assert p["ffn_unwrap_risk"] is True
+
+def test_presence_full_has_ffn_no_risk():
+    p = T.presence(FULL)
+    assert p["has_attn"] and p["has_ffn"] and p["has_gate"]
+    assert p["ffn_unwrap_risk"] is False
+
+def test_presence_empty_no_attn_no_risk():
+    p = T.presence(EMPTY)
+    assert p["has_attn"] is False and p["ffn_unwrap_risk"] is False
+
+def test_presence_tolerates_none_and_nonint():
+    assert T.presence(None)["n_files"] == 0
+    assert T.presence({"attn_weights.bin": "big"})["has_attn"] is False  # non-int size ignored
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest tensor_presence_test.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tensor_presence'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# scripts/lql_matrix/tensor_presence.py
+"""Tensor-presence witness for the σ-expansion (closes Q8). A produced vindex's
+weight-file listing → a presence vector over weight classes. The presence of
+attention vs FFN weight files at a level is the latent variable explaining why
+some partial/hollow vindexes panic on INFER (guard passes, FFN absent) while
+others refuse gracefully (no attention weights → guard refuses)."""
+import glob
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# vindex weight file → the class it witnesses
+_CLASS = {
+    "attn_weights.bin": "attn",
+    "up_weights.bin": "ffn_up",
+    "down_weights.bin": "ffn_down",
+    "gate_vectors.bin": "gate",
+    "embeddings.bin": "embed",
+    "norms.bin": "norm",
+    "down_meta.bin": "down_meta",
+    "interleaved_kquant.bin": "kquant",
+    "lm_head.bin": "lm_head",
+}
+
+
+def presence(listing):
+    cls = {}
+    for fn, sz in (listing or {}).items():
+        c = _CLASS.get(fn)
+        if c and isinstance(sz, int) and sz > 0:
+            cls[c] = sz
+    has_attn = "attn" in cls
+    has_ffn = ("ffn_up" in cls) and ("ffn_down" in cls)
+    return {
+        "n_files": len(listing or {}),
+        "classes": cls,
+        "has_attn": has_attn,
+        "has_ffn": has_ffn,
+        "has_gate": "gate" in cls,
+        "ffn_unwrap_risk": has_attn and not has_ffn,
+    }
+
+
+def listing_of(vindex_dir):
+    try:
+        return {f: os.path.getsize(os.path.join(vindex_dir, f))
+                for f in os.listdir(vindex_dir)}
+    except OSError:
+        return {}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest tensor_presence_test.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lql_matrix/tensor_presence.py scripts/lql_matrix/tensor_presence_test.py
+git commit -m "feat(inventory): presence() witness — attention vs FFN weight-file presence"
+```
+
+---
+
+### Task 2: `load_listing()` + `main()`
+
+**Files:**
+- Modify: `scripts/lql_matrix/tensor_presence.py`
+- Test: `scripts/lql_matrix/tensor_presence_test.py`
+
+**Interfaces:**
+- Produces: `load_listing(path)->dict`; `collect(results_glob)->dict[str,dict]` (maps `leg → presence`, keyed off `manifest-<leg>/listing.json`); `main()` CLI: `<results_glob> <out_json>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tensor_presence_test.py
+def test_collect_maps_leg_to_presence(tmp_path):
+    d = tmp_path / "results-qwen05.native.attention" / "manifest-qwen05.native.attention"
+    d.mkdir(parents=True)
+    (d / "listing.json").write_text(json.dumps(ATTN_ONLY), encoding="utf-8")
+    d2 = tmp_path / "results-qwen05.native.all" / "manifest-qwen05.native.all"
+    d2.mkdir(parents=True)
+    (d2 / "listing.json").write_text(json.dumps(FULL), encoding="utf-8")
+    got = T.collect(str(tmp_path / "results-*/manifest-*/listing.json"))
+    assert got["qwen05.native.attention"]["ffn_unwrap_risk"] is True
+    assert got["qwen05.native.all"]["ffn_unwrap_risk"] is False
+
+def test_load_listing_tolerates_missing(tmp_path):
+    assert T.load_listing(str(tmp_path / "nope.json")) == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest tensor_presence_test.py -k "collect or load_listing" -v`
+Expected: FAIL — `AttributeError: module 'tensor_presence' has no attribute 'collect'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to tensor_presence.py
+def load_listing(path):
+    try:
+        d = json.loads(Path(path).read_text(encoding="utf-8"))
+        return d if isinstance(d, dict) else {}
+    except Exception:
+        return {}
+
+
+_LEG_RE = re.compile(r"manifest-(.+?)/listing\.json$")
+
+
+def collect(results_glob):
+    rows = {}
+    seen = set()
+    pats = sorted(glob.glob(results_glob)) + sorted(
+        glob.glob("**/" + results_glob, recursive=True))
+    for p in pats:
+        if p in seen:
+            continue
+        seen.add(p)
+        m = _LEG_RE.search(p)
+        if m:
+            rows[m.group(1)] = presence(load_listing(p))
+    return rows
+
+
+def main():
+    args = sys.argv[1:]
+    results_glob = args[0] if args else "artifacts/results-*/manifest-*/listing.json"
+    out_json = args[1] if len(args) > 1 else "presence.json"
+    rows = collect(results_glob)
+    Path(out_json).write_text(json.dumps(rows, indent=2), encoding="utf-8")
+    print(f"tensor-presence: {len(rows)} legs, "
+          f"{sum(1 for r in rows.values() if r['ffn_unwrap_risk'])} at ffn_unwrap_risk")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest tensor_presence_test.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lql_matrix/tensor_presence.py scripts/lql_matrix/tensor_presence_test.py
+git commit -m "feat(inventory): collect() + main — leg→presence over manifest listings"
+```
+
+---
+
+### Task 3: `resolve_q8()` — join presence with panic, assert the biconditional
+
+**Files:**
+- Modify: `scripts/lql_matrix/tensor_presence.py`
+- Test: `scripts/lql_matrix/tensor_presence_test.py`
+
+**Interfaces:**
+- Produces: `resolve_q8(presence: dict[str,dict], panic: dict[str,bool]) -> dict` returning `{rows: list, biconditional_holds: bool, counterexamples: list}` where `panic[leg]` is the observed `panic@infer` and the biconditional is `ffn_unwrap_risk(leg) ⟺ panic(leg)` over the shared legs.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tensor_presence_test.py
+def test_resolve_q8_biconditional_and_counterexample():
+    pres = {
+        "qwen05.native.attention":   T.presence(ATTN_ONLY),   # risk=True
+        "qwen05.native.all":         T.presence(FULL),        # risk=False
+        "bitnet2b.native.attention": T.presence(EMPTY),       # risk=False (no attn wt)
+    }
+    panic = {  # observed panic@infer (from conformance no-crash)
+        "qwen05.native.attention":   True,
+        "qwen05.native.all":         False,
+        "bitnet2b.native.attention": False,   # refuses gracefully — matches risk=False
+    }
+    r = T.resolve_q8(pres, panic)
+    assert r["biconditional_holds"] is True
+    assert r["counterexamples"] == []
+    # now inject a violation: risk=True but no panic
+    panic["qwen05.native.attention"] = False
+    r2 = T.resolve_q8(pres, panic)
+    assert r2["biconditional_holds"] is False
+    assert "qwen05.native.attention" in [c["leg"] for c in r2["counterexamples"]]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest tensor_presence_test.py -k resolve_q8 -v`
+Expected: FAIL — `AttributeError: ... 'resolve_q8'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to tensor_presence.py
+def resolve_q8(presence_by_leg, panic_by_leg):
+    rows, counter = [], []
+    for leg in sorted(set(presence_by_leg) & set(panic_by_leg)):
+        risk = bool(presence_by_leg[leg]["ffn_unwrap_risk"])
+        pan = bool(panic_by_leg[leg])
+        agree = (risk == pan)
+        rows.append({"leg": leg, "ffn_unwrap_risk": risk, "panic": pan, "agree": agree})
+        if not agree:
+            counter.append({"leg": leg, "ffn_unwrap_risk": risk, "panic": pan})
+    return {"rows": rows, "biconditional_holds": not counter, "counterexamples": counter}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/lql_matrix && python3 -m pytest tensor_presence_test.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lql_matrix/tensor_presence.py scripts/lql_matrix/tensor_presence_test.py
+git commit -m "feat(inventory): resolve_q8 — assert ffn_unwrap_risk <=> panic@infer"
+```
+
+---
+
+### Task 4: Capture `listing.json` in produce + add the `inventory` CI job
+
+**Files:**
+- Modify: `.github/workflows/lql-strategy-matrix.yml`
+
+**Interfaces:**
+- Consumes: `tensor_presence.py` (`main()` CLI; `collect`, `resolve_q8`), the matrix's uploaded `manifest-<leg>/` artifacts, and the `conformance` job's `conformance.json` (for the panic map).
+
+- [ ] **Step 1: Capture the vindex file listing in the produce step**
+
+In `.github/workflows/lql-strategy-matrix.yml`, in the "Produce vindex" step, immediately after the existing weight-family inventory block (the line `cp "$VINDEX/index.json" "$VINDEX/weight_manifest.json" "$MDIR/" 2>/dev/null || true`), add:
+
+```bash
+          # tensor-presence witness (Q8): filename -> size for every vindex file
+          python3 -c "import json,os,sys; d=sys.argv[1]; print(json.dumps({f: os.path.getsize(os.path.join(d,f)) for f in os.listdir(d)}) if os.path.isdir(d) else '{}')" \
+            "$VINDEX" > "$MDIR/listing.json" 2>/dev/null || echo '{}' > "$MDIR/listing.json"
+```
+
+(The `manifest-${NAME}/` directory is already in the "Upload leg results" `path:` list, so `listing.json` ships with it — no upload change needed.)
+
+- [ ] **Step 2: Add the peer `inventory` job**
+
+In `.github/workflows/lql-strategy-matrix.yml`, after the `conformance` job, add:
+
+```yaml
+  inventory:
+    needs: [matrix, conformance]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Tensor-presence + Q8 resolution
+        run: |
+          python3 scripts/lql_matrix/tensor_presence.py \
+            "artifacts/results-*/manifest-*/listing.json" presence.json
+          python3 - <<'PY'
+          import json, glob, sys
+          sys.path.insert(0, "scripts/lql_matrix")
+          import tensor_presence as T
+          pres = json.load(open("presence.json"))
+          # panic := any no-crash (SIGKILL/panic, ec=101) violation on the leg
+          cj = glob.glob("artifacts/conformance/conformance.json")
+          viol = json.load(open(cj[0]))["violations"] if cj else []
+          panicked = {v["leg"] for v in viol if v["invariant"] == "no-crash"}
+          # Q8 / M3(a) is the *native attention-level* asymmetry (granite panics, bitnet refuses).
+          # Scope the biconditional to native legs; q4k legs panic by the distinct K6 hollow mechanism.
+          native = {k: v for k, v in pres.items() if ".native." in k}
+          panic = {leg: (leg in panicked) for leg in native}
+          res = T.resolve_q8(native, panic)
+          json.dump(res, open("q8.json", "w"), indent=2)
+          L = ["# Q8 — panic ⟺ (has_attn ∧ ¬has_ffn)?", "",
+               f"biconditional holds: **{res['biconditional_holds']}** · counterexamples: {len(res['counterexamples'])}", "",
+               "| leg | ffn_unwrap_risk | panic | agree |", "|---|---|---|---|"]
+          for r in res["rows"]:
+              L.append(f"| `{r['leg']}` | {r['ffn_unwrap_risk']} | {r['panic']} | {'✅' if r['agree'] else '❌'} |")
+          open("q8.md","w").write("\n".join(L)+"\n")
+          print("\n".join(L))
+          PY
+          cat q8.md >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: inventory
+          retention-days: 1
+          path: |
+            presence.json
+            q8.json
+            q8.md
+```
+
+- [ ] **Step 3: Validate**
+
+Run:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lql-strategy-matrix.yml')); print('workflow valid')"
+cd scripts/lql_matrix && python3 -m pytest tensor_presence_test.py -q
+```
+Expected: `workflow valid` and pytest all-pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/lql-strategy-matrix.yml
+git commit -m "ci(inventory): capture vindex listing + peer inventory job resolving Q8"
+```
+
+---
+
+## Verification (end-to-end, before pushing)
+
+1. `cd scripts/lql_matrix && python3 -m pytest tensor_presence_test.py -v` → all pass.
+2. Local witness on a real vindex (if one exists on the box), no model load:
+   ```bash
+   python3 -c "import sys; sys.path.insert(0,'scripts/lql_matrix'); import tensor_presence as T; print(T.presence(T.listing_of('/home/metavacua/work/vindexes/smollm2-360m-canonical.vindex')))"
+   ```
+   Expected: a full vindex → `has_attn=True, has_ffn=True, ffn_unwrap_risk=False`.
+3. On the next full CI run, the `inventory` job's `q8.md` (scoped to native legs) should show `biconditional holds: True` — every attention-level dense leg `ffn_unwrap_risk=True ∧ panic=True`, and `bitnet2b.native.attention` `ffn_unwrap_risk=False ∧ panic=False` (the M3(a) duplicate-row broken by the `has_attn` column: bitnet@attention has no attention-weight file, so the guard refuses rather than unwrapping an absent FFN). A `❌` row is a real counterexample to investigate — and `presence.json` (all legs, including q4k) separately shows whether the q4k hollow panics share the `ffn_unwrap_risk` signature or need the distinct `hollow` column (K6).
+
+## Sibling plans (separate Δ columns, not this plan)
+- **W₅ binary-sweep (Q6)** — needs the candidate-refs input.
+- **W₆ encoding (Q7)** — needs a TQ1_0 gguf (`llama-quantize`).
+- **W₄ confound (Q9)** — uncertain constructibility of a `¬hollow ∧ FFN-absent` q4k vindex.
+- Deferred (σ_device, blocked on larql-cli/repl resource discipline): **Q5 Φ_local, N4 contention**.

--- a/docs/superpowers/specs/2026-07-10-lql-matrix-ci-conformance-layer-design.md
+++ b/docs/superpowers/specs/2026-07-10-lql-matrix-ci-conformance-layer-design.md
@@ -1,0 +1,140 @@
+# CI Conformance Layer for the LQL Strategy Matrix — Design
+
+Date: 2026-07-10 · Status: design (v1, extensible) · Scope: harness/CI only, no larql code.
+
+## Context & motivation
+
+The `lql-strategy-matrix` CI (`scripts/lql_matrix/`, `.github/workflows/lql-strategy-matrix.yml`)
+is a *discovery* experiment: for every `(source × produce-recipe × level)` leg it
+produces a vindex and runs the full LQL command corpus, recording raw mechanical
+outcomes. It has no oracle — a cell can be observed but never judged wrong.
+
+The expanded run (80 legs, 6 models) plus the tracker's V&V issue landscape show
+this is now the limiting factor. Empirically:
+
+- **Silent hollow extraction** — granite-3.0 MoE and BitNet extract to **0 features**
+  (exit 0, `has_model_weights=True`). Confirms/extends the `#183` umbrella
+  (arch-key-driven extraction silently drops unmapped tensors), `#147` (bitnet),
+  `#153` (MoE experts). Only qwen/llama-dense extract real vindexes.
+- **No fail-loud guardrail** — hollow/partial vindexes don't error; downstream ops
+  *panic* instead: attention-level → `sparse_compute.rs:85` (B1); q4k×MoE →
+  `weight.rs:335` (B2).
+- **Diagnostic reporting is itself unreliable** — `larql lql` exits 0 on in-band
+  errors (`#206` zero rejection power); a silent `--level` override on `--quant q4k`;
+  a panic message that blames `--compact` when the cause is q4k×MoE; `SHOW LAYERS`
+  reporting a plausible-but-wrong `0`. Failures and successes are not mechanically
+  trustworthy.
+
+The tracker already theorizes the larql-side fixes (`#183/#155/#201/#206/#216/#247`).
+This design does **not** implement those. It builds the **CI-side empirical oracle**
+that detects these failures automatically — the prerequisite the maintainer named:
+*"the first step is discovering what fails; sorting into regressions is only meaningful
+once we can detect failures at all."*
+
+## Goal
+
+Turn the matrix into a **conformance probe**: evaluate a catalog of principled,
+no-expected-output invariants over the already-captured per-leg/per-cell data, and
+report every violation in a mechanically-checkable form — without abandoning the
+discovery framing (violations warn by default; a `strict` mode gates).
+
+## Design decisions (settled)
+
+1. **Invariants only** — no declared per-`(arch×format×op)` baseline. A failure is a
+   failure; regression-vs-known sorting is deferred (extension point).
+2. **Strict opt-in** — default: record violations red in the report, run stays green.
+   A `strict` `workflow_dispatch` input flips violations to a non-zero run failure.
+   (Resolves `#247`.)
+3. **Separate consumer** — `aggregate.py` stays *descriptive*; a new `conformance.py`
+   is the *oracle/gate*. Single responsibility; the invariant catalog grows
+   independently of the report.
+
+## Invariant catalog (v1 — an extensible registry)
+
+Each invariant is a pure function over fields already in the artifacts
+(`results-*.jsonl` per-cell rows, `descriptor-*.json`, `produce-*.json`). Adding an
+invariant = adding a function to the registry; this catalog is explicitly a *first
+cut* sized for detection coverage, not completeness.
+
+| id | class | check | primary catches |
+|---|---|---|---|
+| C-1 | Completeness | produced vindex `feature_count > 0` (derived from the leg's `STATS` cell output; falls back to Completeness-violation if `STATS` itself failed) | hollow granite/bitnet (#183/#147/#153) |
+| N-1 | No-crash | no `exit 101` (Rust panic) or crash (134/137/139) in `produce` or any corpus cell. A graceful in-band refusal (exit 0 + err_signal) or clean non-zero error is allowed; a crash never is | B1, B2 |
+| D-1 | Descriptor self-match | produced `quant == expect_quant` | silent dequant |
+| D-2 | Descriptor self-match | `family` is a recognized arch, not a silent `GenericArch` fallback | #154 |
+| X-1 | Cross-check | `SHOW LAYERS` per-layer feature count == `STATS` feature count | S1 (mmap SHOW LAYERS) |
+| X-2 | Cross-check | `q4k`-inline descriptor == `q4k`-posthoc descriptor; `safetensors-to-vindex` == `extract` | format/recipe invariants |
+| R-1 | Diagnostic | error-text/exit coherence — a cell with `err_signal=1` that still exits 0 is "failed to error"; exit 0 with no error text but a hollow/degenerate result is "false success" | #206 (no rejection power) |
+| R-2 | Diagnostic | flag-honored — a requested flag not reflected in the produced descriptor, with no warning emitted, is "failed to warn" | S2 (silent `--level` override) |
+| R-3 | Diagnostic | message-attribution — error/panic text names a flag the recipe did not pass (e.g. `--compact`) → misattribution | B2 (misleading `--compact` message) |
+
+**Diagnostic-conformance scope note.** R-* check the *mechanics* of larql's error/
+success reporting (does it error when it should, warn when it should, attribute
+correctly, and not claim false success). They do **not** check semantic output
+correctness (is INFER's answer right?) — that requires an oracle and is out of scope.
+
+## Architecture & data flow
+
+```
+matrix legs (produce + corpus)  ──►  artifacts:
+   results-<leg>.jsonl (meta + per-cell rows: exit_code, bucket, err_signal,
+                        err_line, stdout/stderr head+tail, peak_rss_kb, duration)
+   descriptor-<leg>.json (family, dtype, quant, expect_quant, quant_match, hidden)
+   produce-<leg>.json    (produce exit/bucket/duration/rss/vindex_mb)
+        │
+        ├──►  aggregate.py  ──►  lql-matrix.md      (descriptive; unchanged)
+        └──►  conformance.py ──► conformance.md      (violations by class → job summary)
+                                 conformance.json    (machine-readable: [{id,class,leg,
+                                                       cell,detail,severity}])
+```
+
+`conformance.py`:
+- input: the same `artifacts/results-*/…` glob the aggregate job already downloads.
+- reads each leg's meta/cells/descriptor/produce; derives `feature_count` from the
+  `STATS` cell's `Features: N` line (no new capture step, no larql change).
+- runs the invariant registry over every leg/cell; collects violations.
+- writes `conformance.md` (grouped by class, with the offending leg/cell + the
+  captured evidence line) and `conformance.json`.
+- exit code: `0` always, unless `--strict` (set from the workflow input) **and**
+  violations exist → exit non-zero.
+- **Tolerant**: missing/partial artifacts never crash the checker — a leg with no
+  produced vindex yields a Completeness violation, a malformed line is skipped-and-counted.
+
+**Workflow change.** Add a peer `conformance` job (`needs: matrix`, `if: always()`,
+separate from `aggregate` so the descriptive report and its artifact upload are never
+affected by the gate's exit). It downloads the leg artifacts, runs `conformance.py`,
+appends `conformance.md` to `$GITHUB_STEP_SUMMARY`, uploads the reports (24h
+retention), and honors a `strict` `workflow_dispatch` input for its exit code.
+
+## Minimal capture additions
+
+None to the produce/corpus steps. `feature_count` comes from the `STATS` cell that
+already runs in every corpus. Requested recipe flags are already on the leg record.
+(Optional hardening later: have `descriptor.py` also record `feature_count` directly
+from the vindex so Completeness doesn't depend on `STATS` succeeding.)
+
+## Testing
+
+Extend the stub-driven `lql-matrix-smoke` workflow (no larql build, no model) with
+fixtures that exercise each invariant class and assert `conformance.py` classifies
+them: a hollow stub (0 features) → C-1; a panic stub (exit 101) → N-1; an
+exit-0-with-`Error:` stub → R-1; a `--level`-ignored stub → R-2. Smoke-first on a
+runner, per the established discipline, before wiring into the real matrix.
+
+## Out of scope / extension points (this is v1)
+
+- **Semantic output correctness** (oracle-requiring) — excluded.
+- **Regression-vs-known sorting** (a declared `(arch×format×op)` baseline) — deferred;
+  the invariant registry and `conformance.json` are shaped so a baseline can later
+  reclassify a known violation from red→amber without changing the checks.
+- **Growing the catalog** — the registry is the extension surface; new invariants
+  (e.g. RSS ceilings, timeout budgets, more cross-checks) slot in as functions.
+
+## Success criteria
+
+1. The expanded run's known failures are each caught by an invariant and appear in
+   `conformance.md`: granite/bitnet hollow (C-1), B1/B2 panics (N-1), SHOW LAYERS
+   (X-1), silent `--level` override (R-2), the `--compact` misattribution (R-3).
+2. Default run stays green; `strict` run fails with a non-zero exit listing violations.
+3. `conformance.py` never crashes on missing/partial artifacts.
+4. Adding a new invariant is a single-function change with a stub-smoke fixture.

--- a/scripts/lql_matrix/README.md
+++ b/scripts/lql_matrix/README.md
@@ -62,12 +62,24 @@ the captured files itself, utf-8, truncating by codepoint); `timeout
 
 | file | role |
 |---|---|
-| `commands.jsonl` | the command corpus (matrix columns); `{{VINDEX}}`/`{{MODEL}}`/`{{TMP}}` placeholders |
+| `commands.jsonl` | the command corpus (matrix rows); `{{VINDEX}}`/`{{MODEL}}`/`{{TMP}}` placeholders |
+| `gen_legs.py` | enumerates every CLI-invokable **leg** (`source × produce-recipe × level`) as JSON — the matrix columns |
+| `descriptor.py` | reads a produced vindex's `index.json` → `(family, dtype, quant, …)` vs the leg's expected quant |
 | `run_matrix.py` | the runner — orchestrates each cell, captures full streams + RSS + error-signal → JSONL |
-| `run_matrix.sh` | thin shim → `run_matrix.py` (stable `<level> <vindex> <corpus> <out>` API) |
-| `aggregate.py` | merges per-level JSONL → `lql-matrix.md` (provenance, command×level, tally, resource, failures detail) |
-| `../../.github/workflows/lql-strategy-matrix.yml` | the CI matrix (build once → extract per level → run → aggregate → 24h artifacts + job summary) |
+| `run_matrix.sh` | thin shim → `run_matrix.py` (stable `<leg> <vindex> <corpus> <out>` API) |
+| `aggregate.py` | merges per-leg JSONL → `lql-matrix.md` (descriptor conformance, per-leg tally, resource, failures detail) |
+| `../../.github/workflows/lql-strategy-matrix.yml` | the CI matrix (plan legs → build once → produce vindex per leg → run corpus → aggregate → 24h artifacts + job summary) |
 | `../../.github/workflows/lql-matrix-smoke.yml` | fast stub-driven smoke of the harness itself on a runner (no build/model) |
+
+## Legs (source × recipe × level)
+
+A **leg** is one produced vindex + the corpus run against it. `gen_legs.py` crosses
+each model with each produce recipe — `extract` at every level × quant-state
+(f16 / `--f32` / `--quant q4k`), `convert gguf-to-vindex` (dequant vs `--keep-quant`
+ternary), and post-hoc `convert quantize {q4k,fp4}`. **Every CLI-invokable combination
+is included** — nothing is pruned for predicted meaninglessness (e.g. `--quant q4k`
+is crossed with every level, to test the doc claim that it implies `--level all`).
+Predictions live as `expect_quant` oracles in the descriptor table, not as omissions.
 
 ## Run locally (tooling smoke-test only — NOT the full experiment)
 

--- a/scripts/lql_matrix/README.md
+++ b/scripts/lql_matrix/README.md
@@ -1,0 +1,71 @@
+# LQL Strategy Matrix — empirical extraction × command experiment
+
+**What this is:** a discovery experiment that extracts one real model at **every
+extraction level** (`browse`, `attention`, `inference`, `all`) and runs the
+**full LQL command corpus** against each level's vindex, recording the **raw
+mechanical outcome** of every cell.
+
+**What this is NOT:** a validation suite. It makes **no** claim about whether any
+command's output is *correct*. There are no semantic oracles, no expected
+values, no pass/fail-correctness. A command that breaks is **data to read**, not
+a bug to fix here. Imposing "expected" semantics is how a broken thing gets
+papered over or misreported — so we don't. We run it and record what actually
+happened.
+
+## Why it runs in CI, not on a dev box
+
+Extraction (especially `--level all`) and `COMPILE`/MEMIT are minutes and
+multi-GB per cell. The point is to see how the full matrix behaves under real
+load across levels and (later) models — so it runs on **GitHub-hosted runners**
+(ample RAM, ≤6 h budget, isolated), where a dev machine's constraints are
+irrelevant. See `.github/workflows/lql-strategy-matrix.yml`.
+
+## Axes
+
+- **Level** (matrix job axis): `browse ⊂ attention ⊂ inference ⊂ all`. Extracted
+  fresh per level — extraction itself is an observed cell.
+- **Command variant** (`commands.jsonl`): every LQL statement and its variants.
+  Each cell carries its **own dependency chain** (e.g. the `INSERT` cell opens a
+  patch; the round-trip cell does `INSERT → SAVE → COMPILE → USE → INFER`), so a
+  cell tests both the statement and the chain it needs.
+
+Start with one model (Qwen2.5-Coder-0.5B-Instruct). Add models by extending the
+workflow matrix later.
+
+## Recording (mechanical only)
+
+Per cell, `run_matrix.sh` records: exact command, `exit_code`, `duration_ms`,
+`stdout_bytes`/`stderr_bytes`, an 800-char head of each stream, and a coarse
+**mechanical** bucket:
+
+- `ok` — exit 0
+- `err<N>` — non-zero exit N
+- `timeout` — killed by the per-cell wall cap
+- `crash` — SIGKILL(OOM)/SIGSEGV/SIGABRT (137/139/134)
+
+Note (already observed locally): `larql lql` exits `0` even on an unknown
+statement, so `ok` ≠ "did something meaningful" — the signal is in the captured
+stderr text. That is itself a finding the matrix surfaces; we record it, we do
+not "correct" it.
+
+## Files
+
+| file | role |
+|---|---|
+| `commands.jsonl` | the command corpus (matrix columns); `{{VINDEX}}`/`{{MODEL}}`/`{{TMP}}` placeholders |
+| `run_matrix.sh` | runs a corpus against one vindex → raw JSONL outcomes |
+| `aggregate.py` | merges per-level JSONL → `lql-matrix.md` (level × command table + tallies) |
+| `../../.github/workflows/lql-strategy-matrix.yml` | the CI matrix (extract per level → run → aggregate → artifacts + job summary) |
+
+## Run locally (tooling smoke-test only — NOT the full experiment)
+
+```bash
+# Cheap browse cells against an existing vindex, contained on a dev box:
+LARQL_BIN=target/release/larql \
+WRAP="larql-probe safe --mem 2500 --" \
+scripts/lql_matrix/run_matrix.sh browse <some.vindex> \
+  scripts/lql_matrix/commands.jsonl out/results-browse.jsonl
+python3 scripts/lql_matrix/aggregate.py "out/results-*.jsonl" lql-matrix.md
+```
+
+On CI, `WRAP` is empty (the runner is already isolated) and larql runs directly.

--- a/scripts/lql_matrix/README.md
+++ b/scripts/lql_matrix/README.md
@@ -62,8 +62,9 @@ the captured files itself, utf-8, truncating by codepoint); `timeout
 
 | file | role |
 |---|---|
-| `commands.jsonl` | the command corpus (matrix rows); `{{VINDEX}}`/`{{MODEL}}`/`{{TMP}}` placeholders |
-| `gen_legs.py` | enumerates every CLI-invokable **leg** (`source × produce-recipe × level`) as JSON — the matrix columns |
+| `commands.jsonl` | the **vindex-level** corpus (runs per leg against its produced vindex); `{{VINDEX}}`/`{{TMP}}` placeholders |
+| `commands-model.jsonl` | the **model-level** corpus (`EXTRACT MODEL` / `USE MODEL`) — run once per model by the `model-lifecycle` job, not per leg |
+| `gen_legs.py` | enumerates the **legs** (native level grid + one-off transformation/encoding recipes) as JSON — the matrix columns |
 | `descriptor.py` | reads a produced vindex's `index.json` → `(family, dtype, quant, …)` vs the leg's expected quant |
 | `run_matrix.py` | the runner — orchestrates each cell, captures full streams + RSS + error-signal → JSONL |
 | `run_matrix.sh` | thin shim → `run_matrix.py` (stable `<leg> <vindex> <corpus> <out>` API) |
@@ -71,15 +72,26 @@ the captured files itself, utf-8, truncating by codepoint); `timeout
 | `../../.github/workflows/lql-strategy-matrix.yml` | the CI matrix (plan legs → build once → produce vindex per leg → run corpus → aggregate → 24h artifacts + job summary) |
 | `../../.github/workflows/lql-matrix-smoke.yml` | fast stub-driven smoke of the harness itself on a runner (no build/model) |
 
-## Legs (source × recipe × level)
+## Legs (decoupled axes)
 
-A **leg** is one produced vindex + the corpus run against it. `gen_legs.py` crosses
-each model with each produce recipe — `extract` at every level × quant-state
-(f16 / `--f32` / `--quant q4k`), `convert gguf-to-vindex` (dequant vs `--keep-quant`
-ternary), and post-hoc `convert quantize {q4k,fp4}`. **Every CLI-invokable combination
-is included** — nothing is pruned for predicted meaninglessness (e.g. `--quant q4k`
-is crossed with every level, to test the doc claim that it implies `--level all`).
-Predictions live as `expect_quant` oracles in the descriptor table, not as omissions.
+A **leg** is one produced vindex + the vindex-level corpus run against it.
+`gen_legs.py` keeps the axes separate rather than one uniform cross-product:
+
+- **Native extraction** — every model × every level `{browse, attention, inference,
+  all}` at native precision. This is the real "test each level independently".
+- **Transformations** — tested **once at `level=all`**, not multiplied by the level
+  grid: `--quant q4k` per model, `--f32`, post-hoc `quantize {q4k,fp4}`. A
+  transformation like q4k *implies* `--level all`, so crossing it with levels only
+  homogenises (that redundancy is now *asserted* via a single q4k-browse sentinel +
+  the conformance cross-check, not re-run — see tracker #275).
+- **Encoding / convert** — `gguf-to-vindex`, including BitNet native **I2_S ternary**
+  via `--keep-quant`. GGUF legs carry `tokenizer_repo`; the workflow stages the base
+  repo's `tokenizer.json` beside the `.gguf` (the `-gguf` repo ships none — #180/#277).
+
+Model-level commands (`EXTRACT MODEL` / `USE MODEL`) don't read a produced vindex, so
+they run **once per model** in the `model-lifecycle` job (`commands-model.jsonl`) —
+not replicated across every leg. Each produced vindex's actual `(family, dtype,
+quant, feature_count)` is recorded and checked by the conformance layer.
 
 ## Run locally (tooling smoke-test only — NOT the full experiment)
 

--- a/scripts/lql_matrix/README.md
+++ b/scripts/lql_matrix/README.md
@@ -34,28 +34,40 @@ workflow matrix later.
 
 ## Recording (mechanical only)
 
-Per cell, `run_matrix.sh` records: exact command, `exit_code`, `duration_ms`,
-`stdout_bytes`/`stderr_bytes`, an 800-char head of each stream, and a coarse
-**mechanical** bucket:
+The runner is `run_matrix.py` (invoked via the `run_matrix.sh` shim). It emits a
+`{"type":"meta",…}` **provenance** row per level (commit, `larql --version`,
+model, runner OS, `RUST_BACKTRACE`, timestamp), then one row per cell with:
+exact substituted command, `exit_code`, coarse **mechanical** bucket,
+`duration_ms`, `peak_rss_kb` (via `/usr/bin/time -v`), `stdout_bytes`/
+`stderr_bytes`, an 800-char head of each stream **and** an 800-char `stderr_tail`
+(panics/backtraces live at the tail), plus an **error-text overlay**
+(`err_signal`/`err_line`). The **full** stdout/stderr of every cell are written
+to `<out_dir>/cells/<level>.<id>.{out,err}` and kept as artifacts — nothing is
+captured then discarded.
 
-- `ok` — exit 0
-- `err<N>` — non-zero exit N
-- `timeout` — killed by the per-cell wall cap
-- `crash` — SIGKILL(OOM)/SIGSEGV/SIGABRT (137/139/134)
+Buckets: `ok` (exit 0) · `err<N>` (non-zero N) · `timeout` (per-cell cap) ·
+`crash` (SIGKILL-OOM/SIGSEGV/SIGABRT = 137/139/134).
 
-Note (already observed locally): `larql lql` exits `0` even on an unknown
-statement, so `ok` ≠ "did something meaningful" — the signal is in the captured
-stderr text. That is itself a finding the matrix surfaces; we record it, we do
+`larql lql` exits `0` even on an in-band error, so `ok` ≠ "did something
+meaningful". `err_signal=1` marks a cell whose stdout/stderr carried an
+`Error:`/`panicked`/`Parse error` **despite** exit 0 (a masked error or graceful
+refusal); `aggregate.py` renders it as ⚠️ vs a clean ✅. We surface this, we do
 not "correct" it.
+
+I/O practices: stream content never transits the shell argv (the driver reads
+the captured files itself, utf-8, truncating by codepoint); `timeout
+--kill-after` bounds hung cells; artifacts are retained **24h** then auto-expire.
 
 ## Files
 
 | file | role |
 |---|---|
 | `commands.jsonl` | the command corpus (matrix columns); `{{VINDEX}}`/`{{MODEL}}`/`{{TMP}}` placeholders |
-| `run_matrix.sh` | runs a corpus against one vindex → raw JSONL outcomes |
-| `aggregate.py` | merges per-level JSONL → `lql-matrix.md` (level × command table + tallies) |
-| `../../.github/workflows/lql-strategy-matrix.yml` | the CI matrix (extract per level → run → aggregate → artifacts + job summary) |
+| `run_matrix.py` | the runner — orchestrates each cell, captures full streams + RSS + error-signal → JSONL |
+| `run_matrix.sh` | thin shim → `run_matrix.py` (stable `<level> <vindex> <corpus> <out>` API) |
+| `aggregate.py` | merges per-level JSONL → `lql-matrix.md` (provenance, command×level, tally, resource, failures detail) |
+| `../../.github/workflows/lql-strategy-matrix.yml` | the CI matrix (build once → extract per level → run → aggregate → 24h artifacts + job summary) |
+| `../../.github/workflows/lql-matrix-smoke.yml` | fast stub-driven smoke of the harness itself on a runner (no build/model) |
 
 ## Run locally (tooling smoke-test only — NOT the full experiment)
 

--- a/scripts/lql_matrix/aggregate.py
+++ b/scripts/lql_matrix/aggregate.py
@@ -1,95 +1,198 @@
 #!/usr/bin/env python3
-"""Aggregate per-level LQL matrix results into one table. Descriptive only —
-reports the raw mechanical outcome (bucket + exit code) per (command, level).
-No pass/fail-correctness judgement is made or implied."""
+"""Aggregate per-level LQL matrix results into one Markdown report. Descriptive
+only — reports the raw mechanical outcome (bucket + exit code) per (command,
+level), plus an error-text overlay, resource stats, and a failures/refusals
+detail block. No pass/fail-correctness judgement is made or implied.
+
+Reads JSONL produced by run_matrix.py: one `{"type":"meta",…}` provenance row
+per level followed by one row per cell. Tolerant of malformed lines (skips
+them, loudly) and pins utf-8 so non-ASCII model output never breaks decoding.
+"""
+import glob
 import json
 import sys
-import glob
 from pathlib import Path
 
 LEVEL_ORDER = ["browse", "attention", "inference", "all"]
 
 
-def main(results_glob: str, out_md: str) -> None:
-    rows = {}       # id -> {level -> (bucket, exit_code, duration_ms)}
-    cats = {}       # id -> category
-    order = []      # preserve first-seen command order
-    extract = {}    # level -> extraction outcome dict (from extract-<level>.json if present)
-
+def load(results_glob):
+    rows, cats, order, meta = {}, {}, [], {}
+    bad = 0
     for path in sorted(glob.glob(results_glob)):
-        for line in Path(path).read_text().splitlines():
-            if not line.strip():
+        for line in Path(path).read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
                 continue
-            r = json.loads(line)
-            cid, lvl = r["id"], r["level"]
+            try:
+                r = json.loads(line)
+            except json.JSONDecodeError:
+                bad += 1
+                continue
+            if r.get("type") == "meta":
+                meta[r.get("level", "?")] = r
+                continue
+            try:
+                cid, lvl = r["id"], r["level"]
+            except KeyError:
+                bad += 1
+                continue
             if cid not in rows:
-                rows[cid] = {}
-                cats[cid] = r.get("cat", "")
+                rows[cid], cats[cid] = {}, r.get("cat", "")
                 order.append(cid)
-            rows[cid][lvl] = (r.get("bucket", "?"), r.get("exit_code", "?"),
-                              r.get("duration_ms", "?"))
+            rows[cid][lvl] = r
+    return rows, cats, order, meta, bad
 
-    for ep in glob.glob("**/extract-*.json", recursive=True):
+
+def mark(r):
+    """One-glance cell mark. ⚠️ = exited 0 but printed an error/refusal."""
+    if r is None:
+        return "·"
+    b, ec, es = r.get("bucket"), r.get("exit_code", "?"), r.get("err_signal", 0)
+    if b == "ok":
+        return "⚠️" if es else "✅"
+    if b == "err":
+        return f"❌{ec}"
+    if b == "crash":
+        return f"💥{ec}"
+    if b == "timeout":
+        return "⏱"
+    return str(b)
+
+
+def load_extract():
+    """Best-effort scan for extract-<level>.json (written by the workflow)."""
+    ex = {}
+    for p in glob.glob("extract-*.json") + glob.glob("**/extract-*.json", recursive=True):
         try:
-            d = json.loads(Path(ep).read_text())
-            extract[d["level"]] = d
+            d = json.loads(Path(p).read_text(encoding="utf-8"))
+            ex[d["level"]] = d
         except Exception:
             pass
+    return ex
 
-    levels = [lvl for lvl in LEVEL_ORDER
-              if any(lvl in rows[c] for c in rows)] or LEVEL_ORDER
 
-    def cell(bucket_ec):
-        if bucket_ec is None:
-            return "·"
-        bucket, ec, _ = bucket_ec
-        mark = {"ok": "ok", "err": f"err{ec}", "timeout": "TIMEOUT",
-                "crash": f"CRASH{ec}"}.get(bucket, str(bucket))
-        return mark
+def main(results_glob, out_md):
+    rows, cats, order, meta, bad = load(results_glob)
+    extract = load_extract()
+    present = [l for l in LEVEL_ORDER if any(l in rows[c] for c in rows)] or LEVEL_ORDER
+    expected = max((len(rows[c]) for c in rows), default=0)  # cells in the fullest leg
+    counts = {l: sum(1 for c in rows if l in rows[c]) for l in present}
 
-    lines = ["# LQL Strategy Matrix — raw outcomes",
-             "",
-             "Empirical: each cell is the **mechanical** result of running the "
-             "command against a vindex extracted at that level. `ok`=exit 0, "
-             "`errN`=non-zero exit N, `TIMEOUT`=killed by per-cell cap, "
-             "`CRASH`=SIGKILL/OOM/SIGSEGV/SIGABRT, `·`=not run. **No claim is "
-             "made about whether output is correct** — only what happened.",
-             ""]
+    L = ["# LQL Strategy Matrix — raw outcomes", "",
+         "Each cell is the **mechanical** result of running the command against a "
+         "vindex extracted at that level. **No claim is made about output "
+         "correctness.** Legend: ✅ exit 0 clean · ⚠️ exit 0 **but** stdout/stderr "
+         "carried an error/refusal (`larql lql` exits 0 in-band) · ❌N non-zero "
+         "exit N · 💥N crash (OOM/SIGSEGV/SIGABRT) · ⏱ per-cell timeout · · not run.",
+         ""]
 
-    # extraction row
+    if bad:
+        L += [f"> ⚠️ {bad} malformed result line(s) skipped.", ""]
+
+    # incomplete-leg flag (B4): a leg with fewer cells than the fullest one
+    incomplete = [f"`{l}` ({counts[l]}/{expected})"
+                  for l in present if counts[l] < expected]
+    if incomplete:
+        L += ["> ⚠️ **Incomplete legs** (fewer cells than the fullest — runner "
+              "died / whole-leg timeout mid-corpus): " + ", ".join(incomplete), ""]
+
+    # provenance
+    if meta:
+        L += ["## Provenance", "",
+              "| level | commit | larql | model | runner | started (UTC) | backtrace |",
+              "|---|---|---|---|---|---|---|"]
+        for l in present:
+            m = meta.get(l, {})
+            L.append("| {} | `{}` | {} | {} | {} | {} | {} |".format(
+                l, (m.get("commit") or "?")[:10], m.get("larql_version") or "?",
+                m.get("model") or "?", m.get("runner_os") or "?",
+                (m.get("started_at") or "?")[:19], m.get("backtrace") or "unset"))
+        L.append("")
+
+    # extraction outcome (itself an observed cell)
     if extract:
-        lines += ["## Extraction outcome per level", ""]
-        lines.append("| level | " + " | ".join(levels) + " |")
-        lines.append("|---|" + "---|" * len(levels))
-        erow = []
-        for lvl in levels:
-            e = extract.get(lvl)
-            erow.append(f"{e.get('bucket','?')} ({e.get('duration_ms','?')}ms)"
-                        if e else "·")
-        lines.append("| **extract** | " + " | ".join(erow) + " |")
-        lines.append("")
+        L += ["## Extraction outcome per level", "",
+              "| metric | " + " | ".join(present) + " |",
+              "|---|" + "---|" * len(present)]
+        def erow(label, fn):
+            return "| **" + label + "** | " + " | ".join(
+                fn(extract.get(l)) for l in present) + " |"
+        L.append(erow("outcome", lambda e: f"{e.get('bucket','?')} ({e.get('duration_ms','?')}ms)" if e else "·"))
+        L.append(erow("peak RSS (MB)", lambda e: f"{(e.get('peak_rss_kb') or 0)/1024:.0f}" if e and e.get('peak_rss_kb') else ("n/a" if e else "·")))
+        L.append(erow("vindex (MB)", lambda e: str(e.get('vindex_mb', '?')) if e else "·"))
+        L.append("")
 
-    lines += ["## Command × level", "",
-              "| command | cat | " + " | ".join(levels) + " |",
-              "|---|---|" + "---|" * len(levels)]
+    # command × level
+    L += ["## Command × level", "",
+          "| command | cat | " + " | ".join(present) + " |",
+          "|---|---|" + "---|" * len(present)]
     for cid in order:
-        cells = " | ".join(cell(rows[cid].get(lvl)) for lvl in levels)
-        lines.append(f"| `{cid}` | {cats[cid]} | {cells} |")
+        cells = " | ".join(mark(rows[cid].get(l)) for l in present)
+        L.append(f"| `{cid}` | {cats[cid]} | {cells} |")
 
-    # bucket tally
-    lines += ["", "## Tally (per level)", "",
-              "| level | ok | err | timeout | crash |",
-              "|---|---|---|---|---|"]
-    for lvl in levels:
-        t = {"ok": 0, "err": 0, "timeout": 0, "crash": 0}
+    # tally (adds errtext = exit-0-but-error overlay)
+    L += ["", "## Tally (per level)", "",
+          "| level | ✅ ok | ⚠️ errtext | ❌ err | ⏱ timeout | 💥 crash |",
+          "|---|---|---|---|---|---|"]
+    for l in present:
+        t = {"ok": 0, "errtext": 0, "err": 0, "timeout": 0, "crash": 0}
         for cid in rows:
-            be = rows[cid].get(lvl)
-            if be:
-                t[be[0]] = t.get(be[0], 0) + 1
-        lines.append(f"| {lvl} | {t['ok']} | {t['err']} | {t['timeout']} | {t['crash']} |")
+            r = rows[cid].get(l)
+            if not r:
+                continue
+            b = r.get("bucket")
+            if b == "ok" and r.get("err_signal"):
+                t["errtext"] += 1
+            elif b == "ok":
+                t["ok"] += 1
+            else:
+                t[b] = t.get(b, 0) + 1
+        L.append(f"| {l} | {t['ok']} | {t['errtext']} | {t['err']} | "
+                 f"{t['timeout']} | {t['crash']} |")
 
-    Path(out_md).write_text("\n".join(lines) + "\n")
-    print(f"wrote {out_md} ({len(order)} commands x {len(levels)} levels)")
+    # resource stats (perf): peak RSS + slowest cell per level
+    L += ["", "## Resource (per level)", "",
+          "| level | peak RSS (MB) | slowest cell | slowest (ms) |",
+          "|---|---|---|---|"]
+    for l in present:
+        best_rss, slow_id, slow_ms = 0, "-", 0
+        for cid in rows:
+            r = rows[cid].get(l)
+            if not r:
+                continue
+            rss = r.get("peak_rss_kb") or 0
+            if isinstance(rss, int) and rss > best_rss:
+                best_rss = rss
+            d = r.get("duration_ms") or 0
+            if isinstance(d, int) and d > slow_ms:
+                slow_ms, slow_id = d, cid
+        rss_mb = f"{best_rss/1024:.0f}" if best_rss else "n/a"
+        L.append(f"| {l} | {rss_mb} | `{slow_id}` | {slow_ms} |")
+
+    # failures & refusals detail (C1): evidence inline, collapsed
+    fails = []
+    for cid in order:
+        for l in present:
+            r = rows[cid].get(l)
+            if r and (r.get("bucket") != "ok" or r.get("err_signal")):
+                fails.append((l, cid, mark(r), r.get("exit_code"),
+                              r.get("peak_rss_kb"), r.get("err_line", "")))
+    L += ["", f"## Failures & refusals ({len(fails)})", ""]
+    if fails:
+        L += ["<details><summary>level · cell · mark · exit · rss(kb) · first error line</summary>",
+              "", "| level | cell | mark | exit | rss | first error line |",
+              "|---|---|---|---|---|---|"]
+        for l, cid, mk, ec, rss, el in fails:
+            el = (el or "").replace("|", "\\|")
+            L.append(f"| {l} | `{cid}` | {mk} | {ec} | {rss} | `{el}` |")
+        L += ["", "</details>"]
+    else:
+        L.append("None — every cell exited 0 with no error/refusal text.")
+
+    Path(out_md).write_text("\n".join(L) + "\n", encoding="utf-8")
+    print(f"wrote {out_md} ({len(order)} commands x {len(present)} levels, "
+          f"{len(fails)} failures/refusals, {bad} bad lines)")
 
 
 if __name__ == "__main__":

--- a/scripts/lql_matrix/aggregate.py
+++ b/scripts/lql_matrix/aggregate.py
@@ -1,24 +1,20 @@
 #!/usr/bin/env python3
-"""Aggregate per-level LQL matrix results into one Markdown report. Descriptive
-only — reports the raw mechanical outcome (bucket + exit code) per (command,
-level), plus an error-text overlay, resource stats, and a failures/refusals
-detail block. No pass/fail-correctness judgement is made or implied.
+"""Aggregate per-leg LQL matrix results into one Markdown report. Descriptive
+only — no pass/fail-correctness judgement. A "leg" is one (source × recipe ×
+level) job; its meta row's `level` field carries the leg name.
 
-Reads JSONL produced by run_matrix.py: one `{"type":"meta",…}` provenance row
-per level followed by one row per cell. Tolerant of malformed lines (skips
-them, loudly) and pins utf-8 so non-ASCII model output never breaks decoding.
+Reads run_matrix JSONL (`{"type":"meta",...}` + per-cell rows), plus
+`descriptor-<leg>.json` and `produce-<leg>.json` (best-effort, from cwd). utf-8
++ tolerant of malformed lines.
 """
 import glob
 import json
 import sys
 from pathlib import Path
 
-LEVEL_ORDER = ["browse", "attention", "inference", "all"]
-
 
 def load(results_glob):
-    rows, cats, order, meta = {}, {}, [], {}
-    bad = 0
+    rows, cats, order, meta, bad = {}, {}, [], {}, 0
     for path in sorted(glob.glob(results_glob)):
         for line in Path(path).read_text(encoding="utf-8").splitlines():
             line = line.strip()
@@ -33,19 +29,30 @@ def load(results_glob):
                 meta[r.get("level", "?")] = r
                 continue
             try:
-                cid, lvl = r["id"], r["level"]
+                cid, leg = r["id"], r["level"]
             except KeyError:
                 bad += 1
                 continue
             if cid not in rows:
                 rows[cid], cats[cid] = {}, r.get("cat", "")
                 order.append(cid)
-            rows[cid][lvl] = r
+            rows[cid][leg] = r
     return rows, cats, order, meta, bad
 
 
+def load_json_glob(pattern, key):
+    out = {}
+    for p in glob.glob(pattern) + glob.glob("**/" + pattern, recursive=True):
+        try:
+            d = json.loads(Path(p).read_text(encoding="utf-8"))
+            if d.get(key):
+                out[d[key]] = d
+        except Exception:
+            pass
+    return out
+
+
 def mark(r):
-    """One-glance cell mark. ⚠️ = exited 0 but printed an error/refusal."""
     if r is None:
         return "·"
     b, ec, es = r.get("bucket"), r.get("exit_code", "?"), r.get("err_signal", 0)
@@ -60,85 +67,54 @@ def mark(r):
     return str(b)
 
 
-def load_extract():
-    """Best-effort scan for extract-<level>.json (written by the workflow)."""
-    ex = {}
-    for p in glob.glob("extract-*.json") + glob.glob("**/extract-*.json", recursive=True):
-        try:
-            d = json.loads(Path(p).read_text(encoding="utf-8"))
-            ex[d["level"]] = d
-        except Exception:
-            pass
-    return ex
+def first_err(r):
+    return (r.get("err_line") or "").replace("|", "\\|") if r else ""
 
 
 def main(results_glob, out_md):
     rows, cats, order, meta, bad = load(results_glob)
-    extract = load_extract()
-    present = [l for l in LEVEL_ORDER if any(l in rows[c] for c in rows)] or LEVEL_ORDER
-    expected = max((len(rows[c]) for c in rows), default=0)  # cells in the fullest leg
-    counts = {l: sum(1 for c in rows if l in rows[c]) for l in present}
+    desc = load_json_glob("descriptor-*.json", "name")
+    prod = load_json_glob("produce-*.json", "name")
+    legs = sorted(set(list(meta) + [l for c in rows for l in rows[c]]))
 
     L = ["# LQL Strategy Matrix — raw outcomes", "",
-         "Each cell is the **mechanical** result of running the command against a "
-         "vindex extracted at that level. **No claim is made about output "
-         "correctness.** Legend: ✅ exit 0 clean · ⚠️ exit 0 **but** stdout/stderr "
-         "carried an error/refusal (`larql lql` exits 0 in-band) · ❌N non-zero "
-         "exit N · 💥N crash (OOM/SIGSEGV/SIGABRT) · ⏱ per-cell timeout · · not run.",
-         ""]
+         "Each cell = the **mechanical** result of a command against a vindex "
+         "produced by that leg's recipe. **No output-correctness claim.** Legend: "
+         "✅ exit 0 clean · ⚠️ exit 0 **but** error/refusal text · ❌N non-zero N · "
+         "💥N crash (OOM/SIGSEGV/SIGABRT) · ⏱ timeout · · not run.", "",
+         f"Legs: **{len(legs)}** · commands/leg: **{len(order)}**"
+         + (f" · ⚠️ {bad} malformed line(s) skipped" if bad else ""), ""]
 
-    if bad:
-        L += [f"> ⚠️ {bad} malformed result line(s) skipped.", ""]
-
-    # incomplete-leg flag (B4): a leg with fewer cells than the fullest one
-    incomplete = [f"`{l}` ({counts[l]}/{expected})"
-                  for l in present if counts[l] < expected]
-    if incomplete:
-        L += ["> ⚠️ **Incomplete legs** (fewer cells than the fullest — runner "
-              "died / whole-leg timeout mid-corpus): " + ", ".join(incomplete), ""]
-
-    # provenance
-    if meta:
-        L += ["## Provenance", "",
-              "| level | commit | larql | model | runner | started (UTC) | backtrace |",
-              "|---|---|---|---|---|---|---|"]
-        for l in present:
-            m = meta.get(l, {})
-            L.append("| {} | `{}` | {} | {} | {} | {} | {} |".format(
-                l, (m.get("commit") or "?")[:10], m.get("larql_version") or "?",
-                m.get("model") or "?", m.get("runner_os") or "?",
-                (m.get("started_at") or "?")[:19], m.get("backtrace") or "unset"))
+    # Produced-vindex descriptor conformance — did the recipe yield what we expected?
+    if desc:
+        L += ["## Produced-vindex descriptor", "",
+              "Recorded from each produced `index.json`. `quant?` = observed quant "
+              "(ternary via `bitnet_layout`) vs the leg's expected quant.", "",
+              "| leg | produce | family | dtype | quant (obs/exp) | quant? | hidden | vindex MB |",
+              "|---|---|---|---|---|:--:|---|---|"]
+        for lg in legs:
+            d = desc.get(lg, {})
+            p = prod.get(lg, {})
+            pb = p.get("bucket", "?")
+            produced = "❌ " + pb if pb != "ok" else "ok"
+            if not d.get("produced", True) or d.get("error"):
+                L.append(f"| `{lg}` | {produced} | — | — | — | ❌ | — | {p.get('vindex_mb','?')} |")
+                continue
+            obs, exp = d.get("observed_quant"), d.get("expect_quant")
+            ok = "✅" if d.get("quant_match") else "❌"
+            L.append(f"| `{lg}` | {produced} | {d.get('family')} | {d.get('dtype')} | "
+                     f"{obs}/{exp} | {ok} | {d.get('hidden_size','?')} | {p.get('vindex_mb','?')} |")
         L.append("")
 
-    # extraction outcome (itself an observed cell)
-    if extract:
-        L += ["## Extraction outcome per level", "",
-              "| metric | " + " | ".join(present) + " |",
-              "|---|" + "---|" * len(present)]
-        def erow(label, fn):
-            return "| **" + label + "** | " + " | ".join(
-                fn(extract.get(l)) for l in present) + " |"
-        L.append(erow("outcome", lambda e: f"{e.get('bucket','?')} ({e.get('duration_ms','?')}ms)" if e else "·"))
-        L.append(erow("peak RSS (MB)", lambda e: f"{(e.get('peak_rss_kb') or 0)/1024:.0f}" if e and e.get('peak_rss_kb') else ("n/a" if e else "·")))
-        L.append(erow("vindex (MB)", lambda e: str(e.get('vindex_mb', '?')) if e else "·"))
-        L.append("")
-
-    # command × level
-    L += ["## Command × level", "",
-          "| command | cat | " + " | ".join(present) + " |",
-          "|---|---|" + "---|" * len(present)]
-    for cid in order:
-        cells = " | ".join(mark(rows[cid].get(l)) for l in present)
-        L.append(f"| `{cid}` | {cats[cid]} | {cells} |")
-
-    # tally (adds errtext = exit-0-but-error overlay)
-    L += ["", "## Tally (per level)", "",
-          "| level | ✅ ok | ⚠️ errtext | ❌ err | ⏱ timeout | 💥 crash |",
-          "|---|---|---|---|---|---|"]
-    for l in present:
+    # Per-leg tally (the primary view when legs are many)
+    L += ["## Tally (per leg)", "",
+          "| leg | ✅ ok | ⚠️ errtext | ❌ err | ⏱ timeout | 💥 crash | peak RSS MB |",
+          "|---|---|---|---|---|---|---|"]
+    for lg in legs:
         t = {"ok": 0, "errtext": 0, "err": 0, "timeout": 0, "crash": 0}
+        best_rss = 0
         for cid in rows:
-            r = rows[cid].get(l)
+            r = rows[cid].get(lg)
             if not r:
                 continue
             b = r.get("bucket")
@@ -148,50 +124,42 @@ def main(results_glob, out_md):
                 t["ok"] += 1
             else:
                 t[b] = t.get(b, 0) + 1
-        L.append(f"| {l} | {t['ok']} | {t['errtext']} | {t['err']} | "
-                 f"{t['timeout']} | {t['crash']} |")
-
-    # resource stats (perf): peak RSS + slowest cell per level
-    L += ["", "## Resource (per level)", "",
-          "| level | peak RSS (MB) | slowest cell | slowest (ms) |",
-          "|---|---|---|---|"]
-    for l in present:
-        best_rss, slow_id, slow_ms = 0, "-", 0
-        for cid in rows:
-            r = rows[cid].get(l)
-            if not r:
-                continue
             rss = r.get("peak_rss_kb") or 0
             if isinstance(rss, int) and rss > best_rss:
                 best_rss = rss
-            d = r.get("duration_ms") or 0
-            if isinstance(d, int) and d > slow_ms:
-                slow_ms, slow_id = d, cid
         rss_mb = f"{best_rss/1024:.0f}" if best_rss else "n/a"
-        L.append(f"| {l} | {rss_mb} | `{slow_id}` | {slow_ms} |")
+        L.append(f"| `{lg}` | {t['ok']} | {t['errtext']} | {t['err']} | "
+                 f"{t['timeout']} | {t['crash']} | {rss_mb} |")
 
-    # failures & refusals detail (C1): evidence inline, collapsed
-    fails = []
-    for cid in order:
-        for l in present:
-            r = rows[cid].get(l)
-            if r and (r.get("bucket") != "ok" or r.get("err_signal")):
-                fails.append((l, cid, mark(r), r.get("exit_code"),
-                              r.get("peak_rss_kb"), r.get("err_line", "")))
+    # Command × leg pivot — only when narrow enough to read; else it's in artifacts.
+    if len(legs) <= 8:
+        L += ["", "## Command × leg", "",
+              "| command | cat | " + " | ".join(legs) + " |",
+              "|---|---|" + "---|" * len(legs)]
+        for cid in order:
+            L.append(f"| `{cid}` | {cats[cid]} | "
+                     + " | ".join(mark(rows[cid].get(lg)) for lg in legs) + " |")
+    else:
+        L += ["", f"> Command × leg pivot omitted ({len(legs)} legs too wide); "
+              "per-cell detail is in the `results-*` artifacts.", ""]
+
+    # Failures & refusals detail — evidence inline, collapsed
+    fails = [(lg, cid, mark(r), r.get("exit_code"), r.get("peak_rss_kb"), first_err(r))
+             for cid in order for lg in legs
+             if (r := rows[cid].get(lg)) and (r.get("bucket") != "ok" or r.get("err_signal"))]
     L += ["", f"## Failures & refusals ({len(fails)})", ""]
     if fails:
-        L += ["<details><summary>level · cell · mark · exit · rss(kb) · first error line</summary>",
-              "", "| level | cell | mark | exit | rss | first error line |",
+        L += ["<details><summary>leg · cell · mark · exit · rss(kb) · first error line</summary>",
+              "", "| leg | cell | mark | exit | rss | first error line |",
               "|---|---|---|---|---|---|"]
-        for l, cid, mk, ec, rss, el in fails:
-            el = (el or "").replace("|", "\\|")
-            L.append(f"| {l} | `{cid}` | {mk} | {ec} | {rss} | `{el}` |")
+        L += [f"| `{lg}` | `{cid}` | {mk} | {ec} | {rss} | `{el}` |"
+              for lg, cid, mk, ec, rss, el in fails]
         L += ["", "</details>"]
     else:
         L.append("None — every cell exited 0 with no error/refusal text.")
 
     Path(out_md).write_text("\n".join(L) + "\n", encoding="utf-8")
-    print(f"wrote {out_md} ({len(order)} commands x {len(present)} levels, "
+    print(f"wrote {out_md} ({len(legs)} legs × {len(order)} commands, "
           f"{len(fails)} failures/refusals, {bad} bad lines)")
 
 

--- a/scripts/lql_matrix/aggregate.py
+++ b/scripts/lql_matrix/aggregate.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Aggregate per-level LQL matrix results into one table. Descriptive only —
+reports the raw mechanical outcome (bucket + exit code) per (command, level).
+No pass/fail-correctness judgement is made or implied."""
+import json
+import sys
+import glob
+from pathlib import Path
+
+LEVEL_ORDER = ["browse", "attention", "inference", "all"]
+
+
+def main(results_glob: str, out_md: str) -> None:
+    rows = {}       # id -> {level -> (bucket, exit_code, duration_ms)}
+    cats = {}       # id -> category
+    order = []      # preserve first-seen command order
+    extract = {}    # level -> extraction outcome dict (from extract-<level>.json if present)
+
+    for path in sorted(glob.glob(results_glob)):
+        for line in Path(path).read_text().splitlines():
+            if not line.strip():
+                continue
+            r = json.loads(line)
+            cid, lvl = r["id"], r["level"]
+            if cid not in rows:
+                rows[cid] = {}
+                cats[cid] = r.get("cat", "")
+                order.append(cid)
+            rows[cid][lvl] = (r.get("bucket", "?"), r.get("exit_code", "?"),
+                              r.get("duration_ms", "?"))
+
+    for ep in glob.glob("**/extract-*.json", recursive=True):
+        try:
+            d = json.loads(Path(ep).read_text())
+            extract[d["level"]] = d
+        except Exception:
+            pass
+
+    levels = [lvl for lvl in LEVEL_ORDER
+              if any(lvl in rows[c] for c in rows)] or LEVEL_ORDER
+
+    def cell(bucket_ec):
+        if bucket_ec is None:
+            return "·"
+        bucket, ec, _ = bucket_ec
+        mark = {"ok": "ok", "err": f"err{ec}", "timeout": "TIMEOUT",
+                "crash": f"CRASH{ec}"}.get(bucket, str(bucket))
+        return mark
+
+    lines = ["# LQL Strategy Matrix — raw outcomes",
+             "",
+             "Empirical: each cell is the **mechanical** result of running the "
+             "command against a vindex extracted at that level. `ok`=exit 0, "
+             "`errN`=non-zero exit N, `TIMEOUT`=killed by per-cell cap, "
+             "`CRASH`=SIGKILL/OOM/SIGSEGV/SIGABRT, `·`=not run. **No claim is "
+             "made about whether output is correct** — only what happened.",
+             ""]
+
+    # extraction row
+    if extract:
+        lines += ["## Extraction outcome per level", ""]
+        lines.append("| level | " + " | ".join(levels) + " |")
+        lines.append("|---|" + "---|" * len(levels))
+        erow = []
+        for lvl in levels:
+            e = extract.get(lvl)
+            erow.append(f"{e.get('bucket','?')} ({e.get('duration_ms','?')}ms)"
+                        if e else "·")
+        lines.append("| **extract** | " + " | ".join(erow) + " |")
+        lines.append("")
+
+    lines += ["## Command × level", "",
+              "| command | cat | " + " | ".join(levels) + " |",
+              "|---|---|" + "---|" * len(levels)]
+    for cid in order:
+        cells = " | ".join(cell(rows[cid].get(lvl)) for lvl in levels)
+        lines.append(f"| `{cid}` | {cats[cid]} | {cells} |")
+
+    # bucket tally
+    lines += ["", "## Tally (per level)", "",
+              "| level | ok | err | timeout | crash |",
+              "|---|---|---|---|---|"]
+    for lvl in levels:
+        t = {"ok": 0, "err": 0, "timeout": 0, "crash": 0}
+        for cid in rows:
+            be = rows[cid].get(lvl)
+            if be:
+                t[be[0]] = t.get(be[0], 0) + 1
+        lines.append(f"| {lvl} | {t['ok']} | {t['err']} | {t['timeout']} | {t['crash']} |")
+
+    Path(out_md).write_text("\n".join(lines) + "\n")
+    print(f"wrote {out_md} ({len(order)} commands x {len(levels)} levels)")
+
+
+if __name__ == "__main__":
+    g = sys.argv[1] if len(sys.argv) > 1 else "results-*/*.jsonl"
+    o = sys.argv[2] if len(sys.argv) > 2 else "lql-matrix.md"
+    main(g, o)

--- a/scripts/lql_matrix/commands-model.jsonl
+++ b/scripts/lql_matrix/commands-model.jsonl
@@ -1,0 +1,2 @@
+{"id": "use.model", "cat": "lifecycle", "lql": "USE MODEL \"{{MODEL}}\";"}
+{"id": "extract.into_inference", "cat": "lifecycle", "lql": "EXTRACT MODEL \"{{MODEL}}\" INTO \"{{TMP}}/extract-lql.vindex\" WITH INFERENCE;"}

--- a/scripts/lql_matrix/commands.jsonl
+++ b/scripts/lql_matrix/commands.jsonl
@@ -1,66 +1,64 @@
-{"id":"use.basic","cat":"lifecycle","lql":"USE \"{{VINDEX}}\";"}
-{"id":"use.model","cat":"lifecycle","lql":"USE MODEL \"{{MODEL}}\";"}
-{"id":"describe.basic","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\";"}
-{"id":"describe.all_layers","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" ALL LAYERS;"}
-{"id":"describe.brief","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" BRIEF;"}
-{"id":"describe.raw","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" RAW;"}
-{"id":"describe.syntax","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" SYNTAX;"}
-{"id":"describe.output","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" OUTPUT;"}
-{"id":"describe.at_layer","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" AT LAYER 12;"}
-{"id":"describe.missing_entity","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"Zzzznotanentity\";"}
-{"id":"walk.top10","cat":"browse","lql":"USE \"{{VINDEX}}\"; WALK \"The capital of France is\" TOP 10;"}
-{"id":"walk.notop","cat":"browse","lql":"USE \"{{VINDEX}}\"; WALK \"The capital of France is\";"}
-{"id":"walk.layers","cat":"browse","lql":"USE \"{{VINDEX}}\"; WALK \"The capital of France is\" LAYERS 5-15;"}
-{"id":"infer.top5","cat":"inference","lql":"USE \"{{VINDEX}}\"; INFER \"The capital of France is\" TOP 5;"}
-{"id":"infer.compare","cat":"inference","lql":"USE \"{{VINDEX}}\"; INFER \"The capital of France is\" TOP 5 COMPARE;"}
-{"id":"infer.route_verify","cat":"inference","lql":"USE \"{{VINDEX}}\"; INFER \"The capital of Atlantis is\" ROUTE VERIFY TOP 3;"}
-{"id":"infer.route_verify_exit","cat":"inference","lql":"USE \"{{VINDEX}}\"; INFER \"The capital of Atlantis is\" ROUTE VERIFY EXIT TOP 3;"}
-{"id":"infer.route_fallback","cat":"inference","lql":"USE \"{{VINDEX}}\"; INFER \"The capital of Persia is\" ROUTE VERIFY FALLBACK TOPK 8 TOP 3;"}
-{"id":"select.all","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM EDGES;"}
-{"id":"select.limit","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM EDGES LIMIT 5;"}
-{"id":"select.where_score","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM EDGES WHERE score > 0.85;"}
-{"id":"select.where_layer_range","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM EDGES WHERE layer >= 20 AND layer <= 30;"}
-{"id":"select.order_by","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM EDGES ORDER BY confidence;"}
-{"id":"select.projection","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT entity, target FROM EDGES WHERE relation = \"capital\" LIMIT 10;"}
-{"id":"select.entities","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM ENTITIES LIMIT 20;"}
-{"id":"select.features","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM FEATURES LIMIT 20;"}
-{"id":"explain.infer","cat":"inference","lql":"USE \"{{VINDEX}}\"; EXPLAIN INFER \"The capital of France is\" TOP 5;"}
-{"id":"explain.walk","cat":"browse","lql":"USE \"{{VINDEX}}\"; EXPLAIN WALK \"The capital of France is\" LAYERS 5-15;"}
-{"id":"stats","cat":"browse","lql":"USE \"{{VINDEX}}\"; STATS;"}
-{"id":"show.relations","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW RELATIONS;"}
-{"id":"show.relations_examples","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW RELATIONS WITH EXAMPLES;"}
-{"id":"show.layers","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW LAYERS;"}
-{"id":"show.layers_range","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW LAYERS RANGE 5-15;"}
-{"id":"show.features","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW FEATURES 12 LIMIT 20;"}
-{"id":"show.entities","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW ENTITIES LIMIT 20;"}
-{"id":"show.entities_at_layer","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW ENTITIES AT LAYER 12 LIMIT 50;"}
-{"id":"show.models","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW MODELS;"}
-{"id":"show.patches","cat":"patch","lql":"USE \"{{VINDEX}}\"; SHOW PATCHES;"}
-{"id":"show.compact_status","cat":"compact","lql":"USE \"{{VINDEX}}\"; SHOW COMPACT STATUS;"}
-{"id":"trace.basic","cat":"inference","lql":"USE \"{{VINDEX}}\"; TRACE \"The capital of France is\";"}
-{"id":"trace.for","cat":"inference","lql":"USE \"{{VINDEX}}\"; TRACE \"The capital of France is\" FOR \"Paris\";"}
-{"id":"trace.decompose","cat":"inference","lql":"USE \"{{VINDEX}}\"; TRACE \"The capital of France is\" DECOMPOSE LAYERS 5-15;"}
-{"id":"diff.current","cat":"lifecycle","lql":"USE \"{{VINDEX}}\"; DIFF \"{{VINDEX}}\" CURRENT;"}
-{"id":"insert.auto","cat":"mutation","lql":"USE \"{{VINDEX}}\"; INSERT INTO EDGES (entity, relation, target) VALUES (\"John Coyle\", \"lives-in\", \"Colchester\");"}
-{"id":"insert.in_patch","cat":"mutation","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"John Coyle\", \"lives-in\", \"Colchester\"); SAVE PATCH;"}
-{"id":"delete.where","cat":"mutation","lql":"USE \"{{VINDEX}}\"; DELETE FROM EDGES WHERE entity = \"John Coyle\" AND relation = \"lives-in\";"}
-{"id":"update.set","cat":"mutation","lql":"USE \"{{VINDEX}}\"; UPDATE EDGES SET target = \"London\" WHERE entity = \"John Coyle\" AND relation = \"lives-in\";"}
-{"id":"merge","cat":"mutation","lql":"USE \"{{VINDEX}}\"; MERGE;"}
-{"id":"rebalance.basic","cat":"mutation","lql":"USE \"{{VINDEX}}\"; REBALANCE;"}
-{"id":"rebalance.floor_ceiling","cat":"mutation","lql":"USE \"{{VINDEX}}\"; REBALANCE FLOOR 0.20 CEILING 0.95 MAX 8;"}
-{"id":"rebalance.until_converged","cat":"mutation","lql":"USE \"{{VINDEX}}\"; REBALANCE UNTIL CONVERGED MAX 16;"}
-{"id":"patch.begin","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH;"}
-{"id":"patch.begin_named","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH \"{{TMP}}/matrix-test.vlp\";"}
-{"id":"patch.begin_insert_save","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"MatrixEntity\", \"is-a\", \"Test\"); SAVE PATCH;"}
-{"id":"patch.full_lifecycle","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH \"mlc.vlp\"; INSERT INTO EDGES (entity, relation, target) VALUES (\"MatrixEntity\", \"is-a\", \"Test\"); SAVE PATCH; SHOW PATCHES; APPLY PATCH \"mlc.vlp\"; REMOVE PATCH \"mlc.vlp\";"}
-{"id":"compact.minor","cat":"compact","lql":"USE \"{{VINDEX}}\"; COMPACT MINOR;"}
-{"id":"compact.major","cat":"compact","lql":"USE \"{{VINDEX}}\"; COMPACT MAJOR;"}
-{"id":"compact.major_full","cat":"compact","lql":"USE \"{{VINDEX}}\"; COMPACT MAJOR FULL;"}
-{"id":"compact.major_lambda","cat":"compact","lql":"USE \"{{VINDEX}}\"; COMPACT MAJOR WITH LAMBDA = 0.01;"}
-{"id":"extract.into_inference","cat":"lifecycle","lql":"EXTRACT MODEL \"{{MODEL}}\" INTO \"{{TMP}}/extract-lql.vindex\" WITH INFERENCE;"}
-{"id":"compile.into_vindex","cat":"compile","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"CompileTest\", \"maps-to\", \"Value\"); SAVE PATCH; COMPILE CURRENT INTO VINDEX \"{{TMP}}/compiled.vindex\";"}
-{"id":"compile.into_model","cat":"compile","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"CompileTest\", \"maps-to\", \"Value\"); SAVE PATCH; COMPILE CURRENT INTO MODEL \"{{TMP}}/compiled-model/\" FORMAT safetensors;"}
-{"id":"roundtrip.insert_compile_infer","cat":"roundtrip","lql":"USE \"{{VINDEX}}\"; INFER \"Glarf is a\" TOP 3; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"Glarf\", \"is-a\", \"Wobble\"); SAVE PATCH; DESCRIBE \"Glarf\"; COMPILE CURRENT INTO VINDEX \"{{TMP}}/rt.vindex\"; USE \"{{TMP}}/rt.vindex\"; INFER \"Glarf is a\" TOP 3;"}
-{"id":"neg.parse_error","cat":"negative","lql":"USE \"{{VINDEX}}\"; NOT A VALID STATEMENT;"}
-{"id":"neg.unknown_verb","cat":"negative","lql":"USE \"{{VINDEX}}\"; FOOBAR;"}
-{"id":"neg.show_foobar","cat":"negative","lql":"USE \"{{VINDEX}}\"; SHOW FOOBAR;"}
+{"id": "use.basic", "cat": "lifecycle", "lql": "USE \"{{VINDEX}}\";"}
+{"id": "describe.basic", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; DESCRIBE \"France\";"}
+{"id": "describe.all_layers", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; DESCRIBE \"France\" ALL LAYERS;"}
+{"id": "describe.brief", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; DESCRIBE \"France\" BRIEF;"}
+{"id": "describe.raw", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; DESCRIBE \"France\" RAW;"}
+{"id": "describe.syntax", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; DESCRIBE \"France\" SYNTAX;"}
+{"id": "describe.output", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; DESCRIBE \"France\" OUTPUT;"}
+{"id": "describe.at_layer", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; DESCRIBE \"France\" AT LAYER 12;"}
+{"id": "describe.missing_entity", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; DESCRIBE \"Zzzznotanentity\";"}
+{"id": "walk.top10", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; WALK \"The capital of France is\" TOP 10;"}
+{"id": "walk.notop", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; WALK \"The capital of France is\";"}
+{"id": "walk.layers", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; WALK \"The capital of France is\" LAYERS 5-15;"}
+{"id": "infer.top5", "cat": "inference", "lql": "USE \"{{VINDEX}}\"; INFER \"The capital of France is\" TOP 5;"}
+{"id": "infer.compare", "cat": "inference", "lql": "USE \"{{VINDEX}}\"; INFER \"The capital of France is\" TOP 5 COMPARE;"}
+{"id": "infer.route_verify", "cat": "inference", "lql": "USE \"{{VINDEX}}\"; INFER \"The capital of Atlantis is\" ROUTE VERIFY TOP 3;"}
+{"id": "infer.route_verify_exit", "cat": "inference", "lql": "USE \"{{VINDEX}}\"; INFER \"The capital of Atlantis is\" ROUTE VERIFY EXIT TOP 3;"}
+{"id": "infer.route_fallback", "cat": "inference", "lql": "USE \"{{VINDEX}}\"; INFER \"The capital of Persia is\" ROUTE VERIFY FALLBACK TOPK 8 TOP 3;"}
+{"id": "select.all", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SELECT * FROM EDGES;"}
+{"id": "select.limit", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SELECT * FROM EDGES LIMIT 5;"}
+{"id": "select.where_score", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SELECT * FROM EDGES WHERE score > 0.85;"}
+{"id": "select.where_layer_range", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SELECT * FROM EDGES WHERE layer >= 20 AND layer <= 30;"}
+{"id": "select.order_by", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SELECT * FROM EDGES ORDER BY confidence;"}
+{"id": "select.projection", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SELECT entity, target FROM EDGES WHERE relation = \"capital\" LIMIT 10;"}
+{"id": "select.entities", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SELECT * FROM ENTITIES LIMIT 20;"}
+{"id": "select.features", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SELECT * FROM FEATURES LIMIT 20;"}
+{"id": "explain.infer", "cat": "inference", "lql": "USE \"{{VINDEX}}\"; EXPLAIN INFER \"The capital of France is\" TOP 5;"}
+{"id": "explain.walk", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; EXPLAIN WALK \"The capital of France is\" LAYERS 5-15;"}
+{"id": "stats", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; STATS;"}
+{"id": "show.relations", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SHOW RELATIONS;"}
+{"id": "show.relations_examples", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SHOW RELATIONS WITH EXAMPLES;"}
+{"id": "show.layers", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SHOW LAYERS;"}
+{"id": "show.layers_range", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SHOW LAYERS RANGE 5-15;"}
+{"id": "show.features", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SHOW FEATURES 12 LIMIT 20;"}
+{"id": "show.entities", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SHOW ENTITIES LIMIT 20;"}
+{"id": "show.entities_at_layer", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SHOW ENTITIES AT LAYER 12 LIMIT 50;"}
+{"id": "show.models", "cat": "browse", "lql": "USE \"{{VINDEX}}\"; SHOW MODELS;"}
+{"id": "show.patches", "cat": "patch", "lql": "USE \"{{VINDEX}}\"; SHOW PATCHES;"}
+{"id": "show.compact_status", "cat": "compact", "lql": "USE \"{{VINDEX}}\"; SHOW COMPACT STATUS;"}
+{"id": "trace.basic", "cat": "inference", "lql": "USE \"{{VINDEX}}\"; TRACE \"The capital of France is\";"}
+{"id": "trace.for", "cat": "inference", "lql": "USE \"{{VINDEX}}\"; TRACE \"The capital of France is\" FOR \"Paris\";"}
+{"id": "trace.decompose", "cat": "inference", "lql": "USE \"{{VINDEX}}\"; TRACE \"The capital of France is\" DECOMPOSE LAYERS 5-15;"}
+{"id": "diff.current", "cat": "lifecycle", "lql": "USE \"{{VINDEX}}\"; DIFF \"{{VINDEX}}\" CURRENT;"}
+{"id": "insert.auto", "cat": "mutation", "lql": "USE \"{{VINDEX}}\"; INSERT INTO EDGES (entity, relation, target) VALUES (\"John Coyle\", \"lives-in\", \"Colchester\");"}
+{"id": "insert.in_patch", "cat": "mutation", "lql": "USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"John Coyle\", \"lives-in\", \"Colchester\"); SAVE PATCH;"}
+{"id": "delete.where", "cat": "mutation", "lql": "USE \"{{VINDEX}}\"; DELETE FROM EDGES WHERE entity = \"John Coyle\" AND relation = \"lives-in\";"}
+{"id": "update.set", "cat": "mutation", "lql": "USE \"{{VINDEX}}\"; UPDATE EDGES SET target = \"London\" WHERE entity = \"John Coyle\" AND relation = \"lives-in\";"}
+{"id": "merge", "cat": "mutation", "lql": "USE \"{{VINDEX}}\"; MERGE;"}
+{"id": "rebalance.basic", "cat": "mutation", "lql": "USE \"{{VINDEX}}\"; REBALANCE;"}
+{"id": "rebalance.floor_ceiling", "cat": "mutation", "lql": "USE \"{{VINDEX}}\"; REBALANCE FLOOR 0.20 CEILING 0.95 MAX 8;"}
+{"id": "rebalance.until_converged", "cat": "mutation", "lql": "USE \"{{VINDEX}}\"; REBALANCE UNTIL CONVERGED MAX 16;"}
+{"id": "patch.begin", "cat": "patch", "lql": "USE \"{{VINDEX}}\"; BEGIN PATCH;"}
+{"id": "patch.begin_named", "cat": "patch", "lql": "USE \"{{VINDEX}}\"; BEGIN PATCH \"{{TMP}}/matrix-test.vlp\";"}
+{"id": "patch.begin_insert_save", "cat": "patch", "lql": "USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"MatrixEntity\", \"is-a\", \"Test\"); SAVE PATCH;"}
+{"id": "patch.full_lifecycle", "cat": "patch", "lql": "USE \"{{VINDEX}}\"; BEGIN PATCH \"mlc.vlp\"; INSERT INTO EDGES (entity, relation, target) VALUES (\"MatrixEntity\", \"is-a\", \"Test\"); SAVE PATCH; SHOW PATCHES; APPLY PATCH \"mlc.vlp\"; REMOVE PATCH \"mlc.vlp\";"}
+{"id": "compact.minor", "cat": "compact", "lql": "USE \"{{VINDEX}}\"; COMPACT MINOR;"}
+{"id": "compact.major", "cat": "compact", "lql": "USE \"{{VINDEX}}\"; COMPACT MAJOR;"}
+{"id": "compact.major_full", "cat": "compact", "lql": "USE \"{{VINDEX}}\"; COMPACT MAJOR FULL;"}
+{"id": "compact.major_lambda", "cat": "compact", "lql": "USE \"{{VINDEX}}\"; COMPACT MAJOR WITH LAMBDA = 0.01;"}
+{"id": "compile.into_vindex", "cat": "compile", "lql": "USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"CompileTest\", \"maps-to\", \"Value\"); SAVE PATCH; COMPILE CURRENT INTO VINDEX \"{{TMP}}/compiled.vindex\";"}
+{"id": "compile.into_model", "cat": "compile", "lql": "USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"CompileTest\", \"maps-to\", \"Value\"); SAVE PATCH; COMPILE CURRENT INTO MODEL \"{{TMP}}/compiled-model/\" FORMAT safetensors;"}
+{"id": "roundtrip.insert_compile_infer", "cat": "roundtrip", "lql": "USE \"{{VINDEX}}\"; INFER \"Glarf is a\" TOP 3; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"Glarf\", \"is-a\", \"Wobble\"); SAVE PATCH; DESCRIBE \"Glarf\"; COMPILE CURRENT INTO VINDEX \"{{TMP}}/rt.vindex\"; USE \"{{TMP}}/rt.vindex\"; INFER \"Glarf is a\" TOP 3;"}
+{"id": "neg.parse_error", "cat": "negative", "lql": "USE \"{{VINDEX}}\"; NOT A VALID STATEMENT;"}
+{"id": "neg.unknown_verb", "cat": "negative", "lql": "USE \"{{VINDEX}}\"; FOOBAR;"}
+{"id": "neg.show_foobar", "cat": "negative", "lql": "USE \"{{VINDEX}}\"; SHOW FOOBAR;"}

--- a/scripts/lql_matrix/commands.jsonl
+++ b/scripts/lql_matrix/commands.jsonl
@@ -50,7 +50,7 @@
 {"id":"rebalance.floor_ceiling","cat":"mutation","lql":"USE \"{{VINDEX}}\"; REBALANCE FLOOR 0.20 CEILING 0.95 MAX 8;"}
 {"id":"rebalance.until_converged","cat":"mutation","lql":"USE \"{{VINDEX}}\"; REBALANCE UNTIL CONVERGED MAX 16;"}
 {"id":"patch.begin","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH;"}
-{"id":"patch.begin_named","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH \"matrix-test.vlp\";"}
+{"id":"patch.begin_named","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH \"{{TMP}}/matrix-test.vlp\";"}
 {"id":"patch.begin_insert_save","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"MatrixEntity\", \"is-a\", \"Test\"); SAVE PATCH;"}
 {"id":"patch.full_lifecycle","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH \"mlc.vlp\"; INSERT INTO EDGES (entity, relation, target) VALUES (\"MatrixEntity\", \"is-a\", \"Test\"); SAVE PATCH; SHOW PATCHES; APPLY PATCH \"mlc.vlp\"; REMOVE PATCH \"mlc.vlp\";"}
 {"id":"compact.minor","cat":"compact","lql":"USE \"{{VINDEX}}\"; COMPACT MINOR;"}

--- a/scripts/lql_matrix/commands.jsonl
+++ b/scripts/lql_matrix/commands.jsonl
@@ -1,0 +1,66 @@
+{"id":"use.basic","cat":"lifecycle","lql":"USE \"{{VINDEX}}\";"}
+{"id":"use.model","cat":"lifecycle","lql":"USE MODEL \"{{MODEL}}\";"}
+{"id":"describe.basic","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\";"}
+{"id":"describe.all_layers","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" ALL LAYERS;"}
+{"id":"describe.brief","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" BRIEF;"}
+{"id":"describe.raw","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" RAW;"}
+{"id":"describe.syntax","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" SYNTAX;"}
+{"id":"describe.output","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" OUTPUT;"}
+{"id":"describe.at_layer","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"France\" AT LAYER 12;"}
+{"id":"describe.missing_entity","cat":"browse","lql":"USE \"{{VINDEX}}\"; DESCRIBE \"Zzzznotanentity\";"}
+{"id":"walk.top10","cat":"browse","lql":"USE \"{{VINDEX}}\"; WALK \"The capital of France is\" TOP 10;"}
+{"id":"walk.notop","cat":"browse","lql":"USE \"{{VINDEX}}\"; WALK \"The capital of France is\";"}
+{"id":"walk.layers","cat":"browse","lql":"USE \"{{VINDEX}}\"; WALK \"The capital of France is\" LAYERS 5-15;"}
+{"id":"infer.top5","cat":"inference","lql":"USE \"{{VINDEX}}\"; INFER \"The capital of France is\" TOP 5;"}
+{"id":"infer.compare","cat":"inference","lql":"USE \"{{VINDEX}}\"; INFER \"The capital of France is\" TOP 5 COMPARE;"}
+{"id":"infer.route_verify","cat":"inference","lql":"USE \"{{VINDEX}}\"; INFER \"The capital of Atlantis is\" ROUTE VERIFY TOP 3;"}
+{"id":"infer.route_verify_exit","cat":"inference","lql":"USE \"{{VINDEX}}\"; INFER \"The capital of Atlantis is\" ROUTE VERIFY EXIT TOP 3;"}
+{"id":"infer.route_fallback","cat":"inference","lql":"USE \"{{VINDEX}}\"; INFER \"The capital of Persia is\" ROUTE VERIFY FALLBACK TOPK 8 TOP 3;"}
+{"id":"select.all","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM EDGES;"}
+{"id":"select.limit","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM EDGES LIMIT 5;"}
+{"id":"select.where_score","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM EDGES WHERE score > 0.85;"}
+{"id":"select.where_layer_range","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM EDGES WHERE layer >= 20 AND layer <= 30;"}
+{"id":"select.order_by","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM EDGES ORDER BY confidence;"}
+{"id":"select.projection","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT entity, target FROM EDGES WHERE relation = \"capital\" LIMIT 10;"}
+{"id":"select.entities","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM ENTITIES LIMIT 20;"}
+{"id":"select.features","cat":"browse","lql":"USE \"{{VINDEX}}\"; SELECT * FROM FEATURES LIMIT 20;"}
+{"id":"explain.infer","cat":"inference","lql":"USE \"{{VINDEX}}\"; EXPLAIN INFER \"The capital of France is\" TOP 5;"}
+{"id":"explain.walk","cat":"browse","lql":"USE \"{{VINDEX}}\"; EXPLAIN WALK \"The capital of France is\" LAYERS 5-15;"}
+{"id":"stats","cat":"browse","lql":"USE \"{{VINDEX}}\"; STATS;"}
+{"id":"show.relations","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW RELATIONS;"}
+{"id":"show.relations_examples","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW RELATIONS WITH EXAMPLES;"}
+{"id":"show.layers","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW LAYERS;"}
+{"id":"show.layers_range","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW LAYERS RANGE 5-15;"}
+{"id":"show.features","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW FEATURES 12 LIMIT 20;"}
+{"id":"show.entities","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW ENTITIES LIMIT 20;"}
+{"id":"show.entities_at_layer","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW ENTITIES AT LAYER 12 LIMIT 50;"}
+{"id":"show.models","cat":"browse","lql":"USE \"{{VINDEX}}\"; SHOW MODELS;"}
+{"id":"show.patches","cat":"patch","lql":"USE \"{{VINDEX}}\"; SHOW PATCHES;"}
+{"id":"show.compact_status","cat":"compact","lql":"USE \"{{VINDEX}}\"; SHOW COMPACT STATUS;"}
+{"id":"trace.basic","cat":"inference","lql":"USE \"{{VINDEX}}\"; TRACE \"The capital of France is\";"}
+{"id":"trace.for","cat":"inference","lql":"USE \"{{VINDEX}}\"; TRACE \"The capital of France is\" FOR \"Paris\";"}
+{"id":"trace.decompose","cat":"inference","lql":"USE \"{{VINDEX}}\"; TRACE \"The capital of France is\" DECOMPOSE LAYERS 5-15;"}
+{"id":"diff.current","cat":"lifecycle","lql":"USE \"{{VINDEX}}\"; DIFF \"{{VINDEX}}\" CURRENT;"}
+{"id":"insert.auto","cat":"mutation","lql":"USE \"{{VINDEX}}\"; INSERT INTO EDGES (entity, relation, target) VALUES (\"John Coyle\", \"lives-in\", \"Colchester\");"}
+{"id":"insert.in_patch","cat":"mutation","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"John Coyle\", \"lives-in\", \"Colchester\"); SAVE PATCH;"}
+{"id":"delete.where","cat":"mutation","lql":"USE \"{{VINDEX}}\"; DELETE FROM EDGES WHERE entity = \"John Coyle\" AND relation = \"lives-in\";"}
+{"id":"update.set","cat":"mutation","lql":"USE \"{{VINDEX}}\"; UPDATE EDGES SET target = \"London\" WHERE entity = \"John Coyle\" AND relation = \"lives-in\";"}
+{"id":"merge","cat":"mutation","lql":"USE \"{{VINDEX}}\"; MERGE;"}
+{"id":"rebalance.basic","cat":"mutation","lql":"USE \"{{VINDEX}}\"; REBALANCE;"}
+{"id":"rebalance.floor_ceiling","cat":"mutation","lql":"USE \"{{VINDEX}}\"; REBALANCE FLOOR 0.20 CEILING 0.95 MAX 8;"}
+{"id":"rebalance.until_converged","cat":"mutation","lql":"USE \"{{VINDEX}}\"; REBALANCE UNTIL CONVERGED MAX 16;"}
+{"id":"patch.begin","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH;"}
+{"id":"patch.begin_named","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH \"matrix-test.vlp\";"}
+{"id":"patch.begin_insert_save","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"MatrixEntity\", \"is-a\", \"Test\"); SAVE PATCH;"}
+{"id":"patch.full_lifecycle","cat":"patch","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH \"mlc.vlp\"; INSERT INTO EDGES (entity, relation, target) VALUES (\"MatrixEntity\", \"is-a\", \"Test\"); SAVE PATCH; SHOW PATCHES; APPLY PATCH \"mlc.vlp\"; REMOVE PATCH \"mlc.vlp\";"}
+{"id":"compact.minor","cat":"compact","lql":"USE \"{{VINDEX}}\"; COMPACT MINOR;"}
+{"id":"compact.major","cat":"compact","lql":"USE \"{{VINDEX}}\"; COMPACT MAJOR;"}
+{"id":"compact.major_full","cat":"compact","lql":"USE \"{{VINDEX}}\"; COMPACT MAJOR FULL;"}
+{"id":"compact.major_lambda","cat":"compact","lql":"USE \"{{VINDEX}}\"; COMPACT MAJOR WITH LAMBDA = 0.01;"}
+{"id":"extract.into_inference","cat":"lifecycle","lql":"EXTRACT MODEL \"{{MODEL}}\" INTO \"{{TMP}}/extract-lql.vindex\" WITH INFERENCE;"}
+{"id":"compile.into_vindex","cat":"compile","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"CompileTest\", \"maps-to\", \"Value\"); SAVE PATCH; COMPILE CURRENT INTO VINDEX \"{{TMP}}/compiled.vindex\";"}
+{"id":"compile.into_model","cat":"compile","lql":"USE \"{{VINDEX}}\"; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"CompileTest\", \"maps-to\", \"Value\"); SAVE PATCH; COMPILE CURRENT INTO MODEL \"{{TMP}}/compiled-model/\" FORMAT safetensors;"}
+{"id":"roundtrip.insert_compile_infer","cat":"roundtrip","lql":"USE \"{{VINDEX}}\"; INFER \"Glarf is a\" TOP 3; BEGIN PATCH; INSERT INTO EDGES (entity, relation, target) VALUES (\"Glarf\", \"is-a\", \"Wobble\"); SAVE PATCH; DESCRIBE \"Glarf\"; COMPILE CURRENT INTO VINDEX \"{{TMP}}/rt.vindex\"; USE \"{{TMP}}/rt.vindex\"; INFER \"Glarf is a\" TOP 3;"}
+{"id":"neg.parse_error","cat":"negative","lql":"USE \"{{VINDEX}}\"; NOT A VALID STATEMENT;"}
+{"id":"neg.unknown_verb","cat":"negative","lql":"USE \"{{VINDEX}}\"; FOOBAR;"}
+{"id":"neg.show_foobar","cat":"negative","lql":"USE \"{{VINDEX}}\"; SHOW FOOBAR;"}

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -103,7 +103,7 @@ def inv_completeness(legs):
     return out
 
 
-_LAYER_ROW = re.compile(r"^L\d+\s+(\d+)\s+\d+", re.M)
+_LAYER_ROW = re.compile(r"^L\d+\s+([\d.]+[KM]?)\s+[\d.]+[KM]?", re.M)
 
 _CRASH_CODES = {101, 134, 137, 139}
 
@@ -142,12 +142,31 @@ def inv_descriptor_match(legs):
     return out
 
 
+def _parse_num(tok):
+    m = re.fullmatch(r"([\d.]+)([KM]?)", tok, re.I)
+    if not m:
+        return None
+    try:
+        n = float(m.group(1))
+    except ValueError:
+        return None
+    return n * {"K": 1e3, "M": 1e6, "": 1}[m.group(2).upper()]
+
+
 def show_layers_total(leg):
     row = leg.cells.get("show.layers")
     if not row:
         return None
-    counts = _LAYER_ROW.findall(row.get("stdout_head", "") or "")
-    return sum(int(c) for c in counts) if counts else None
+    toks = _LAYER_ROW.findall(row.get("stdout_head", "") or "")
+    if not toks:
+        return None
+    total, seen = 0.0, False
+    for t in toks:
+        v = _parse_num(t)
+        if v is not None:
+            total += v
+            seen = True
+    return int(round(total)) if seen else None
 
 
 def inv_cross_check(legs):

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -107,6 +107,8 @@ _LAYER_ROW = re.compile(r"^L\d+\s+([\d.]+[KM]?)\s+[\d.]+[KM]?", re.M)
 
 _CRASH_CODES = {101, 134, 137, 139}
 
+_WARN = re.compile(r"warn|overrid|ignor", re.I)
+
 
 def _is_crash(row):
     return row.get("bucket") == "crash" or row.get("exit_code") in _CRASH_CODES
@@ -181,7 +183,30 @@ def inv_cross_check(legs):
     return out
 
 
-INVARIANTS = [inv_completeness, inv_no_crash, inv_descriptor_match, inv_cross_check]
+def inv_diagnostic(legs):
+    out = []
+    for name, lg in legs.items():
+        p = lg.produce
+        # R-2: --quant q4k silently overrides a non-all --level
+        if (p.get("op") == "extract" and "--quant q4k" in (p.get("flags") or "")
+                and p.get("level") in {"browse", "attention", "inference"}):
+            txt = (p.get("stdout_head", "") or "") + (p.get("stderr_head", "") or "")
+            if not _WARN.search(txt):
+                out.append(Violation("diagnostic", name, "produce",
+                                     f"--level {p.get('level')} silently ignored under --quant q4k "
+                                     "(no warn/override text; cf #208)"))
+        # R-3: error text blames --compact but the recipe never passed it
+        flags = (p.get("flags") or "")
+        if "compact" not in flags:
+            for cid, row in lg.cells.items():
+                if "--compact" in (row.get("err_line", "") or ""):
+                    out.append(Violation("diagnostic", name, cid,
+                                         "error text misattributes to `--compact` (not in recipe flags)"))
+                    break
+    return out
+
+
+INVARIANTS = [inv_completeness, inv_no_crash, inv_descriptor_match, inv_cross_check, inv_diagnostic]
 
 
 def run(results_glob, out_md, out_json, strict):

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -103,7 +103,27 @@ def inv_completeness(legs):
     return out
 
 
-INVARIANTS = [inv_completeness]
+_CRASH_CODES = {101, 134, 137, 139}
+
+
+def _is_crash(row):
+    return row.get("bucket") == "crash" or row.get("exit_code") in _CRASH_CODES
+
+
+def inv_no_crash(legs):
+    out = []
+    for name, lg in legs.items():
+        if lg.produce and _is_crash(lg.produce):
+            out.append(Violation("no-crash", name, "produce",
+                                 f"produce crashed (exit {lg.produce.get('exit_code')})"))
+        for cid, row in lg.cells.items():
+            if _is_crash(row):
+                out.append(Violation("no-crash", name, cid,
+                                     f"panic/crash (exit {row.get('exit_code')})"))
+    return out
+
+
+INVARIANTS = [inv_completeness, inv_no_crash]
 
 
 def run(results_glob, out_md, out_json, strict):

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -81,7 +81,10 @@ def feature_count(leg):
     for row in leg.cells.values():
         m = _FEAT.search(row.get("stdout_head", "") or "")
         if m:
-            n = float(m.group(1))
+            try:
+                n = float(m.group(1))
+            except ValueError:
+                continue
             n *= {"K": 1e3, "M": 1e6, "": 1}[m.group(2).upper()]
             return int(round(n))
     return None

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -1,0 +1,103 @@
+"""Conformance oracle for the lql-strategy-matrix. Evaluates principled,
+no-expected-output invariants over already-captured artifacts and emits a
+report. Default exit 0 (discovery preserved); non-zero only under --strict."""
+import glob
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Leg:
+    name: str
+    meta: dict = field(default_factory=dict)
+    cells: dict = field(default_factory=dict)       # id -> row
+    descriptor: dict = field(default_factory=dict)
+    produce: dict = field(default_factory=dict)
+
+
+@dataclass
+class Violation:
+    invariant: str
+    leg: str
+    cell: str
+    detail: str
+
+
+def _read_json(path):
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def load(results_glob):
+    legs = {}
+    for rf in sorted(glob.glob(results_glob)):
+        d = Path(rf).parent
+        for line in Path(rf).read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            name = r.get("level")
+            if not name:
+                continue
+            lg = legs.setdefault(name, Leg(name=name))
+            if r.get("type") == "meta":
+                lg.meta = r
+            else:
+                lg.cells[r.get("id", "?")] = r
+        # sidecars: descriptor-<name>.json / produce-<name>.json in the same dir
+        for name, lg in legs.items():
+            dp = d / f"descriptor-{name}.json"
+            pp = d / f"produce-{name}.json"
+            if dp.exists():
+                lg.descriptor = _read_json(dp)
+            if pp.exists():
+                lg.produce = _read_json(pp)
+    return legs
+
+
+INVARIANTS = []
+
+
+def run(results_glob, out_md, out_json, strict):
+    legs = load(results_glob)
+    violations = [v for inv in INVARIANTS for v in inv(legs)]
+    Path(out_json).write_text(json.dumps(
+        {"violations": [v.__dict__ for v in violations]}, indent=2), encoding="utf-8")
+    Path(out_md).write_text(render(legs, violations), encoding="utf-8")
+    print(f"conformance: {len(violations)} violation(s) across {len(legs)} legs "
+          f"(strict={strict})")
+    return 1 if (strict and violations) else 0
+
+
+def render(legs, violations):
+    L = ["# LQL Matrix — Conformance", "",
+         f"Legs: {len(legs)} · Violations: {len(violations)}", ""]
+    if violations:
+        L += ["| invariant | leg | cell | detail |", "|---|---|---|---|"]
+        for v in violations:
+            L.append(f"| {v.invariant} | `{v.leg}` | {v.cell or '-'} | {v.detail} |")
+    else:
+        L.append("No invariant violations.")
+    return "\n".join(L) + "\n"
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    strict = "--strict" in sys.argv[1:]
+    results_glob = args[0] if args else "artifacts/results-*/results-*.jsonl"
+    out_md = args[1] if len(args) > 1 else "conformance.md"
+    out_json = args[2] if len(args) > 2 else "conformance.json"
+    sys.exit(run(results_glob, out_md, out_json, strict))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -67,10 +67,17 @@ def load(results_glob):
             lg = legs[name]
             dp = d / f"descriptor-{name}.json"
             pp = d / f"produce-{name}.json"
+            ep = d / f"produce-{name}.err"
             if dp.exists():
                 lg.descriptor = _read_json(dp)
             if pp.exists():
                 lg.produce = _read_json(pp)
+            if ep.exists():
+                try:
+                    lg.produce["stderr_head"] = ep.read_text(
+                        encoding="utf-8", errors="replace")[:800]
+                except OSError:
+                    pass
     return legs
 
 

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -37,7 +37,12 @@ def load(results_glob):
     legs = {}
     for rf in sorted(glob.glob(results_glob)):
         d = Path(rf).parent
-        for line in Path(rf).read_text(encoding="utf-8").splitlines():
+        names_here = []
+        try:
+            text = Path(rf).read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
             line = line.strip()
             if not line:
                 continue
@@ -45,16 +50,21 @@ def load(results_glob):
                 r = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            if not isinstance(r, dict):
+                continue
             name = r.get("level")
             if not name:
                 continue
             lg = legs.setdefault(name, Leg(name=name))
+            if name not in names_here:
+                names_here.append(name)
             if r.get("type") == "meta":
                 lg.meta = r
             else:
                 lg.cells[r.get("id", "?")] = r
-        # sidecars: descriptor-<name>.json / produce-<name>.json in the same dir
-        for name, lg in legs.items():
+        # sidecars: only for legs introduced by THIS results file, from THIS dir
+        for name in names_here:
+            lg = legs[name]
             dp = d / f"descriptor-{name}.json"
             pp = d / f"produce-{name}.json"
             if dp.exists():

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -103,6 +103,8 @@ def inv_completeness(legs):
     return out
 
 
+_LAYER_ROW = re.compile(r"^L\d+\s+(\d+)\s+\d+", re.M)
+
 _CRASH_CODES = {101, 134, 137, 139}
 
 
@@ -140,7 +142,27 @@ def inv_descriptor_match(legs):
     return out
 
 
-INVARIANTS = [inv_completeness, inv_no_crash, inv_descriptor_match]
+def show_layers_total(leg):
+    row = leg.cells.get("show.layers")
+    if not row:
+        return None
+    counts = _LAYER_ROW.findall(row.get("stdout_head", "") or "")
+    return sum(int(c) for c in counts) if counts else None
+
+
+def inv_cross_check(legs):
+    out = []
+    for name, lg in legs.items():
+        sl = show_layers_total(lg)
+        fc = feature_count(lg)
+        if sl is not None and fc and sl == 0:
+            out.append(Violation("cross-check", name, "show.layers",
+                                 f"SHOW LAYERS reports 0 features but STATS reports {fc} "
+                                 "(mmap heap-only accessor, cf SHOW LAYERS bug)"))
+    return out
+
+
+INVARIANTS = [inv_completeness, inv_no_crash, inv_descriptor_match, inv_cross_check]
 
 
 def run(results_glob, out_md, out_json, strict):

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -123,7 +123,24 @@ def inv_no_crash(legs):
     return out
 
 
-INVARIANTS = [inv_completeness, inv_no_crash]
+def inv_descriptor_match(legs):
+    out = []
+    for name, lg in legs.items():
+        d = lg.descriptor
+        if not d or not d.get("produced", True) or d.get("error"):
+            continue  # produce-side failure — covered by completeness/no-crash
+        if not d.get("quant_match", True):
+            out.append(Violation("descriptor-match", name, "",
+                                 f"quant mismatch: produced {d.get('observed_quant')} != "
+                                 f"expected {d.get('expect_quant')}"))
+        fam = (d.get("family") or "").lower()
+        if fam in ("", "generic"):
+            out.append(Violation("descriptor-match", name, "",
+                                 f"unrecognized/generic arch fallback (family={d.get('family')!r}, cf #154)"))
+    return out
+
+
+INVARIANTS = [inv_completeness, inv_no_crash, inv_descriptor_match]
 
 
 def run(results_glob, out_md, out_json, strict):

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -74,7 +74,33 @@ def load(results_glob):
     return legs
 
 
-INVARIANTS = []
+_FEAT = re.compile(r"\(\s*\d+\s+layers?,\s*([\d.]+)\s*([KM]?)\s+features", re.I)
+
+
+def feature_count(leg):
+    for row in leg.cells.values():
+        m = _FEAT.search(row.get("stdout_head", "") or "")
+        if m:
+            n = float(m.group(1))
+            n *= {"K": 1e3, "M": 1e6, "": 1}[m.group(2).upper()]
+            return int(round(n))
+    return None
+
+
+def inv_completeness(legs):
+    out = []
+    for name, lg in legs.items():
+        fc = feature_count(lg)
+        if fc is None:
+            out.append(Violation("completeness", name, "",
+                                 "feature_count unknown (no STATS/banner — produce may have failed)"))
+        elif fc == 0:
+            out.append(Violation("completeness", name, "",
+                                 "hollow vindex: 0 features (silent-incomplete extraction, cf #183)"))
+    return out
+
+
+INVARIANTS = [inv_completeness]
 
 
 def run(results_glob, out_md, out_json, strict):

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -28,9 +28,10 @@ class Violation:
 
 def _read_json(path):
     try:
-        return json.loads(Path(path).read_text(encoding="utf-8"))
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
     except Exception:
         return {}
+    return data if isinstance(data, dict) else {}
 
 
 def load(results_glob):

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -216,6 +216,30 @@ def inv_diagnostic(legs):
 INVARIANTS = [inv_completeness, inv_no_crash, inv_descriptor_match, inv_cross_check, inv_diagnostic]
 
 
+_SRC_FMT = {"extract": "safetensors", "gguf-to-vindex": "gguf",
+            "quantize-q4k": "safetensors", "quantize-fp4": "safetensors"}
+
+
+def transformation_report(legs):
+    L = ["## Transformation & consumability coverage", "",
+         "| leg | source fmt | produced arch | produced quant |",
+         "|---|---|---|---|"]
+    for name in sorted(legs):
+        lg = legs[name]
+        src = _SRC_FMT.get(lg.produce.get("op"), "?")
+        L.append(f"| `{name}` | {src} | {lg.descriptor.get('family','?')} | "
+                 f"{lg.descriptor.get('observed_quant','?')} |")
+    L += ["",
+          "**Consumer reachability & gaps (static):**",
+          "- larql-cli / larql-server (`/v1/chat`): reach any produced vindex directly.",
+          "- **Ollama:** needs GGUF; larql `compile` emits safetensors and there is **no "
+          "compiled→GGUF export** — Ollama is a **gap** (cf #181/N11).",
+          "- **Cross-arch transform** (e.g. qwen↔bitnet): produced arch equals source arch in "
+          "every leg — larql changes quant/format, **not architecture** — a **gap** for the "
+          "'transform one arch into another' use case.", ""]
+    return L
+
+
 def run(results_glob, out_md, out_json, strict):
     legs = load(results_glob)
     violations = [v for inv in INVARIANTS for v in inv(legs)]
@@ -236,6 +260,7 @@ def render(legs, violations):
             L.append(f"| {v.invariant} | `{v.leg}` | {v.cell or '-'} | {v.detail} |")
     else:
         L.append("No invariant violations.")
+    L += [""] + transformation_report(legs)
     return "\n".join(L) + "\n"
 
 

--- a/scripts/lql_matrix/conformance.py
+++ b/scripts/lql_matrix/conformance.py
@@ -101,6 +101,8 @@ def feature_count(leg):
 def inv_completeness(legs):
     out = []
     for name, lg in legs.items():
+        if _produce_failed(lg):
+            continue  # vindex was never produced → inv_produce, not a hollow vindex
         fc = feature_count(lg)
         if fc is None:
             out.append(Violation("completeness", name, "",
@@ -122,6 +124,19 @@ def _is_crash(row):
     return row.get("bucket") == "crash" or row.get("exit_code") in _CRASH_CODES
 
 
+def _produce_failed(lg):
+    """True iff this leg's vindex was not successfully produced — the definitive
+    signal (descriptor.produced=False, or a non-zero/err/timeout produce). Distinct
+    from a produced-but-hollow vindex (feat=0), which is a completeness violation."""
+    if lg.descriptor.get("produced") is False:
+        return True
+    p = lg.produce or {}
+    ec = p.get("exit_code")
+    if isinstance(ec, int) and ec != 0:
+        return True
+    return p.get("bucket") in {"err", "crash", "timeout"}
+
+
 def inv_no_crash(legs):
     out = []
     for name, lg in legs.items():
@@ -132,6 +147,25 @@ def inv_no_crash(legs):
             if _is_crash(row):
                 out.append(Violation("no-crash", name, cid,
                                      f"panic/crash (exit {row.get('exit_code')})"))
+    return out
+
+
+def inv_produce(legs):
+    """Definitive produce-failure violation: the vindex was never created. Produce
+    *crashes* (SIGKILL/panic) are already reported by inv_no_crash, so skip them here
+    to avoid double-counting; this catches the non-crash failures (exit!=0 / err /
+    timeout / descriptor.produced=False) that would otherwise be mislabeled as a
+    hedged completeness-unknown."""
+    out = []
+    for name, lg in legs.items():
+        if _is_crash(lg.produce):
+            continue
+        if _produce_failed(lg):
+            p = lg.produce or {}
+            out.append(Violation("produce", name, "produce",
+                                 f"produce failed: op={p.get('op')} exit={p.get('exit_code')} "
+                                 f"bucket={p.get('bucket')} (vindex not created; "
+                                 f"descriptor.produced={lg.descriptor.get('produced')})"))
     return out
 
 
@@ -214,7 +248,7 @@ def inv_diagnostic(legs):
     return out
 
 
-INVARIANTS = [inv_completeness, inv_no_crash, inv_descriptor_match, inv_cross_check, inv_diagnostic]
+INVARIANTS = [inv_completeness, inv_produce, inv_no_crash, inv_descriptor_match, inv_cross_check, inv_diagnostic]
 
 
 _SRC_FMT = {"extract": "safetensors", "gguf-to-vindex": "gguf",

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -109,3 +109,17 @@ def test_cross_check_flags_show_layers_zero_vs_stats_nonzero():
     vs = C.inv_cross_check({"bad": bad, "good": good})
     assert [v.leg for v in vs] == ["bad"]
     assert vs[0].invariant == "cross-check"
+
+
+SHOW_LAYERS_MIXED = ("Layer      Features  With Meta       Top Token\n"
+                     "------------------------------------------------\n"
+                     "L0                0          0\n"
+                     "L1             2.6K          0\n")
+
+
+def test_cross_check_no_false_positive_on_ksuffix_rows():
+    lg = make_leg("mixed", cells={
+        "stats": _cell("stats", "(24 layers, 5K features, m)"),
+        "show.layers": _cell("show.layers", SHOW_LAYERS_MIXED)})
+    assert C.show_layers_total(lg) == 2600
+    assert C.inv_cross_check({"mixed": lg}) == []

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -140,3 +140,16 @@ def test_diagnostic_flag_honored_and_message_attribution():
     assert ("mis", "diagnostic") in invs
     assert ("q4kbrowse", "diagnostic") in invs
     assert not any(v.leg == "q4kall" for v in vs)
+
+
+def test_load_folds_produce_err_into_stderr_head(tmp_path):
+    d = tmp_path / "results-lg1"
+    d.mkdir()
+    (d / "results-lg1.jsonl").write_text(
+        json.dumps({"type": "meta", "level": "lg1"}) + "\n", encoding="utf-8")
+    (d / "produce-lg1.json").write_text(
+        json.dumps({"name": "lg1", "op": "extract", "level": "browse", "flags": "--quant q4k"}),
+        encoding="utf-8")
+    (d / "produce-lg1.err").write_text("extract stderr, no override warning here", encoding="utf-8")
+    legs = C.load(str(tmp_path / "results-*/results-*.jsonl"))
+    assert "no override warning" in legs["lg1"].produce["stderr_head"]

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -177,3 +177,18 @@ def test_run_strict_fails_on_violation(tmp_path, monkeypatch):
     monkeypatch.setattr(C, "load", lambda g: {"lg": make_leg()})
     assert C.run("x", str(tmp_path/"c.md"), str(tmp_path/"c.json"), strict=True) == 1
     assert C.run("x", str(tmp_path/"c.md"), str(tmp_path/"c.json"), strict=False) == 0
+
+
+def test_non_dict_sidecar_does_not_crash(tmp_path):
+    d = tmp_path / "results-lg"
+    d.mkdir()
+    (d / "results-lg.jsonl").write_text(
+        json.dumps({"type": "meta", "level": "lg"}) + "\n", encoding="utf-8")
+    (d / "produce-lg.json").write_text("[1, 2, 3]", encoding="utf-8")   # valid JSON, not a dict
+    (d / "descriptor-lg.json").write_text("null", encoding="utf-8")
+    legs = C.load(str(tmp_path / "results-*/results-*.jsonl"))
+    assert legs["lg"].produce == {}
+    assert legs["lg"].descriptor == {}
+    # running the full oracle over this leg must not raise
+    C.run(str(tmp_path / "results-*/results-*.jsonl"),
+          str(tmp_path / "m.md"), str(tmp_path / "j.json"), strict=False)

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -153,3 +153,27 @@ def test_load_folds_produce_err_into_stderr_head(tmp_path):
     (d / "produce-lg1.err").write_text("extract stderr, no override warning here", encoding="utf-8")
     legs = C.load(str(tmp_path / "results-*/results-*.jsonl"))
     assert "no override warning" in legs["lg1"].produce["stderr_head"]
+
+
+def test_transformation_report_surfaces_gaps():
+    legs = {
+        "qwen.q4k": make_leg("qwen.q4k",
+            produce={"op": "extract", "flags": "--quant q4k"},
+            descriptor={"family": "qwen2", "observed_quant": "q4k"}),
+        "bitnet.gguf": make_leg("bitnet.gguf",
+            produce={"op": "gguf-to-vindex", "flags": ""},
+            descriptor={"family": "bitnet", "observed_quant": "none"}),
+    }
+    md = "\n".join(C.transformation_report(legs))
+    assert "Transformation" in md
+    assert "qwen2" in md and "bitnet" in md
+    # gaps surfaced verbatim
+    assert "Ollama" in md and "GGUF" in md
+    assert "no compiled" in md.lower() or "gap" in md.lower()
+
+
+def test_run_strict_fails_on_violation(tmp_path, monkeypatch):
+    monkeypatch.setattr(C, "INVARIANTS", [lambda legs: [C.Violation("x", "lg", "", "boom")]])
+    monkeypatch.setattr(C, "load", lambda g: {"lg": make_leg()})
+    assert C.run("x", str(tmp_path/"c.md"), str(tmp_path/"c.json"), strict=True) == 1
+    assert C.run("x", str(tmp_path/"c.md"), str(tmp_path/"c.json"), strict=False) == 0

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -74,3 +74,16 @@ def test_no_crash_flags_panic_and_crash_not_graceful():
     flagged = sorted({v.leg for v in vs})
     assert flagged == ["crash", "panic", "produce_panic"]
     assert all(v.invariant == "no-crash" for v in vs)
+
+
+def test_descriptor_match_flags_quant_mismatch_and_generic_fallback():
+    legs = {
+        "ok": make_leg("ok", descriptor={"name": "ok", "quant_match": True, "family": "qwen2"}),
+        "dequant": make_leg("dequant", descriptor={"name": "dequant", "quant_match": False,
+                            "observed_quant": "none", "expect_quant": "q4k", "family": "qwen2"}),
+        "generic": make_leg("generic", descriptor={"name": "generic", "quant_match": True, "family": "generic"}),
+        "nodesc": make_leg("nodesc", descriptor={}),
+    }
+    vs = C.inv_descriptor_match(legs)
+    assert sorted({v.leg for v in vs}) == ["dequant", "generic"]
+    assert all(v.invariant == "descriptor-match" for v in vs)

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -33,3 +33,23 @@ def test_run_with_empty_registry_is_green(tmp_path, monkeypatch):
     code = C.run("x", str(tmp_path / "c.md"), str(tmp_path / "c.json"), strict=True)
     assert code == 0
     assert json.loads((tmp_path / "c.json").read_text())["violations"] == []
+
+
+def _cell(cid, stdout="", bucket="ok", exit_code=0, err_signal=0, err_line="", stderr=""):
+    return {"id": cid, "bucket": bucket, "exit_code": exit_code, "err_signal": err_signal,
+            "err_line": err_line, "stdout_head": stdout, "stderr_head": stderr}
+
+
+def test_feature_count_parses_banner_with_suffix():
+    lg = make_leg(cells={"stats": _cell("stats", "Using: x (24 layers, 116.7K features, m)")})
+    assert C.feature_count(lg) == 116700
+    lg0 = make_leg(cells={"stats": _cell("stats", "Using: x (24 layers, 0 features, m)")})
+    assert C.feature_count(lg0) == 0
+
+
+def test_completeness_flags_hollow_vindex():
+    hollow = make_leg("granite", cells={"stats": _cell("stats", "(24 layers, 0 features, m)")})
+    healthy = make_leg("qwen", cells={"stats": _cell("stats", "(24 layers, 5K features, m)")})
+    vs = C.inv_completeness({"granite": hollow, "qwen": healthy})
+    assert [v.leg for v in vs] == ["granite"]
+    assert vs[0].invariant == "completeness"

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -1,0 +1,35 @@
+import json, os, sys
+sys.path.insert(0, os.path.dirname(__file__))
+import conformance as C
+
+
+def make_leg(name="lg", cells=None, descriptor=None, produce=None, meta=None):
+    return C.Leg(name=name, meta=meta or {"level": name},
+                 cells=cells or {}, descriptor=descriptor or {},
+                 produce=produce or {})
+
+
+def test_load_reads_meta_cells_descriptor_produce(tmp_path):
+    d = tmp_path / "results-lgA"
+    d.mkdir()
+    (d / "results-lgA.jsonl").write_text(
+        json.dumps({"type": "meta", "level": "lgA"}) + "\n" +
+        json.dumps({"level": "lgA", "id": "stats", "bucket": "ok",
+                    "exit_code": 0, "stdout_head": "(24 layers, 5K features, m)"}) + "\n",
+        encoding="utf-8")
+    (d / "descriptor-lgA.json").write_text(json.dumps({"name": "lgA", "family": "qwen2"}), encoding="utf-8")
+    (d / "produce-lgA.json").write_text(json.dumps({"name": "lgA", "op": "extract", "bucket": "ok"}), encoding="utf-8")
+    legs = C.load(str(tmp_path / "results-*/results-*.jsonl"))
+    assert set(legs) == {"lgA"}
+    assert legs["lgA"].cells["stats"]["bucket"] == "ok"
+    assert legs["lgA"].descriptor["family"] == "qwen2"
+    assert legs["lgA"].produce["op"] == "extract"
+
+
+def test_run_with_empty_registry_is_green(tmp_path, monkeypatch):
+    monkeypatch.setattr(C, "INVARIANTS", [])
+    legs = {"lg": make_leg()}
+    monkeypatch.setattr(C, "load", lambda g: legs)
+    code = C.run("x", str(tmp_path / "c.md"), str(tmp_path / "c.json"), strict=True)
+    assert code == 0
+    assert json.loads((tmp_path / "c.json").read_text())["violations"] == []

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -60,3 +60,17 @@ def test_feature_count_tolerates_malformed_banner():
     assert C.feature_count(lg) is None
     lg2 = make_leg(cells={"stats": _cell("stats", "(24 layers, 1.2.3 features, m)")})
     assert C.feature_count(lg2) is None
+
+
+def test_no_crash_flags_panic_and_crash_not_graceful():
+    legs = {
+        "panic": make_leg("panic", cells={"infer.top5": _cell("infer.top5", bucket="err", exit_code=101)}),
+        "crash": make_leg("crash", cells={"x": _cell("x", bucket="crash", exit_code=137)}),
+        "graceful": make_leg("graceful", cells={"infer.top5": _cell("infer.top5", bucket="ok", exit_code=0, err_signal=1, err_line="Error: requires model weights")}),
+        "cleanerr": make_leg("cleanerr", cells={"y": _cell("y", bucket="err", exit_code=3)}),
+        "produce_panic": make_leg("pp", produce={"bucket": "crash", "exit_code": 139}),
+    }
+    vs = C.inv_no_crash(legs)
+    flagged = sorted({v.leg for v in vs})
+    assert flagged == ["crash", "panic", "produce_panic"]
+    assert all(v.invariant == "no-crash" for v in vs)

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -53,3 +53,10 @@ def test_completeness_flags_hollow_vindex():
     vs = C.inv_completeness({"granite": hollow, "qwen": healthy})
     assert [v.leg for v in vs] == ["granite"]
     assert vs[0].invariant == "completeness"
+
+
+def test_feature_count_tolerates_malformed_banner():
+    lg = make_leg(cells={"stats": _cell("stats", "(24 layers, . features, m)")})
+    assert C.feature_count(lg) is None
+    lg2 = make_leg(cells={"stats": _cell("stats", "(24 layers, 1.2.3 features, m)")})
+    assert C.feature_count(lg2) is None

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -55,6 +55,41 @@ def test_completeness_flags_hollow_vindex():
     assert vs[0].invariant == "completeness"
 
 
+def test_produce_failure_is_distinct_produce_violation_not_hollow():
+    # fp4-like: produce FAILED (exit 1, err bucket), descriptor knows produced=False,
+    # and every corpus cell errored so there is no feature banner. This must be a
+    # definitive `produce` violation, NOT a hedged completeness/hollow one.
+    fp4 = make_leg("qwen15.xform.fp4",
+                   cells={"stats": _cell("stats", "Error: vindex not found", err_signal=1)},
+                   descriptor={"produced": False, "quant_match": False},
+                   produce={"op": "quantize-fp4", "bucket": "err", "exit_code": 1})
+    # a genuinely produced-but-hollow leg (granite-like) must STAY a completeness/hollow
+    hollow = make_leg("granite",
+                      cells={"stats": _cell("stats", "(24 layers, 0 features, m)")},
+                      descriptor={"produced": True},
+                      produce={"op": "extract", "bucket": "ok", "exit_code": 0})
+    legs = {"qwen15.xform.fp4": fp4, "granite": hollow}
+
+    prod = C.inv_produce(legs)
+    assert [v.leg for v in prod] == ["qwen15.xform.fp4"]
+    assert prod[0].invariant == "produce"
+    assert "1" in prod[0].detail  # the exit code is surfaced
+
+    comp = C.inv_completeness(legs)
+    # the produce-failed leg is NOT reported as hollow; only the real hollow is
+    assert [v.leg for v in comp] == ["granite"]
+
+
+def test_produce_crash_left_to_no_crash_not_double_reported():
+    # a produce CRASH (137) is already handled by inv_no_crash; inv_produce must
+    # not also report it (avoid double-counting the same failure).
+    crash = make_leg("boom", descriptor={"produced": False},
+                     produce={"op": "extract", "bucket": "crash", "exit_code": 137})
+    legs = {"boom": crash}
+    assert any(v.invariant == "no-crash" and v.cell == "produce" for v in C.inv_no_crash(legs))
+    assert C.inv_produce(legs) == []
+
+
 def test_feature_count_tolerates_malformed_banner():
     lg = make_leg(cells={"stats": _cell("stats", "(24 layers, . features, m)")})
     assert C.feature_count(lg) is None

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -87,3 +87,25 @@ def test_descriptor_match_flags_quant_mismatch_and_generic_fallback():
     vs = C.inv_descriptor_match(legs)
     assert sorted({v.leg for v in vs}) == ["dequant", "generic"]
     assert all(v.invariant == "descriptor-match" for v in vs)
+
+
+SHOW_LAYERS_HOLLOW = ("Layer      Features  With Meta       Top Token\n"
+                      "------------------------------------------------\n"
+                      "L0                0          0\n"
+                      "L1                0          0\n")
+SHOW_LAYERS_OK = ("Layer      Features  With Meta       Top Token\n"
+                  "------------------------------------------------\n"
+                  "L0             2560          0\n"
+                  "L1             2560          0\n")
+
+
+def test_cross_check_flags_show_layers_zero_vs_stats_nonzero():
+    bad = make_leg("bad", cells={
+        "stats": _cell("stats", "(24 layers, 5K features, m)"),
+        "show.layers": _cell("show.layers", SHOW_LAYERS_HOLLOW)})
+    good = make_leg("good", cells={
+        "stats": _cell("stats", "(24 layers, 5K features, m)"),
+        "show.layers": _cell("show.layers", SHOW_LAYERS_OK)})
+    vs = C.inv_cross_check({"bad": bad, "good": good})
+    assert [v.leg for v in vs] == ["bad"]
+    assert vs[0].invariant == "cross-check"

--- a/scripts/lql_matrix/conformance_test.py
+++ b/scripts/lql_matrix/conformance_test.py
@@ -123,3 +123,20 @@ def test_cross_check_no_false_positive_on_ksuffix_rows():
         "show.layers": _cell("show.layers", SHOW_LAYERS_MIXED)})
     assert C.show_layers_total(lg) == 2600
     assert C.inv_cross_check({"mixed": lg}) == []
+
+
+def test_diagnostic_flag_honored_and_message_attribution():
+    silent_override = make_leg("q4kbrowse",
+        produce={"op": "extract", "level": "browse", "flags": "--quant q4k",
+                 "stdout_head": "Extracting…", "stderr_head": ""})
+    honored = make_leg("q4kall",
+        produce={"op": "extract", "level": "all", "flags": "--quant q4k",
+                 "stdout_head": "Extracting…", "stderr_head": ""})
+    misattrib = make_leg("mis", produce={"op": "extract", "level": "all", "flags": ""},
+        cells={"infer.top5": _cell("infer.top5", bucket="err", exit_code=101,
+               err_line="panicked: FFN weight tensor missing — this is a `--compact` vindex")})
+    vs = C.inv_diagnostic({"q4kbrowse": silent_override, "q4kall": honored, "mis": misattrib})
+    invs = sorted((v.leg, v.invariant) for v in vs)
+    assert ("mis", "diagnostic") in invs
+    assert ("q4kbrowse", "diagnostic") in invs
+    assert not any(v.leg == "q4kall" for v in vs)

--- a/scripts/lql_matrix/descriptor.py
+++ b/scripts/lql_matrix/descriptor.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Read a produced vindex's index.json and emit its structural descriptor as JSON,
+compared against the leg's expected quant. Descriptive only — records what the
+produce recipe actually yielded (family/dtype/quant/has_model_weights, and whether
+a bitnet ternary layout was retained), so extraction/conversion breakage or silent
+dequantization is observed on the current binary rather than assumed.
+
+Usage: descriptor.py <vindex_dir> <leg_name> <expect_quant>
+"""
+import json
+import os
+import sys
+
+
+def main():
+    vindex, name, expect = sys.argv[1], sys.argv[2], sys.argv[3]
+    d = {"name": name, "expect_quant": expect, "produced": os.path.isdir(vindex)}
+    idx_path = os.path.join(vindex, "index.json")
+    try:
+        idx = json.load(open(idx_path, encoding="utf-8"))
+        d.update({
+            "family": idx.get("family"),
+            "dtype": idx.get("dtype"),
+            "quant": idx.get("quant"),
+            "has_model_weights": idx.get("has_model_weights"),
+            "num_layers": idx.get("num_layers"),
+            "hidden_size": idx.get("hidden_size"),
+            "bitnet_layout": idx.get("bitnet_layout") is not None,
+        })
+        # ternary is signalled by the bitnet_layout sidecar, not the quant field
+        observed = "ternary" if d["bitnet_layout"] else d.get("quant")
+        d["observed_quant"] = observed
+        d["quant_match"] = (observed == expect)
+    except Exception as e:  # missing/malformed index.json is itself a finding
+        d.update({"error": str(e), "observed_quant": None, "quant_match": False})
+    print(json.dumps(d))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lql_matrix/gen_legs.py
+++ b/scripts/lql_matrix/gen_legs.py
@@ -1,21 +1,25 @@
 #!/usr/bin/env python3
-"""Emit the full leg list for the LQL strategy matrix as a JSON array (one object
-per parallel CI job). A "leg" is a (source × produce-recipe × level) tuple: the
-recipe produces a vindex, then the command corpus runs against it.
+"""Emit the leg list for the LQL strategy matrix as a JSON array (one object per
+parallel CI job). A "leg" is a (source × produce-recipe) that yields a vindex; the
+per-vindex command corpus then runs against it.
 
-Design rule (see the matrix README + discussion): include EVERY CLI-invokable
-combination — do NOT prune by predicted meaninglessness. E.g. `--quant q4k` is
-crossed with every level, not just `all`, precisely to test the doc claim that it
-"implies --level all". A leg is omitted only when it is structurally un-formable
-(e.g. a convert recipe with no GGUF source). Predictions live as `expect_quant`
-oracles, not as omissions.
+Design (decoupled axes — see docs/superpowers + tracker discussion):
+  * NATIVE EXTRACTION axis — the real "test each level independently": every model
+    extracted at every level {browse, attention, inference, all} at native precision.
+  * TRANSFORMATION axis — tested ONCE at level=all, NOT multiplied by the level grid
+    (a transformation like `--quant q4k` implies --level all, so crossing it with
+    levels only homogenises; that redundancy is now asserted, not re-run — see #275).
+    A single level sentinel (q4k.browse on the baseline) lets the conformance layer
+    assert the level-invariance still holds, so a future fix to #275 is caught.
+  * ENCODING/CONVERT axis — GGUF ingestion, including BitNet native I2_S ternary via
+    `--keep-quant`. GGUF legs carry `tokenizer_repo` so the workflow can stage the
+    base repo's tokenizer.json beside the .gguf (the -gguf repo ships none; #180/#277).
 
-Each leg: name (artifact-safe), hf (repo for snapshot_download + corpus_model),
-source_kind, op, level, flags, expect_quant.
+Leg fields: name, hf, corpus_model, source_kind, op, level, flags, expect_quant,
+tokenizer_repo (only set for gguf legs).
 """
 import json
 
-# (short-id, HF repo) — all MIT/Apache, ungated.
 SAFETENSORS = [
     ("qwen05",    "Qwen/Qwen2.5-Coder-0.5B-Instruct"),
     ("smol135",   "HuggingFaceTB/SmolLM2-135M-Instruct"),
@@ -25,48 +29,53 @@ SAFETENSORS = [
     ("bitnet2b",  "microsoft/bitnet-b1.58-2B-4T"),
 ]
 LEVELS = ["browse", "attention", "inference", "all"]
-# quant-state axis: (id, extract-flags, expected quant in produced index.json)
-QUANTS = [("f16", "", "none"), ("f32", "--f32", "none"), ("q4k", "--quant q4k", "q4k")]
 
-# GGUF sources for the convert path: (short-id, gguf repo, corpus model id)
+# GGUF source for the convert/ternary path: (id, gguf repo, base repo w/ tokenizer)
 GGUF = [("bitnetgguf", "microsoft/bitnet-b1.58-2B-4T-gguf", "microsoft/bitnet-b1.58-2B-4T")]
-GGUF_LEVELS = ["browse", "inference", "all"]  # gguf-to-vindex's supported levels
-# dequantize (default) vs retain native ternary
-GGUF_QUANT = [("dequant", "", "none"), ("keepq", "--keep-quant", "ternary")]
+
+
+def leg(name, hf, op, level="all", flags="", expect_quant="none",
+        source_kind="safetensors", corpus_model=None, tokenizer_repo=""):
+    return {"name": name, "hf": hf, "corpus_model": corpus_model or hf,
+            "source_kind": source_kind, "op": op, "level": level, "flags": flags,
+            "expect_quant": expect_quant, "tokenizer_repo": tokenizer_repo}
 
 
 def main():
     legs = []
 
-    # extract path: full quant × level grid per safetensors source
+    # 1. NATIVE EXTRACTION — full level grid per model, native precision (f16).
     for mid, hf in SAFETENSORS:
-        for qid, qflags, eq in QUANTS:
-            for lv in LEVELS:
-                legs.append({
-                    "name": f"{mid}.{qid}.{lv}", "hf": hf, "corpus_model": hf,
-                    "source_kind": "safetensors", "op": "extract",
-                    "level": lv, "flags": qflags, "expect_quant": eq,
-                })
+        for lv in LEVELS:
+            legs.append(leg(f"{mid}.native.{lv}", hf, "extract", level=lv))
 
-    # convert path: gguf-to-vindex, dequant vs keep-quant, across its levels
-    for mid, ghf, cm in GGUF:
-        for lv in GGUF_LEVELS:
-            for kid, kflags, eq in GGUF_QUANT:
-                legs.append({
-                    "name": f"{mid}.{kid}.{lv}", "hf": ghf, "corpus_model": cm,
-                    "source_kind": "gguf", "op": "gguf-to-vindex",
-                    "level": lv, "flags": kflags, "expect_quant": eq,
-                })
+    # 2. TRANSFORMATIONS — one all-level leg each (no level cross).
+    #    q4k requantize per model (arch × quant coverage; re-catches the MoE panic #273).
+    for mid, hf in SAFETENSORS:
+        legs.append(leg(f"{mid}.xform.q4k", hf, "extract", level="all",
+                        flags="--quant q4k", expect_quant="q4k"))
+    #    level-invariance sentinel: one q4k at a non-all level, asserted ≡ q4k.all (#275).
+    legs.append(leg("qwen05.xform.q4k-sentinel-browse",
+                    "Qwen/Qwen2.5-Coder-0.5B-Instruct", "extract",
+                    level="browse", flags="--quant q4k", expect_quant="q4k"))
+    #    post-hoc requant invariants: quantize q4k (assert ≡ inline) + fp4 (hidden%256==0).
+    legs.append(leg("qwen05.xform.posthoc-q4k", "Qwen/Qwen2.5-Coder-0.5B-Instruct",
+                    "quantize-q4k", level="inference", expect_quant="q4k"))
+    legs.append(leg("qwen15.xform.fp4", "Qwen/Qwen2.5-1.5B-Instruct",
+                    "quantize-fp4", level="inference", expect_quant="fp4"))  # 1536 % 256 == 0
+    #    f32 side-channel path coverage: one leg on a small model.
+    legs.append(leg("smol135.xform.f32", "HuggingFaceTB/SmolLM2-135M-Instruct",
+                    "extract", level="all", flags="--f32", expect_quant="none"))
 
-    # post-hoc requantize on the baseline (invariant vs inline extract --quant q4k;
-    # + the FP4 store path). Source needs --level inference/all; job extracts first.
-    for sub, eq in [("q4k", "q4k"), ("fp4", "fp4")]:
-        legs.append({
-            "name": f"qwen05.quantize.{sub}", "hf": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
-            "corpus_model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
-            "source_kind": "safetensors", "op": f"quantize-{sub}",
-            "level": "inference", "flags": "", "expect_quant": eq,
-        })
+    # 3. GGUF / BitNet ternary — tokenizer staged from the base repo (fixes the #180 wall).
+    for mid, ghf, tok in GGUF:
+        for lv in ["inference", "all"]:
+            legs.append(leg(f"{mid}.ternary.{lv}", ghf, "gguf-to-vindex", level=lv,
+                            flags="--keep-quant", expect_quant="ternary",
+                            source_kind="gguf", corpus_model=tok, tokenizer_repo=tok))
+        legs.append(leg(f"{mid}.dequant.all", ghf, "gguf-to-vindex", level="all",
+                        expect_quant="none", source_kind="gguf",
+                        corpus_model=tok, tokenizer_repo=tok))
 
     print(json.dumps(legs))
 

--- a/scripts/lql_matrix/gen_legs.py
+++ b/scripts/lql_matrix/gen_legs.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Emit the full leg list for the LQL strategy matrix as a JSON array (one object
+per parallel CI job). A "leg" is a (source × produce-recipe × level) tuple: the
+recipe produces a vindex, then the command corpus runs against it.
+
+Design rule (see the matrix README + discussion): include EVERY CLI-invokable
+combination — do NOT prune by predicted meaninglessness. E.g. `--quant q4k` is
+crossed with every level, not just `all`, precisely to test the doc claim that it
+"implies --level all". A leg is omitted only when it is structurally un-formable
+(e.g. a convert recipe with no GGUF source). Predictions live as `expect_quant`
+oracles, not as omissions.
+
+Each leg: name (artifact-safe), hf (repo for snapshot_download + corpus_model),
+source_kind, op, level, flags, expect_quant.
+"""
+import json
+
+# (short-id, HF repo) — all MIT/Apache, ungated.
+SAFETENSORS = [
+    ("qwen05",    "Qwen/Qwen2.5-Coder-0.5B-Instruct"),
+    ("smol135",   "HuggingFaceTB/SmolLM2-135M-Instruct"),
+    ("smol360",   "HuggingFaceTB/SmolLM2-360M-Instruct"),
+    ("qwen15",    "Qwen/Qwen2.5-1.5B-Instruct"),
+    ("granite1b", "ibm-granite/granite-3.0-1b-a400m-instruct"),
+    ("bitnet2b",  "microsoft/bitnet-b1.58-2B-4T"),
+]
+LEVELS = ["browse", "attention", "inference", "all"]
+# quant-state axis: (id, extract-flags, expected quant in produced index.json)
+QUANTS = [("f16", "", "none"), ("f32", "--f32", "none"), ("q4k", "--quant q4k", "q4k")]
+
+# GGUF sources for the convert path: (short-id, gguf repo, corpus model id)
+GGUF = [("bitnetgguf", "microsoft/bitnet-b1.58-2B-4T-gguf", "microsoft/bitnet-b1.58-2B-4T")]
+GGUF_LEVELS = ["browse", "inference", "all"]  # gguf-to-vindex's supported levels
+# dequantize (default) vs retain native ternary
+GGUF_QUANT = [("dequant", "", "none"), ("keepq", "--keep-quant", "ternary")]
+
+
+def main():
+    legs = []
+
+    # extract path: full quant × level grid per safetensors source
+    for mid, hf in SAFETENSORS:
+        for qid, qflags, eq in QUANTS:
+            for lv in LEVELS:
+                legs.append({
+                    "name": f"{mid}.{qid}.{lv}", "hf": hf, "corpus_model": hf,
+                    "source_kind": "safetensors", "op": "extract",
+                    "level": lv, "flags": qflags, "expect_quant": eq,
+                })
+
+    # convert path: gguf-to-vindex, dequant vs keep-quant, across its levels
+    for mid, ghf, cm in GGUF:
+        for lv in GGUF_LEVELS:
+            for kid, kflags, eq in GGUF_QUANT:
+                legs.append({
+                    "name": f"{mid}.{kid}.{lv}", "hf": ghf, "corpus_model": cm,
+                    "source_kind": "gguf", "op": "gguf-to-vindex",
+                    "level": lv, "flags": kflags, "expect_quant": eq,
+                })
+
+    # post-hoc requantize on the baseline (invariant vs inline extract --quant q4k;
+    # + the FP4 store path). Source needs --level inference/all; job extracts first.
+    for sub, eq in [("q4k", "q4k"), ("fp4", "fp4")]:
+        legs.append({
+            "name": f"qwen05.quantize.{sub}", "hf": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
+            "corpus_model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
+            "source_kind": "safetensors", "op": f"quantize-{sub}",
+            "level": "inference", "flags": "", "expect_quant": eq,
+        })
+
+    print(json.dumps(legs))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lql_matrix/peak_rss.py
+++ b/scripts/lql_matrix/peak_rss.py
@@ -1,0 +1,41 @@
+"""Peak RSS across one or more `/usr/bin/time -v` output files.
+
+The strategy-matrix produce step runs several commands (e.g. extract → quantize).
+The true peak RSS is the MAX 'Maximum resident set size' across ALL of them — not
+just the last/wrapped one. Wrapping only the final command under-reports the peak
+(a failed fast quantize hides a multi-GB extract), corrupting the resource audit.
+"""
+import re
+import sys
+from pathlib import Path
+
+_RSS = re.compile(r"Maximum resident set size.*?:\s*(\d+)", re.I)
+
+
+def parse_rss_kb(text):
+    """The 'Maximum resident set size (kbytes)' from one /usr/bin/time -v output, or None."""
+    m = _RSS.search(text or "")
+    return int(m.group(1)) if m else None
+
+
+def peak_rss_kb(paths):
+    """Max RSS (kB) across the given time-output files; None if none parse.
+    Missing/unparseable files are ignored (not an error)."""
+    vals = []
+    for p in paths:
+        try:
+            v = parse_rss_kb(Path(p).read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            v = None
+        if v is not None:
+            vals.append(v)
+    return max(vals) if vals else None
+
+
+def main():
+    peak = peak_rss_kb(sys.argv[1:])
+    print(peak if peak is not None else "")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lql_matrix/peak_rss_test.py
+++ b/scripts/lql_matrix/peak_rss_test.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import peak_rss as P
+
+# A representative `/usr/bin/time -v` output block.
+TIME_EXTRACT = """\
+\tCommand being timed: "larql extract qwen15 -o out/x.vindex.src --level inference"
+\tUser time (seconds): 700.12
+\tMaximum resident set size (kbytes): 4400000
+\tExit status: 0
+"""
+TIME_QUANTIZE_FAIL = """\
+\tCommand being timed: "larql convert quantize fp4 --input out/x.vindex.src"
+\tUser time (seconds): 0.10
+\tMaximum resident set size (kbytes): 17808
+\tExit status: 1
+"""
+
+
+def test_parse_rss_from_time_output():
+    assert P.parse_rss_kb(TIME_EXTRACT) == 4400000
+    assert P.parse_rss_kb(TIME_QUANTIZE_FAIL) == 17808
+
+
+def test_parse_rss_none_when_absent():
+    assert P.parse_rss_kb("no rss line here") is None
+    assert P.parse_rss_kb("") is None
+    assert P.parse_rss_kb(None) is None
+
+
+def test_peak_is_max_across_files(tmp_path):
+    # the fp4 case: extract command peaks high, the failed quantize peaks tiny —
+    # the true peak is the extract's, not the last (quantize) command's.
+    a = tmp_path / "t.src"
+    b = tmp_path / "t"
+    a.write_text(TIME_EXTRACT)
+    b.write_text(TIME_QUANTIZE_FAIL)
+    assert P.peak_rss_kb([str(a), str(b)]) == 4400000
+    assert P.peak_rss_kb([str(b), str(a)]) == 4400000  # order-independent
+
+
+def test_missing_and_unparseable_files_ignored(tmp_path):
+    good = tmp_path / "g"
+    good.write_text(TIME_EXTRACT)
+    missing = tmp_path / "nope"
+    empty = tmp_path / "e"
+    empty.write_text("garbage")
+    assert P.peak_rss_kb([str(missing), str(good), str(empty)]) == 4400000
+    assert P.peak_rss_kb([str(missing)]) is None
+    assert P.peak_rss_kb([]) is None

--- a/scripts/lql_matrix/run_matrix.py
+++ b/scripts/lql_matrix/run_matrix.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""LQL strategy-matrix runner — EMPIRICAL, NOT a validation suite.
+
+Runs every LQL command in a corpus against one already-extracted vindex and
+records RAW MECHANICAL OUTCOMES ONLY per cell: exit code, coarse bucket
+(ok / err / timeout / crash), wall duration, peak RSS, and an *error-text
+signal* (did stdout/stderr contain an error/refusal even though the process
+exited 0 — `larql lql` exits 0 on in-band errors). It makes NO judgement about
+whether output is "correct"; a break is data to read. A failing cell never
+aborts the run.
+
+I/O practices (deliberate):
+  * FULL stdout/stderr of every cell are written to per-cell files under
+    <out_dir>/cells/ and kept for artifact upload — nothing is captured then
+    discarded, and a panic's backtrace TAIL survives.
+  * Stream *content* never transits the shell argv. This driver reads the
+    captured files itself (utf-8, errors="replace") and truncates by CODEPOINT,
+    so a multibyte boundary can never corrupt a row.
+  * One process orchestrates each cell via an argv list (no shell, no
+    injection); WRAP is shlex-split so containment prefixes compose cleanly.
+
+Usage:   run_matrix.py <level> <vindex_dir> <corpus.jsonl> <out.jsonl>
+Env:     LARQL_BIN (default target/release/larql), MODEL_ID, TMPROOT,
+         WRAP (e.g. "larql-probe safe --mem 5600 --"), CELL_TIMEOUT (default 900),
+         plus GITHUB_SHA / RUNNER_OS / RUST_BACKTRACE recorded as provenance.
+"""
+import datetime
+import json
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+
+# larql prints "Error: …" for in-band failures and Rust prints "… panicked at …";
+# case-sensitive on purpose — matches what larql/Rust actually emit, avoids
+# flagging benign prose that merely contains the word "error".
+ERR_RE = re.compile(r"Error:|panicked|Parse error|note: run with RUST_BACKTRACE")
+RSS_RE = re.compile(r"Maximum resident set size.*?:\s*(\d+)")
+CLIP = 800  # codepoint budget for head/tail snapshots in the JSONL
+
+
+def bucket_for(rc: int) -> str:
+    if rc == 0:
+        return "ok"
+    if rc == 124:
+        return "timeout"
+    if rc in (137, 139, 134) or (rc < 0 and -rc in (9, 11, 6)):
+        return "crash"  # SIGKILL(OOM)/SIGSEGV/SIGABRT
+    return "err"
+
+
+def first_error_line(text: str) -> str:
+    for ln in text.splitlines():
+        if ERR_RE.search(ln):
+            return ln.strip()[:200]
+    return ""
+
+
+def main() -> None:
+    level, vindex, corpus, out = sys.argv[1:5]
+    larql = os.environ.get("LARQL_BIN", "target/release/larql")
+    model = os.environ.get("MODEL_ID", "")
+    tmproot = os.environ.get("TMPROOT") or tempfile.mkdtemp()
+    wrap = shlex.split(os.environ.get("WRAP", ""))
+    cell_timeout = os.environ.get("CELL_TIMEOUT", "900")
+    os.makedirs(tmproot, exist_ok=True)
+
+    out_path = pathlib.Path(out)
+    cells_dir = out_path.parent / "cells"
+    cells_dir.mkdir(parents=True, exist_ok=True)
+    time_bin = "/usr/bin/time" if pathlib.Path("/usr/bin/time").exists() else None
+
+    def subst(s: str) -> str:
+        return (s.replace("{{VINDEX}}", vindex)
+                 .replace("{{MODEL}}", model)
+                 .replace("{{TMP}}", tmproot))
+
+    # ── provenance row (anchors the artifact to a commit/binary/model/runner) ──
+    try:
+        ver = subprocess.run([larql, "--version"], capture_output=True,
+                             text=True, timeout=30).stdout.strip()
+    except Exception:
+        ver = ""
+    meta = {
+        "type": "meta", "level": level, "larql_version": ver,
+        "commit": os.environ.get("GITHUB_SHA", ""),
+        "model": model, "runner_os": os.environ.get("RUNNER_OS", ""),
+        "vindex": vindex, "backtrace": os.environ.get("RUST_BACKTRACE", ""),
+        "time_bin": bool(time_bin), "wrap": " ".join(wrap),
+        "started_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    with out_path.open("w", encoding="utf-8") as f:
+        f.write(json.dumps(meta) + "\n")
+
+    n = 0
+    with open(corpus, encoding="utf-8") as cf:
+        for line in cf:
+            line = line.strip()
+            if not line:
+                continue
+            c = json.loads(line)
+            cid, cat, lql = c["id"], c.get("cat", ""), subst(c["lql"])
+
+            outf = cells_dir / f"{level}.{cid}.out"
+            errf = cells_dir / f"{level}.{cid}.err"
+            timef = cells_dir / f"{level}.{cid}.time"
+
+            argv = ["timeout", "--kill-after=10", cell_timeout, *wrap]
+            if time_bin:
+                argv += [time_bin, "-v", "-o", str(timef)]
+            argv += [larql, "lql", lql]
+
+            t0 = time.monotonic()
+            with outf.open("wb") as so, errf.open("wb") as se:
+                rc = subprocess.run(argv, stdout=so, stderr=se).returncode
+            dur_ms = int((time.monotonic() - t0) * 1000)
+            bucket = bucket_for(rc)
+
+            # read the FULL captured streams back (utf-8, tolerant, codepoint-safe)
+            so_b, se_b = outf.read_bytes(), errf.read_bytes()
+            so_txt = so_b.decode("utf-8", "replace")
+            se_txt = se_b.decode("utf-8", "replace")
+            combined = so_txt + "\n" + se_txt
+            err_signal = 1 if ERR_RE.search(combined) else 0
+
+            peak_rss_kb = ""
+            if time_bin and timef.exists():
+                m = RSS_RE.search(timef.read_text("utf-8", "replace"))
+                if m:
+                    peak_rss_kb = int(m.group(1))
+                timef.unlink()  # RSS captured; keep only .out/.err for artifacts
+
+            row = {
+                "level": level, "id": cid, "cat": cat, "lql": lql,
+                "exit_code": rc, "bucket": bucket, "duration_ms": dur_ms,
+                "peak_rss_kb": peak_rss_kb, "err_signal": err_signal,
+                "err_line": first_error_line(combined) if err_signal else "",
+                "stdout_bytes": len(so_b), "stderr_bytes": len(se_b),
+                "stdout_head": so_txt[:CLIP], "stderr_head": se_txt[:CLIP],
+                "stderr_tail": se_txt[-CLIP:],
+            }
+            with out_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(row) + "\n")
+
+            flag = " ERR*" if err_signal else ""
+            print(f"[{level}] {cid} -> exit={rc} {bucket}{flag} "
+                  f"{dur_ms}ms rss={peak_rss_kb}", file=sys.stderr)
+            n += 1
+
+    print(f"wrote {n} rows + provenance to {out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lql_matrix/run_matrix.sh
+++ b/scripts/lql_matrix/run_matrix.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# LQL strategy-matrix runner — EMPIRICAL, NOT a validation suite.
+#
+# Runs every LQL command in a corpus against one already-extracted vindex and
+# records RAW MECHANICAL OUTCOMES ONLY: exit code, wall time, stdout/stderr
+# size + head, and a coarse mechanical bucket (ok / err / timeout). It makes
+# NO judgement about whether output is "correct" — a break is data to read,
+# not something to fix or interpret here. A failing cell never aborts the run.
+#
+# Usage:
+#   run_matrix.sh <level> <vindex_dir> <corpus.jsonl> <out.jsonl>
+# Env:
+#   LARQL_BIN   path to larql binary            (default: target/release/larql)
+#   MODEL_ID    model id/path for EXTRACT/USE MODEL cells (default: empty)
+#   TMPROOT     scratch dir for cells that write outputs (default: mktemp)
+#   WRAP        optional command prefix, e.g. containment on a dev box:
+#               WRAP="larql-probe safe --mem 5600 --"   (default: empty -> CI)
+#   CELL_TIMEOUT  per-command wall cap in seconds (default: 900)
+set -uo pipefail
+
+LEVEL="${1:?level}"; VINDEX="${2:?vindex dir}"; CORPUS="${3:?corpus.jsonl}"; OUT="${4:?out.jsonl}"
+LARQL_BIN="${LARQL_BIN:-target/release/larql}"
+MODEL_ID="${MODEL_ID:-}"
+TMPROOT="${TMPROOT:-$(mktemp -d)}"
+WRAP="${WRAP:-}"
+CELL_TIMEOUT="${CELL_TIMEOUT:-900}"
+mkdir -p "$TMPROOT"
+: > "$OUT"
+
+emit() { # emit one JSONL row via python (safe escaping); args are name=value pairs read from env
+  python3 - "$@" <<'PY'
+import json, sys
+row = {}
+for kv in sys.argv[1:]:
+    k, _, v = kv.partition("=")
+    # ints where sensible
+    if k in ("exit_code","duration_ms","stdout_bytes","stderr_bytes"):
+        try: v = int(v)
+        except ValueError: pass
+    row[k] = v
+print(json.dumps(row))
+PY
+}
+
+row_count=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  id=$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['id'])" "$line")
+  cat=$(python3 -c "import json,sys;print(json.loads(sys.argv[1]).get('cat',''))" "$line")
+  lql=$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['lql'])" "$line")
+  # substitute placeholders
+  lql=${lql//\{\{VINDEX\}\}/$VINDEX}
+  lql=${lql//\{\{MODEL\}\}/$MODEL_ID}
+  lql=${lql//\{\{TMP\}\}/$TMPROOT}
+
+  so=$(mktemp); se=$(mktemp)
+  start=$(date +%s%3N)
+  # shellcheck disable=SC2086
+  timeout "$CELL_TIMEOUT" $WRAP "$LARQL_BIN" lql "$lql" >"$so" 2>"$se"
+  ec=$?
+  end=$(date +%s%3N)
+  dur=$((end - start))
+
+  case "$ec" in
+    0)   bucket=ok ;;
+    124) bucket=timeout ;;
+    137|139|134) bucket=crash ;;   # SIGKILL(OOM)/SIGSEGV/SIGABRT
+    *)   bucket=err ;;
+  esac
+  sob=$(wc -c <"$so" | tr -d ' '); seb=$(wc -c <"$se" | tr -d ' ')
+  sohead=$(head -c 800 "$so"); sehead=$(head -c 800 "$se")
+
+  emit "level=$LEVEL" "id=$id" "cat=$cat" "lql=$lql" \
+       "exit_code=$ec" "bucket=$bucket" "duration_ms=$dur" \
+       "stdout_bytes=$sob" "stderr_bytes=$seb" \
+       "stdout_head=$sohead" "stderr_head=$sehead" >> "$OUT"
+  rm -f "$so" "$se"
+  row_count=$((row_count + 1))
+  echo "[$LEVEL] $id -> exit=$ec bucket=$bucket ${dur}ms" >&2
+done < "$CORPUS"
+
+echo "wrote $row_count rows to $OUT" >&2

--- a/scripts/lql_matrix/run_matrix.sh
+++ b/scripts/lql_matrix/run_matrix.sh
@@ -1,82 +1,9 @@
 #!/usr/bin/env bash
-# LQL strategy-matrix runner — EMPIRICAL, NOT a validation suite.
-#
-# Runs every LQL command in a corpus against one already-extracted vindex and
-# records RAW MECHANICAL OUTCOMES ONLY: exit code, wall time, stdout/stderr
-# size + head, and a coarse mechanical bucket (ok / err / timeout). It makes
-# NO judgement about whether output is "correct" — a break is data to read,
-# not something to fix or interpret here. A failing cell never aborts the run.
-#
-# Usage:
-#   run_matrix.sh <level> <vindex_dir> <corpus.jsonl> <out.jsonl>
-# Env:
-#   LARQL_BIN   path to larql binary            (default: target/release/larql)
-#   MODEL_ID    model id/path for EXTRACT/USE MODEL cells (default: empty)
-#   TMPROOT     scratch dir for cells that write outputs (default: mktemp)
-#   WRAP        optional command prefix, e.g. containment on a dev box:
-#               WRAP="larql-probe safe --mem 5600 --"   (default: empty -> CI)
-#   CELL_TIMEOUT  per-command wall cap in seconds (default: 900)
+# Thin entrypoint → run_matrix.py (the real runner). Kept so the workflow and
+# README keep a stable `run_matrix.sh <level> <vindex> <corpus> <out>` API while
+# the capture logic lives in Python, where UTF-8 handling, codepoint-safe
+# truncation, full-stream files, and shell-free subprocess orchestration are
+# correct by construction. All configuration is via env (see run_matrix.py):
+#   LARQL_BIN  MODEL_ID  TMPROOT  WRAP  CELL_TIMEOUT
 set -uo pipefail
-
-LEVEL="${1:?level}"; VINDEX="${2:?vindex dir}"; CORPUS="${3:?corpus.jsonl}"; OUT="${4:?out.jsonl}"
-LARQL_BIN="${LARQL_BIN:-target/release/larql}"
-MODEL_ID="${MODEL_ID:-}"
-TMPROOT="${TMPROOT:-$(mktemp -d)}"
-WRAP="${WRAP:-}"
-CELL_TIMEOUT="${CELL_TIMEOUT:-900}"
-mkdir -p "$TMPROOT"
-: > "$OUT"
-
-emit() { # emit one JSONL row via python (safe escaping); args are name=value pairs read from env
-  python3 - "$@" <<'PY'
-import json, sys
-row = {}
-for kv in sys.argv[1:]:
-    k, _, v = kv.partition("=")
-    # ints where sensible
-    if k in ("exit_code","duration_ms","stdout_bytes","stderr_bytes"):
-        try: v = int(v)
-        except ValueError: pass
-    row[k] = v
-print(json.dumps(row))
-PY
-}
-
-row_count=0
-while IFS= read -r line; do
-  [ -z "$line" ] && continue
-  id=$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['id'])" "$line")
-  cat=$(python3 -c "import json,sys;print(json.loads(sys.argv[1]).get('cat',''))" "$line")
-  lql=$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['lql'])" "$line")
-  # substitute placeholders
-  lql=${lql//\{\{VINDEX\}\}/$VINDEX}
-  lql=${lql//\{\{MODEL\}\}/$MODEL_ID}
-  lql=${lql//\{\{TMP\}\}/$TMPROOT}
-
-  so=$(mktemp); se=$(mktemp)
-  start=$(date +%s%3N)
-  # shellcheck disable=SC2086
-  timeout "$CELL_TIMEOUT" $WRAP "$LARQL_BIN" lql "$lql" >"$so" 2>"$se"
-  ec=$?
-  end=$(date +%s%3N)
-  dur=$((end - start))
-
-  case "$ec" in
-    0)   bucket=ok ;;
-    124) bucket=timeout ;;
-    137|139|134) bucket=crash ;;   # SIGKILL(OOM)/SIGSEGV/SIGABRT
-    *)   bucket=err ;;
-  esac
-  sob=$(wc -c <"$so" | tr -d ' '); seb=$(wc -c <"$se" | tr -d ' ')
-  sohead=$(head -c 800 "$so"); sehead=$(head -c 800 "$se")
-
-  emit "level=$LEVEL" "id=$id" "cat=$cat" "lql=$lql" \
-       "exit_code=$ec" "bucket=$bucket" "duration_ms=$dur" \
-       "stdout_bytes=$sob" "stderr_bytes=$seb" \
-       "stdout_head=$sohead" "stderr_head=$sehead" >> "$OUT"
-  rm -f "$so" "$se"
-  row_count=$((row_count + 1))
-  echo "[$LEVEL] $id -> exit=$ec bucket=$bucket ${dur}ms" >&2
-done < "$CORPUS"
-
-echo "wrote $row_count rows to $OUT" >&2
+exec python3 "$(dirname "$0")/run_matrix.py" "$@"

--- a/scripts/lql_matrix/tensor_presence.py
+++ b/scripts/lql_matrix/tensor_presence.py
@@ -88,6 +88,54 @@ def resolve_q8(presence_by_leg, panic_by_leg):
     return {"rows": rows, "biconditional_holds": not counter, "counterexamples": counter}
 
 
+def render_q8(presence_by_leg, violations, native_only=True):
+    """Join presence with observed crash outcomes → Q8 resolution.
+    violations: the conformance.json "violations" list, or None if the artifact
+    was unavailable. Returns a dict with keys: status ∈ {"holds","refuted",
+    "inconclusive"}, biconditional_holds (bool|None), rows, counterexamples,
+    n_native (int), n_risk (int), reason (str)."""
+    def _incon(reason):
+        return {"status": "inconclusive", "biconditional_holds": None, "rows": [],
+                "counterexamples": [], "n_native": 0, "n_risk": 0, "reason": reason}
+    if violations is None:
+        return _incon("conformance data unavailable")
+    # panic := a no-crash violation on a CORPUS cell (produce-time crashes excluded)
+    panicked = {v.get("leg") for v in violations
+                if v.get("invariant") == "no-crash" and v.get("cell") != "produce"}
+    legs = {k: p for k, p in presence_by_leg.items()
+            if (not native_only) or (".native." in k)}
+    if not legs:
+        return _incon("no native legs with a produced listing")
+    n_risk = sum(1 for p in legs.values() if p.get("ffn_unwrap_risk"))
+    n_panic = sum(1 for k in legs if k in panicked)
+    if n_risk == 0 and n_panic == 0:
+        return _incon("no risk legs and no panics observed — nothing to test")
+    panic = {k: (k in panicked) for k in legs}
+    res = resolve_q8(legs, panic)
+    res["status"] = "holds" if res["biconditional_holds"] else "refuted"
+    res["n_native"] = len(legs)
+    res["n_risk"] = n_risk
+    res["reason"] = ""
+    return res
+
+
+def q8_markdown(result):
+    """Render a render_q8() result as the q8.md report."""
+    head = {"holds": "biconditional holds: **True**",
+            "refuted": "biconditional holds: **False**",
+            "inconclusive": "**inconclusive**"}[result["status"]]
+    L = ["# Q8 — panic ⇔ (has_attn ∧ ¬has_ffn)?", "",
+         f"{head} · counterexamples: {len(result['counterexamples'])} "
+         f"· native legs: {result.get('n_native', 0)} · risk legs: {result.get('n_risk', 0)}"]
+    if result.get("reason"):
+        L.append(f"reason: {result['reason']}")
+    L += ["", "| leg | ffn_unwrap_risk | panic | agree |", "|---|---|---|---|"]
+    for r in result["rows"]:
+        mark = "✅" if r["agree"] else "❌"
+        L.append(f"| `{r['leg']}` | {r['ffn_unwrap_risk']} | {r['panic']} | {mark} |")
+    return "\n".join(L) + "\n"
+
+
 def main():
     args = sys.argv[1:]
     results_glob = args[0] if args else "artifacts/results-*/manifest-*/listing.json"

--- a/scripts/lql_matrix/tensor_presence.py
+++ b/scripts/lql_matrix/tensor_presence.py
@@ -1,0 +1,50 @@
+"""Tensor-presence witness for the σ-expansion (closes Q8). A produced vindex's
+weight-file listing → a presence vector over weight classes. The presence of
+attention vs FFN weight files at a level is the latent variable explaining why
+some partial/hollow vindexes panic on INFER (guard passes, FFN absent) while
+others refuse gracefully (no attention weights → guard refuses)."""
+import glob
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# vindex weight file → the class it witnesses
+_CLASS = {
+    "attn_weights.bin": "attn",
+    "up_weights.bin": "ffn_up",
+    "down_weights.bin": "ffn_down",
+    "gate_vectors.bin": "gate",
+    "embeddings.bin": "embed",
+    "norms.bin": "norm",
+    "down_meta.bin": "down_meta",
+    "interleaved_kquant.bin": "kquant",
+    "lm_head.bin": "lm_head",
+}
+
+
+def presence(listing):
+    cls = {}
+    for fn, sz in (listing or {}).items():
+        c = _CLASS.get(fn)
+        if c and isinstance(sz, int) and sz > 0:
+            cls[c] = sz
+    has_attn = "attn" in cls
+    has_ffn = ("ffn_up" in cls) and ("ffn_down" in cls)
+    return {
+        "n_files": len(listing or {}),
+        "classes": cls,
+        "has_attn": has_attn,
+        "has_ffn": has_ffn,
+        "has_gate": "gate" in cls,
+        "ffn_unwrap_risk": has_attn and not has_ffn,
+    }
+
+
+def listing_of(vindex_dir):
+    try:
+        return {f: os.path.getsize(os.path.join(vindex_dir, f))
+                for f in os.listdir(vindex_dir)}
+    except OSError:
+        return {}

--- a/scripts/lql_matrix/tensor_presence.py
+++ b/scripts/lql_matrix/tensor_presence.py
@@ -76,6 +76,18 @@ def collect(results_glob):
     return rows
 
 
+def resolve_q8(presence_by_leg, panic_by_leg):
+    rows, counter = [], []
+    for leg in sorted(set(presence_by_leg) & set(panic_by_leg)):
+        risk = bool(presence_by_leg[leg]["ffn_unwrap_risk"])
+        pan = bool(panic_by_leg[leg])
+        agree = (risk == pan)
+        rows.append({"leg": leg, "ffn_unwrap_risk": risk, "panic": pan, "agree": agree})
+        if not agree:
+            counter.append({"leg": leg, "ffn_unwrap_risk": risk, "panic": pan})
+    return {"rows": rows, "biconditional_holds": not counter, "counterexamples": counter}
+
+
 def main():
     args = sys.argv[1:]
     results_glob = args[0] if args else "artifacts/results-*/manifest-*/listing.json"

--- a/scripts/lql_matrix/tensor_presence.py
+++ b/scripts/lql_matrix/tensor_presence.py
@@ -48,3 +48,43 @@ def listing_of(vindex_dir):
                 for f in os.listdir(vindex_dir)}
     except OSError:
         return {}
+
+
+def load_listing(path):
+    try:
+        d = json.loads(Path(path).read_text(encoding="utf-8"))
+        return d if isinstance(d, dict) else {}
+    except Exception:
+        return {}
+
+
+_LEG_RE = re.compile(r"manifest-(.+?)/listing\.json$")
+
+
+def collect(results_glob):
+    rows = {}
+    seen = set()
+    pats = sorted(glob.glob(results_glob)) + sorted(
+        glob.glob("**/" + results_glob, recursive=True))
+    for p in pats:
+        if p in seen:
+            continue
+        seen.add(p)
+        m = _LEG_RE.search(p)
+        if m:
+            rows[m.group(1)] = presence(load_listing(p))
+    return rows
+
+
+def main():
+    args = sys.argv[1:]
+    results_glob = args[0] if args else "artifacts/results-*/manifest-*/listing.json"
+    out_json = args[1] if len(args) > 1 else "presence.json"
+    rows = collect(results_glob)
+    Path(out_json).write_text(json.dumps(rows, indent=2), encoding="utf-8")
+    print(f"tensor-presence: {len(rows)} legs, "
+          f"{sum(1 for r in rows.values() if r['ffn_unwrap_risk'])} at ffn_unwrap_risk")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lql_matrix/tensor_presence_test.py
+++ b/scripts/lql_matrix/tensor_presence_test.py
@@ -59,3 +59,49 @@ def test_resolve_q8_biconditional_and_counterexample():
     r2 = T.resolve_q8(pres, panic)
     assert r2["biconditional_holds"] is False
     assert "qwen05.native.attention" in [c["leg"] for c in r2["counterexamples"]]
+
+
+def test_render_q8_none_violations_is_inconclusive():
+    pres = {"m.native.attention": T.presence(ATTN_ONLY)}
+    res = T.render_q8(pres, None)
+    assert res["status"] == "inconclusive"
+    assert res["biconditional_holds"] is None
+
+def test_render_q8_empty_presence_is_inconclusive():
+    res = T.render_q8({}, [])
+    assert res["status"] == "inconclusive"
+    assert res["biconditional_holds"] is None
+
+def test_render_q8_excludes_produce_crash_from_panic():
+    # one genuine risk leg that agrees (panicked at an actual corpus cell), plus
+    # a non-risk leg whose ONLY no-crash violation is at produce-time — that
+    # produce crash must NOT be counted as a panic, so it still agrees (risk=False).
+    pres = {
+        "m.native.attention": T.presence(ATTN_ONLY),   # risk=True
+        "m.native.all":       T.presence(FULL),         # risk=False
+    }
+    violations = [
+        {"invariant": "no-crash", "leg": "m.native.attention", "cell": "infer.top5"},
+        {"invariant": "no-crash", "leg": "m.native.all", "cell": "produce"},
+    ]
+    res = T.render_q8(pres, violations)
+    assert res["status"] == "holds"
+    assert res["counterexamples"] == []
+    assert "m.native.all" not in [r["leg"] for r in res["counterexamples"]]
+
+def test_render_q8_genuine_refutation():
+    # risk=True leg with no observed corpus panic at all -> real disagreement.
+    pres = {"m.native.attention": T.presence(ATTN_ONLY)}
+    res = T.render_q8(pres, [])
+    assert res["status"] == "refuted"
+    assert "m.native.attention" in [c["leg"] for c in res["counterexamples"]]
+
+def test_render_q8_no_risk_no_panic_is_inconclusive():
+    pres = {"m.native.all": T.presence(FULL)}  # risk=False
+    res = T.render_q8(pres, [])
+    assert res["status"] == "inconclusive"
+
+def test_q8_markdown_inconclusive_does_not_raise():
+    res = T.render_q8({}, None)
+    md = T.q8_markdown(res)
+    assert "inconclusive" in md

--- a/scripts/lql_matrix/tensor_presence_test.py
+++ b/scripts/lql_matrix/tensor_presence_test.py
@@ -1,0 +1,27 @@
+import json, os, sys
+sys.path.insert(0, os.path.dirname(__file__))
+import tensor_presence as T
+
+ATTN_ONLY = {"attn_weights.bin": 1000, "gate_vectors.bin": 500, "embeddings.bin": 200, "index.json": 10}
+FULL      = {"attn_weights.bin": 1000, "up_weights.bin": 800, "down_weights.bin": 800,
+             "gate_vectors.bin": 500, "embeddings.bin": 200}
+EMPTY     = {"index.json": 10, "gate_vectors.bin": 0}   # 0-byte gate = absent
+
+
+def test_presence_attention_only_flags_ffn_unwrap_risk():
+    p = T.presence(ATTN_ONLY)
+    assert p["has_attn"] is True and p["has_ffn"] is False
+    assert p["ffn_unwrap_risk"] is True
+
+def test_presence_full_has_ffn_no_risk():
+    p = T.presence(FULL)
+    assert p["has_attn"] and p["has_ffn"] and p["has_gate"]
+    assert p["ffn_unwrap_risk"] is False
+
+def test_presence_empty_no_attn_no_risk():
+    p = T.presence(EMPTY)
+    assert p["has_attn"] is False and p["ffn_unwrap_risk"] is False
+
+def test_presence_tolerates_none_and_nonint():
+    assert T.presence(None)["n_files"] == 0
+    assert T.presence({"attn_weights.bin": "big"})["has_attn"] is False  # non-int size ignored

--- a/scripts/lql_matrix/tensor_presence_test.py
+++ b/scripts/lql_matrix/tensor_presence_test.py
@@ -39,3 +39,23 @@ def test_collect_maps_leg_to_presence(tmp_path):
 
 def test_load_listing_tolerates_missing(tmp_path):
     assert T.load_listing(str(tmp_path / "nope.json")) == {}
+
+def test_resolve_q8_biconditional_and_counterexample():
+    pres = {
+        "qwen05.native.attention":   T.presence(ATTN_ONLY),   # risk=True
+        "qwen05.native.all":         T.presence(FULL),        # risk=False
+        "bitnet2b.native.attention": T.presence(EMPTY),       # risk=False (no attn wt)
+    }
+    panic = {  # observed panic@infer (from conformance no-crash)
+        "qwen05.native.attention":   True,
+        "qwen05.native.all":         False,
+        "bitnet2b.native.attention": False,   # refuses gracefully — matches risk=False
+    }
+    r = T.resolve_q8(pres, panic)
+    assert r["biconditional_holds"] is True
+    assert r["counterexamples"] == []
+    # now inject a violation: risk=True but no panic
+    panic["qwen05.native.attention"] = False
+    r2 = T.resolve_q8(pres, panic)
+    assert r2["biconditional_holds"] is False
+    assert "qwen05.native.attention" in [c["leg"] for c in r2["counterexamples"]]

--- a/scripts/lql_matrix/tensor_presence_test.py
+++ b/scripts/lql_matrix/tensor_presence_test.py
@@ -25,3 +25,17 @@ def test_presence_empty_no_attn_no_risk():
 def test_presence_tolerates_none_and_nonint():
     assert T.presence(None)["n_files"] == 0
     assert T.presence({"attn_weights.bin": "big"})["has_attn"] is False  # non-int size ignored
+
+def test_collect_maps_leg_to_presence(tmp_path):
+    d = tmp_path / "results-qwen05.native.attention" / "manifest-qwen05.native.attention"
+    d.mkdir(parents=True)
+    (d / "listing.json").write_text(json.dumps(ATTN_ONLY), encoding="utf-8")
+    d2 = tmp_path / "results-qwen05.native.all" / "manifest-qwen05.native.all"
+    d2.mkdir(parents=True)
+    (d2 / "listing.json").write_text(json.dumps(FULL), encoding="utf-8")
+    got = T.collect(str(tmp_path / "results-*/manifest-*/listing.json"))
+    assert got["qwen05.native.attention"]["ffn_unwrap_risk"] is True
+    assert got["qwen05.native.all"]["ffn_unwrap_risk"] is False
+
+def test_load_listing_tolerates_missing(tmp_path):
+    assert T.load_listing(str(tmp_path / "nope.json")) == {}


### PR DESCRIPTION
## What this is

An empirical **LQL strategy matrix** — a CI harness that produces vindexes/models across a grid of `(source × produce-recipe × extraction-level)` and runs the full LQL command corpus against each, recording raw mechanical outcomes — **plus** a **conformance layer** that turns those raw outcomes into asserted V&V invariants.

## Contents

**1. Discovery matrix** (`scripts/lql_matrix/`, `.github/workflows/lql-strategy-matrix.yml`)
- `gen_legs.py` enumerates every CLI-invokable leg across 6 MIT/Apache models (Qwen2.5-Coder-0.5B, SmolLM2-135M/360M, Qwen2.5-1.5B, Granite-3.0-1B-a400m MoE, BitNet-b1.58-2B) — **80 legs**.
- Covers both ingestion paths (`extract` safetensors, `convert gguf-to-vindex`) and quant/dequant permutations (`--f32`, `--quant q4k`, `gguf --keep-quant` ternary, post-hoc `quantize {q4k,fp4}`). No prediction-pruning — e.g. `q4k` is crossed with every level to test the "implies `--level all`" doc claim.
- `run_matrix.py` captures full per-cell stdout/stderr, peak RSS (`/usr/bin/time -v`), an error-signal overlay, and a provenance row; `descriptor.py` records each produced vindex's `(family, dtype, quant)` vs expected. Build-once + fan-out, least-priv `permissions`, serialized `concurrency`, 24h artifact retention, `RUST_BACKTRACE=1`.

**2. Conformance layer** (`scripts/lql_matrix/conformance.py`, spec + plan under `docs/superpowers/`)
- A stdlib-only oracle: an invariant registry over the captured artifacts — **completeness** (no hollow 0-feature vindex), **no-crash** (no panic/OOM in produce or corpus), **descriptor self-match** (produced quant/family == declared; no silent GenericArch), **cross-check** (`SHOW LAYERS` count == `STATS` count), **diagnostic** (silent `--level` override; `--compact` message misattribution).
- **Discovery preserved:** default run stays green; violations gate the run only under a `strict` `workflow_dispatch` input.
- Emits `conformance.md` + `conformance.json` and a **transformation/consumability coverage report** that surfaces interface gaps (no compiled→GGUF/Ollama export; no cross-arch qwen↔bitnet transform).

## Findings the matrix + oracle surfaced (data-backed)

- **Silent hollow extraction** for MoE (Granite) and BitNet → 0-feature vindexes (extends #183; confirms #147 reproduces).
- **Universal FFN-unwrap panic** on `--level attention` vindexes (`sparse_compute.rs:85`) across llama/qwen2/granitemoe, f16+f32.
- **kquant × MoE panic** (`weight.rs:335`, dense FFN backend on missing tensors).
- **`SHOW LAYERS` reports 0 features** on mmap vindexes while STATS/SELECT show real counts.
- **Silent `--level` override** under `--quant q4k`; **misleading `--compact`** panic message.
- Run against the real 80-leg artifacts, the oracle flags **361 violations** and catches every finding above (strict off → exit 0).

## Testing

- `python3 -m pytest scripts/lql_matrix/conformance_test.py` — **14 tests**, all green; the smoke workflow runs them on a runner (no larql build/model).
- **No larql/Rust source is modified** — this PR is harness/CI + docs only.

## Notes for review

- The conformance layer was built spec-first (`docs/superpowers/specs/2026-07-10-lql-matrix-ci-conformance-layer-design.md`) then implemented TDD task-by-task with per-task review; two review-caught bugs (a `SHOW LAYERS` K/M-suffix false positive; an R-2 data-source mismatch) are fixed in-branch.
- Runtime consumer validation (boot `larql serve` + drive `/v1/chat` for Goose/Ollama/etc.) is a documented **Phase 2** follow-on; browser/web-llm (T3) is a separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
