### PR TITLE
sync: fast-forward fork main to upstream chrishayuk/larql main (7e5b84b8)

### DIFF
--- a/crates/larql-compute/src/cpu/ops/q4k_q8k_dot.rs
+++ b/crates/larql-compute/src/cpu/ops/q4k_q8k_dot.rs
@@ -43,6 +43,24 @@ const SUBBLOCKS_PER_BLOCK: usize = 8;
 /// Sub-block size (matches Q4_K's per-32 nibble groups).
 const SUBBLOCK_SIZE: usize = 32;
 
+/// Runtime-checked replacement for the `out.len()==rows` / `q8k_x.qs.len()==cols`
+/// / `cols % ELEMS_PER_BLOCK==0` shape invariants every matvec kernel below
+/// used to rely on `debug_assert_eq!` alone for. Those compile to nothing in
+/// this workspace's release profile (`[profile.release]` never sets
+/// `debug-assertions`), so a caller-side length mismatch on `q8k_x.qs` fell
+/// straight through the NEON/scalar kernels' own bounds-checked slicing is
+/// fine on its own, but the hand-asm kernels (`q4k_q8k_matvec_asm*`,
+/// `q4k_q8k_gate_up_asm`, `q6k_q8k_matvec_asm`) take `q8k_x.qs.as_ptr()` as a
+/// bare pointer with no length of its own and no per-iteration bound in the
+/// `asm!` block - a real unguarded OOB read, not a debug-only guard.
+/// Callers zero-fill and return early when this is `false`, matching the
+/// `w.len() < rows * row_bytes` early-return already present in every one of
+/// these kernels.
+#[inline]
+fn q8k_shape_ok(out_len: usize, rows: usize, q8k_qs_len: usize, cols: usize) -> bool {
+    out_len == rows && q8k_qs_len == cols && cols % ELEMS_PER_BLOCK == 0
+}
+
 /// Quantised activation in Q8_K layout, one entry per super-block of `x`.
 ///
 /// `qs` packs all super-blocks contiguously: `qs[sb * 256 .. (sb+1) * 256]`
@@ -181,10 +199,7 @@ pub fn q4k_q8k_matvec_scalar(
     rows: usize,
     cols: usize,
 ) {
-    debug_assert_eq!(out.len(), rows);
-    debug_assert_eq!(q8k_x.qs.len(), cols);
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
-    if rows == 0 || cols == 0 {
+    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
         for v in out.iter_mut() {
             *v = 0.0;
         }
@@ -314,10 +329,7 @@ pub fn q4k_q8k_matvec_neon(
 ) {
     use std::arch::aarch64::*;
 
-    debug_assert_eq!(out.len(), rows);
-    debug_assert_eq!(q8k_x.qs.len(), cols);
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
-    if rows == 0 || cols == 0 {
+    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
         for v in out.iter_mut() {
             *v = 0.0;
         }
@@ -463,10 +475,7 @@ pub fn q4k_q8k_matvec_neon_2row(
 ) {
     use std::arch::aarch64::*;
 
-    debug_assert_eq!(out.len(), rows);
-    debug_assert_eq!(q8k_x.qs.len(), cols);
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
-    if rows == 0 || cols == 0 {
+    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
         for v in out.iter_mut() {
             *v = 0.0;
         }
@@ -695,10 +704,7 @@ pub fn q4k_q8k_matvec_asm(
     rows: usize,
     cols: usize,
 ) {
-    debug_assert_eq!(out.len(), rows);
-    debug_assert_eq!(q8k_x.qs.len(), cols);
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
-    if rows == 0 || cols == 0 {
+    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
         for v in out.iter_mut() {
             *v = 0.0;
         }
@@ -919,10 +925,7 @@ pub fn q4k_q8k_matvec_asm_v2(
     rows: usize,
     cols: usize,
 ) {
-    debug_assert_eq!(out.len(), rows);
-    debug_assert_eq!(q8k_x.qs.len(), cols);
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
-    if rows == 0 || cols == 0 {
+    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
         for v in out.iter_mut() {
             *v = 0.0;
         }
@@ -1102,10 +1105,7 @@ pub fn q4k_q8k_matvec_asm_v3(
     rows: usize,
     cols: usize,
 ) {
-    debug_assert_eq!(out.len(), rows);
-    debug_assert_eq!(q8k_x.qs.len(), cols);
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
-    if rows == 0 || cols == 0 {
+    if !q8k_shape_ok(out.len(), rows, q8k_x.qs.len(), cols) || rows == 0 || cols == 0 {
         for v in out.iter_mut() {
             *v = 0.0;
         }
@@ -1394,11 +1394,9 @@ pub fn q4k_q8k_gate_up_neon(
 ) {
     use std::arch::aarch64::*;
 
-    debug_assert_eq!(gate_out.len(), rows);
-    debug_assert_eq!(up_out.len(), rows);
-    debug_assert_eq!(q8k_x.qs.len(), cols);
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
-    if rows == 0 || cols == 0 {
+    let shapes_ok = q8k_shape_ok(gate_out.len(), rows, q8k_x.qs.len(), cols)
+        && up_out.len() == rows;
+    if !shapes_ok || rows == 0 || cols == 0 {
         for v in gate_out.iter_mut() {
             *v = 0.0;
         }
@@ -1643,11 +1641,9 @@ pub fn q4k_q8k_gate_up_asm(
     rows: usize,
     cols: usize,
 ) {
-    debug_assert_eq!(gate_out.len(), rows);
-    debug_assert_eq!(up_out.len(), rows);
-    debug_assert_eq!(q8k_x.qs.len(), cols);
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
-    if rows == 0 || cols == 0 {
+    let shapes_ok = q8k_shape_ok(gate_out.len(), rows, q8k_x.qs.len(), cols)
+        && up_out.len() == rows;
+    if !shapes_ok || rows == 0 || cols == 0 {
         for v in gate_out.iter_mut() {
             *v = 0.0;
         }
@@ -1768,13 +1764,18 @@ pub fn q6k_q8k_matvec_scalar(
     rows: usize,
     cols: usize,
 ) {
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * Q6K_BLOCK_BYTES;
     for v in out.iter_mut() {
         *v = 0.0;
     }
-    if rows == 0 || cols == 0 || w.len() < rows * row_bytes {
+    if rows == 0
+        || cols == 0
+        || cols % ELEMS_PER_BLOCK != 0
+        || out.len() != rows
+        || q8k_x.qs.len() != cols
+        || w.len() < rows * row_bytes
+    {
         return;
     }
     for (r, out_r) in out.iter_mut().enumerate().take(rows) {
@@ -1835,13 +1836,18 @@ pub fn q6k_q8k_matvec_neon(
 ) {
     use std::arch::aarch64::*;
 
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * Q6K_BLOCK_BYTES;
     for v in out.iter_mut() {
         *v = 0.0;
     }
-    if rows == 0 || cols == 0 || w.len() < rows * row_bytes {
+    if rows == 0
+        || cols == 0
+        || cols % ELEMS_PER_BLOCK != 0
+        || out.len() != rows
+        || q8k_x.qs.len() != cols
+        || w.len() < rows * row_bytes
+    {
         return;
     }
 
@@ -2056,13 +2062,18 @@ pub fn q6k_q8k_matvec_asm(
     rows: usize,
     cols: usize,
 ) {
-    debug_assert_eq!(cols % ELEMS_PER_BLOCK, 0);
     let n_blocks = cols / ELEMS_PER_BLOCK;
     let row_bytes = n_blocks * Q6K_BLOCK_BYTES;
     for v in out.iter_mut() {
         *v = 0.0;
     }
-    if rows == 0 || cols == 0 || w.len() < rows * row_bytes {
+    if rows == 0
+        || cols == 0
+        || cols % ELEMS_PER_BLOCK != 0
+        || out.len() != rows
+        || q8k_x.qs.len() != cols
+        || w.len() < rows * row_bytes
+    {
         return;
     }
 

--- a/crates/larql-compute/src/cpu/spin_pool.rs
+++ b/crates/larql-compute/src/cpu/spin_pool.rs
@@ -346,7 +346,16 @@ where
         let base = out.as_mut_ptr() as usize;
         global().for_each_chunk(n, |ci| {
             let start = ci * chunk;
-            let len = chunk.min(total - start);
+            // `start < total` holds by construction for `ci < n` - but this
+            // feeds a raw `.add(start)` below with no bounds check of its
+            // own, so `saturating_sub` (not `-`) turns any violation of that
+            // invariant into an inert zero-length chunk instead of a wrapped
+            // `usize` producing a wild slice length (release builds have no
+            // overflow-checks).
+            let len = chunk.min(total.saturating_sub(start));
+            if len == 0 {
+                return;
+            }
             // SAFETY: chunk index `ci` owns the disjoint range
             // `[start, start+len)` of `out`; no two chunks overlap, and the
             // dispatch barrier keeps `out` borrowed for the whole call.
@@ -381,7 +390,11 @@ where
         let base_b = b.as_mut_ptr() as usize;
         global().for_each_chunk(n, |ci| {
             let start = ci * chunk;
-            let len = chunk.min(total - start);
+            // See the matching comment in `par_chunks_mut` above.
+            let len = chunk.min(total.saturating_sub(start));
+            if len == 0 {
+                return;
+            }
             // SAFETY: disjoint per-chunk ranges of `a` and `b` (separate
             // buffers); barrier keeps both borrowed for the call.
             let sa = unsafe { std::slice::from_raw_parts_mut((base_a as *mut T).add(start), len) };
@@ -584,5 +597,124 @@ mod tests {
                 assert_eq!(a.load(Ordering::Relaxed), round * (c as u64 + 1));
             }
         }
+    }
+
+    // ── SIGSEGV reproduction attempt (three crash reports, all localizing
+    // inside `par_chunks_mut`/`run_chunks`, fault addresses matching real
+    // model dimensions or `0x1`) ────────────────────────────────────────────
+
+    const RD_HIDDEN: usize = 2560;
+    const RD_INTER: usize = 10240;
+    const RD_Q_DIM: usize = 2048;
+    const RD_KV_DIM: usize = 1024;
+    const RD_ROWS_CHUNK: usize = 32;
+    const RD_ELEM_CHUNK: usize = 256;
+
+    fn rd_f32_encode(caller: u64, round: u64, tag: u64, idx: usize) -> f32 {
+        // Cheap, collision-resistant-enough encoding of (caller, round, tag,
+        // idx) into an f32 so a read of the wrong slot/epoch/caller's data is
+        // caught as a mismatch rather than silently looking plausible.
+        ((caller.wrapping_mul(998_244_353)
+            ^ round.wrapping_mul(1_000_003)
+            ^ tag.wrapping_mul(97)
+            ^ idx as u64)
+            % 1_000_000) as f32
+    }
+    fn rd_fill_chunk(chunk: &mut [f32], global_start: usize, caller: u64, round: u64, tag: u64) {
+        for (local_i, v) in chunk.iter_mut().enumerate() {
+            // Cheap but non-trivial busy-work per element (~tens of ns) so a
+            // chunk's dispatched duration is closer to the real matvec
+            // kernel's (many SDOTs per row) than a near-instant synthetic
+            // write - in case the bug is timing/duration-dependent (spin ->
+            // yield -> park transitions calibrated around real chunk cost).
+            let mut acc = 0.0f32;
+            for j in 0..64u32 {
+                acc = acc * 1.0000001 + (j as f32).sin();
+            }
+            *v = rd_f32_encode(caller, round, tag, global_start + local_i) + acc * 0.0;
+        }
+    }
+    fn rd_check(buf: &[f32], caller: u64, round: u64, tag: u64) {
+        for (i, &v) in buf.iter().enumerate() {
+            let want = rd_f32_encode(caller, round, tag, i);
+            assert_eq!(
+                v.to_bits(),
+                want.to_bits(),
+                "caller {caller} round {round} tag {tag} idx {i}: corrupted \
+                 (got {v}, want {want}) - buffer len {}",
+                buf.len()
+            );
+        }
+    }
+
+    /// One simulated decode step's worth of dispatches against `par_chunks_mut`
+    /// - the actual public entry point production uses, with the REAL
+    /// gemma-3-4b-it row counts (q_dim=2048, kv_dim=1024, hidden=2560,
+    /// intermediate=10240 - all exact multiples of their chunk sizes, same as
+    /// production, so this can't exercise the underflow this file already
+    /// hardened against; it's targeting a different bug). `caller` tags every
+    /// value so concurrent callers (simulating overlapping requests) can tell
+    /// their own data apart from a caller they got mixed up with.
+    fn rd_run(caller: u64, rounds: u64, layers: u64) {
+        let mut q = vec![0.0f32; RD_Q_DIM];
+        let mut k = vec![0.0f32; RD_KV_DIM];
+        let mut v = vec![0.0f32; RD_KV_DIM];
+        let mut o = vec![0.0f32; RD_HIDDEN];
+        let mut gate = vec![0.0f32; RD_INTER];
+        let mut up = vec![0.0f32; RD_INTER];
+        let mut activated = vec![0.0f32; RD_INTER];
+        let mut down = vec![0.0f32; RD_HIDDEN];
+
+        for round in 0..rounds {
+            for layer in 0..layers {
+                let tag = round * layers + layer;
+                for (buf, sub) in [
+                    (&mut q, 0u64),
+                    (&mut k, 1),
+                    (&mut v, 2),
+                    (&mut o, 3),
+                    (&mut gate, 4),
+                    (&mut up, 5),
+                    (&mut down, 7),
+                ] {
+                    let t = tag.wrapping_mul(8) + sub;
+                    par_chunks_mut(buf, RD_ROWS_CHUNK, |ci, chunk| {
+                        rd_fill_chunk(chunk, ci * RD_ROWS_CHUNK, caller, round, t)
+                    });
+                    rd_check(buf, caller, round, t);
+                }
+                // Elementwise activation: 256-chunked, INTER-sized - the
+                // production shape at kquant_forward/cached.rs:869.
+                let t = tag.wrapping_mul(8) + 6;
+                par_chunks_mut(&mut activated, RD_ELEM_CHUNK, |ci, chunk| {
+                    rd_fill_chunk(chunk, ci * RD_ELEM_CHUNK, caller, round, t)
+                });
+                rd_check(&activated, caller, round, t);
+            }
+        }
+    }
+
+    /// Single sequential caller, at production scale (34 layers x 400
+    /// simulated tokens). `--test-threads` contention from other tests
+    /// sharing `global()` is part of the reproduction attempt - do not run
+    /// this test in isolation only.
+    #[test]
+    fn stress_realistic_decode_shape_no_corruption() {
+        rd_run(0, 40, 34);
+    }
+
+    /// Genuinely concurrent callers (unlike `concurrent_dispatchers_stay_
+    /// consistent` above, which uses one FIXED dispatch size for every
+    /// thread) - each thread runs its own independent `rd_run`-shaped decode
+    /// loop against the SAME shared `global()` pool at the SAME time, so
+    /// `dispatch_lock` has to actually serialize dispatchers with DIFFERENT
+    /// `(total, chunk)` shapes mid-flight, not just identical ones.
+    #[test]
+    fn stress_concurrent_realistic_decode_shape_no_corruption() {
+        std::thread::scope(|s| {
+            for caller in 0..6u64 {
+                s.spawn(move || rd_run(caller, 8, 34));
+            }
+        });
     }
 }

--- a/crates/larql-server/src/routes/openai/chat.rs
+++ b/crates/larql-server/src/routes/openai/chat.rs
@@ -351,8 +351,16 @@ pub async fn handle_chat_completions(
         .into_response());
     }
 
+    // Race the blocking generation against `state.infer_timeout`, mirroring
+    // `run_infer_with_timeout` (routes/infer.rs, BUG-infer-deadlock §5.6).
+    // Without this, a stuck/slow chat completion holds `LoadedModel.weights`'
+    // write guard for as long as the spawned thread runs, and every other
+    // OpenAI-route request queues on that guard indefinitely. On timeout we
+    // drop the JoinHandle and respond 504; the spawned thread finishes (or
+    // doesn't) in the background, same tradeoff /v1/infer already accepts.
     let logprobs_requested = req.logprobs.unwrap_or(false);
-    let output = tokio::task::spawn_blocking(move || -> Result<_, ServerError> {
+    let started = std::time::Instant::now();
+    let handle = tokio::task::spawn_blocking(move || -> Result<_, ServerError> {
         run_chat_completion(
             &model_arc,
             &messages,
@@ -361,9 +369,27 @@ pub async fn handle_chat_completions(
             &stop_strings,
             constrained_schema,
         )
-    })
-    .await
-    .map_err(|e| ServerError::Internal(e.to_string()))??;
+    });
+    let timeout = state.infer_timeout;
+    let output = if timeout.is_zero() {
+        handle.await.map_err(|e| ServerError::Internal(e.to_string()))??
+    } else {
+        match tokio::time::timeout(timeout, handle).await {
+            Ok(join_result) => join_result.map_err(|e| ServerError::Internal(e.to_string()))??,
+            Err(_elapsed) => {
+                tracing::warn!(
+                    target: "larql_server::openai::chat",
+                    "chat completion timed out after {:.1}s; dropping in-flight task and \
+                     responding 504 (background thread will finish on its own)",
+                    started.elapsed().as_secs_f64(),
+                );
+                return Err(OpenAIError::from(ServerError::Timeout(format!(
+                    "chat completion exceeded server-side timeout of {}s",
+                    timeout.as_secs(),
+                ))));
+            }
+        }
+    };
 
     let logprobs = if logprobs_requested && !tools_active {
         Some(build_chat_logprobs(&output.tokens))

--- a/crates/larql-server/src/routes/openai/completions.rs
+++ b/crates/larql-server/src/routes/openai/completions.rs
@@ -252,22 +252,47 @@ pub async fn handle_completions(
         .into_response());
     }
 
-    // Non-streaming: the existing buffered path.
+    // Non-streaming: the existing buffered path. Racing the blocking
+    // generation against `state.infer_timeout` mirrors
+    // `run_infer_with_timeout` (routes/infer.rs, BUG-infer-deadlock §5.6):
+    // without it, a stuck/slow generation call holds `LoadedModel.weights`'
+    // write guard for as long as the spawned thread runs, and every other
+    // OpenAI-route request queues on that guard indefinitely. On timeout we
+    // drop the JoinHandle and respond 504; the spawned thread finishes (or
+    // doesn't) in the background, same tradeoff /v1/infer already accepts.
     let logprobs_requested = req.logprobs;
-    let (choices, prompt_tokens, completion_tokens) =
-        tokio::task::spawn_blocking(move || -> Result<_, ServerError> {
-            run_completions_loop(
-                &model_arc,
-                &prompts,
-                max_tokens,
-                sampling_params,
-                &stop_strings,
-                echo,
-                logprobs_requested,
-            )
-        })
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))??;
+    let started = std::time::Instant::now();
+    let handle = tokio::task::spawn_blocking(move || -> Result<_, ServerError> {
+        run_completions_loop(
+            &model_arc,
+            &prompts,
+            max_tokens,
+            sampling_params,
+            &stop_strings,
+            echo,
+            logprobs_requested,
+        )
+    });
+    let timeout = state.infer_timeout;
+    let (choices, prompt_tokens, completion_tokens) = if timeout.is_zero() {
+        handle.await.map_err(|e| ServerError::Internal(e.to_string()))??
+    } else {
+        match tokio::time::timeout(timeout, handle).await {
+            Ok(join_result) => join_result.map_err(|e| ServerError::Internal(e.to_string()))??,
+            Err(_elapsed) => {
+                tracing::warn!(
+                    target: "larql_server::openai::completions",
+                    "completion timed out after {:.1}s; dropping in-flight task and \
+                     responding 504 (background thread will finish on its own)",
+                    started.elapsed().as_secs_f64(),
+                );
+                return Err(OpenAIError::from(ServerError::Timeout(format!(
+                    "completion exceeded server-side timeout of {}s",
+                    timeout.as_secs(),
+                ))));
+            }
+        }
+    };
 
     Ok(Json(CompletionsResponse {
         id: format!("cmpl-{}", new_id_suffix()),


### PR DESCRIPTION
Sync the fork's `main` with upstream `chrishayuk/larql` `main`.

The fork's default branch was **3 commits behind** upstream. This branch is a fast-forward of `origin/main` up to upstream's `7e5b84b8`, bringing in:

- harden(compute): spin_pool chunk-size underflow + production-shape stress coverage
- fix(compute): unguarded q8k activation length in the default Q4_K/Q6_K asm kernels
- fix(server): OpenAI-route requests never timed out, wedging every subsequent request

No local changes — this is a clean fast-forward, so the merge introduces no divergence from upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
